### PR TITLE
fix(stream_proxy): remove redundant function-local math import

### DIFF
--- a/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -966,8 +966,6 @@ class _StreamHandler(BaseHTTPRequestHandler):
             self.send_error(500)
             return
 
-        import math
-
         total_segs = int(math.ceil(duration / seg_dur))
         target = int(math.ceil(seg_dur))
 


### PR DESCRIPTION
The `import math` inside `_serve_hls_playlist` shadowed the module-level import (line 14) and triggered pylint W0621 (redefined-outer-name) in CI.

https://claude.ai/code/session_016poqQR84oyv3odDNzCjn7s

## Summary

Brief description of the changes.

## Changes

-

## Testing

- [ ] `just test` passes
- [ ] `just lint` passes
- [ ] Tested in Kodi (if applicable)
