### PR TITLE
Group fallback streams by NZB manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Released | What it's about |
 |---|---|---|
-| **[1.0.7](#107--2026-05-04)** | 2026-05-04 | Fallback streams enabled by default, 5 standby submits, pass-through fallback playback, size-independent candidates with runtime validation, fallback-only recovery |
+| **[1.0.7](#107--2026-05-04)** | 2026-05-04 | Fallback streams enabled by default, 5 standby submits, pass-through playback, NZB-manifest grouping, 1000-sample validation, fallback-only recovery |
 | **[1.0.6](#106--2026-05-04)** | 2026-05-04 | Pass-through-first proxy, live duplicate-release fallback streams, authenticated settings checks, fallback worker cleanup, threshold-zero remux semantics |
 | **[1.0.5](#105--2026-05-04)** | 2026-05-04 | Direct Newznab indexers, manual Indexers settings, concurrent provider fan-out, Kodi repo publishing fixes, WebDAV range compatibility, cache eviction race fix |
 | **[1.0.4](#104--2026-04-25)** | 2026-04-25 | Pass-through stall watchdog (closes the slow-trickle wedge where seek doesn't unstick), proxy seek perf, sha256 cache keys, credential redaction sweep, Prowlarr UI label fix, §H.2 audit closure batch |
@@ -64,8 +64,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaulting to 5 standby submissions per primary result.
 - **Fallback playback uses the pass-through proxy** so standby streams can be
   switched in without forcing ffmpeg remux.
-- **Fallback candidates are tried regardless of release size.** Runtime source
-  validation still checks content length and fingerprints before switching.
+- **Fallback grouping now uses NZB manifest payload metadata** instead of
+  release title/quality or indexer-reported size. Visible video entries group
+  by normalized filename plus file-level segment bytes; RAR-only NZBs stay
+  eligible under a provisional archive grouping key.
+- **Mirrored NZB listings are rejected by Article Message-ID digest** so a
+  fallback prefers a separate upload instead of the same NZB on another indexer.
+- **Unhealthy file candidates inside one NZB are skipped individually.** If the
+  first selected file fails a Message-ID health check, the addon tries the next
+  eligible file in that NZB bundle instead of failing the whole result.
+- **Runtime validation now samples 1000 pseudo-random 4096-byte ranges** after
+  exact WebDAV content-length equality before switching to a fallback source.
 - **Fallback recovery is the only rescue path for fallback sessions.** If no
   validated fallback source can resume the failed range, the proxy closes the
   stream instead of retrying the original source, zero-filling, or probing

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Kodi 21 (Omega) player/resolver addon that enables Usenet-based streaming thro
 > **Current release: `v1.0.7`** on `main`. Highlights on this branch:
 >
 > - **Pass-through-first proxy**: MKV and other non-MP4 streams use byte pass-through by default, preserving native source seeking and zero-fill recovery. Force-remux is now optional, with threshold `0` meaning fully off.
-> - **Live fallback streams**: duplicate NZB releases are enabled by default with up to 5 standby submissions; fallback playback stays on the pass-through proxy and uses fallback recovery instead of retry, zero-fill, or skip rescue paths.
+> - **Live fallback streams**: duplicate NZB releases are enabled by default with up to 5 standby submissions, grouped by NZB manifest payload metadata, and validated with exact content length plus 1000 sampled byte ranges before switching.
 > - **MP4 rewrite remains first-class**: moov-at-tail MP4s are rewritten in pure Python for native Kodi seek; already-faststart MP4s direct-play unless fallback metadata requires proxy session tracking.
 > - **Prowlarr support** as an alternative indexer to NZBHydra2.
 > - **Dolby Vision routing matrix**: P5 / P7 FEL / P8 / unknown DV are routed to matroska automatically; P7 MEL and non-DV go to fmp4 HLS when that mode is selected.
@@ -62,7 +62,9 @@ If ffmpeg isn't installed, the proxy degrades gracefully to pass-through or dire
 
 When **Submit duplicate releases as live fallbacks** is enabled, the resolver attaches conservative duplicate candidates from the result list and submits them after the primary NZB is accepted. This is enabled by default. Standby submits run in a background worker so primary playback can continue polling immediately. Once playback starts, the proxy keeps the fallback job metadata with the session and can switch to another prepared stream if the active source becomes unrecoverable.
 
-Fallback selection is intentionally strict: candidates must share the normalized title and quality markers and have a valid NZB link. Candidates can be tried regardless of release size, but runtime source validation still checks content length and fingerprints before switching. **Maximum fallback releases** caps how many standby submits are attached per primary result and defaults to `5`.
+Fallback grouping is based on the NZB manifest's selected payload entry, not the search result size. The addon fetches each candidate NZB, prefers the main video filename and file-level segment-byte total when visible, and falls back to a provisional archive/RAR grouping key when only archive parts are visible. If the initially selected file candidate fails a Message-ID health check, the addon skips that candidate and tries the next eligible file in the same NZB bundle instead of failing the whole result. Candidates with the same selected payload Article Message-IDs are treated as mirrored copies of the same NZB and are not used as fallbacks.
+
+Runtime switching still requires exact WebDAV `Content-Length` equality and 1000 pseudo-random 4096-byte fingerprint samples before the proxy switches to a fallback source. **Maximum fallback releases** caps how many standby submits are attached per primary result and defaults to `5`.
 
 Fallback recovery is the only rescue path for fallback sessions: if no validated fallback source can resume the failed range, the proxy closes the stream instead of retrying the original source, zero-filling, or probing forward to skip bytes.
 

--- a/plugin.video.nzbdav/addon.xml
+++ b/plugin.video.nzbdav/addon.xml
@@ -25,7 +25,10 @@
         <news>v1.0.7
 - Enable fallback streams by default with a default maximum of 5 fallback submissions per primary result.
 - Keep fallback playback on the pass-through proxy path so standby streams can be switched in without force-remux.
-- Try fallback candidates regardless of release size, while runtime validation still checks source byte length and fingerprints before switching.
+- Group fallback candidates by NZB manifest payload metadata instead of release title/quality or indexer-reported size. Visible video entries group by normalized filename plus file-level segment bytes; RAR-only NZBs stay eligible under a provisional archive grouping key.
+- Reject mirrored NZB listings by Article Message-ID digest, so fallback submissions prefer separate uploads instead of the same NZB listed on another indexer.
+- Skip only the unhealthy file candidate when an initial Message-ID health check fails, then continue to the next eligible file in the NZB bundle.
+- Require exact WebDAV source byte length and 1000 pseudo-random 4096-byte fingerprint samples before runtime fallback switching.
 - Use fallback recovery instead of retry, zero-fill, or skip recovery; if no validated fallback can resume, close the stream cleanly.
 
 v1.0.6

--- a/plugin.video.nzbdav/changelog.txt
+++ b/plugin.video.nzbdav/changelog.txt
@@ -1,7 +1,10 @@
 v1.0.7 (2026-05-04)
 - Enable fallback streams by default with a default maximum of 5 fallback submissions per primary result.
 - Keep fallback playback on the pass-through proxy path so standby streams can be switched in without force-remux.
-- Try fallback candidates regardless of release size, while runtime validation still checks source byte length and fingerprints before switching.
+- Group fallback candidates by NZB manifest payload metadata instead of release title/quality or indexer-reported size. Visible video entries group by normalized filename plus file-level segment bytes; RAR-only NZBs stay eligible under a provisional archive grouping key.
+- Reject mirrored NZB listings by Article Message-ID digest, so fallback submissions prefer separate uploads instead of the same NZB listed on another indexer.
+- Skip only the unhealthy file candidate when an initial Message-ID health check fails, then continue to the next eligible file in the NZB bundle.
+- Require exact WebDAV source byte length and 1000 pseudo-random 4096-byte fingerprint samples before runtime fallback switching.
 - Use fallback recovery instead of retry, zero-fill, or skip recovery; if no validated fallback can resume, close the stream cleanly.
 
 v1.0.6 (2026-05-04)

--- a/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -12,7 +12,7 @@ from urllib.request import Request, urlopen
 import xbmc
 import xbmcaddon
 
-from resources.lib.nzb_manifest import fetch_nzb_video_manifest
+from resources.lib.nzb_manifest import fetch_nzb_video_manifest, make_empty_manifest
 
 _SAFE_JOB_RE = re.compile(r"^[A-Za-z0-9._ \[\]-]+$")
 _CONTENT_RANGE_RE = re.compile(r"^bytes\s+(\d+)-(\d+)/(\d+|\*)$")
@@ -191,20 +191,7 @@ def _manifest_candidate_message_ids_are_healthy(candidate):
 
 
 def _manifest_error(reason):
-    return {
-        "payload_kind": "",
-        "group_name": "",
-        "group_bytes": 0,
-        "video_name": "",
-        "normalized_video_name": "",
-        "video_bytes": 0,
-        "archive_base_name": "",
-        "article_digest": "",
-        "article_count": 0,
-        "skipped_candidate_count": 0,
-        "skipped_candidates": [],
-        "unsupported_reason": reason,
-    }
+    return make_empty_manifest(reason)
 
 
 def _fallback_settings():

--- a/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -175,6 +175,21 @@ def _article_digest(result):
     return manifest.get("article_digest", "") or ""
 
 
+def _manifest_candidate_message_ids_are_healthy(candidate):
+    message_ids = candidate.get("message_ids") if isinstance(candidate, dict) else None
+    if not isinstance(message_ids, list) or not message_ids:
+        return False
+    for message_id in message_ids:
+        if not isinstance(message_id, str):
+            return False
+        clean = message_id.strip()
+        if not clean or "@" not in clean:
+            return False
+        if any(char.isspace() or ord(char) < 0x20 for char in clean):
+            return False
+    return True
+
+
 def _manifest_error(reason):
     return {
         "payload_kind": "",
@@ -233,7 +248,9 @@ def attach_fallback_candidates(results):
             continue
         if link not in manifest_cache:
             try:
-                manifest_cache[link] = fetch_nzb_video_manifest(link)
+                manifest_cache[link] = fetch_nzb_video_manifest(
+                    link, health_check=_manifest_candidate_message_ids_are_healthy
+                )
             except Exception:  # pylint: disable=broad-except
                 manifest_cache[link] = _manifest_error("fetch_error")
         manifest = manifest_cache[link]

--- a/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -158,7 +158,10 @@ def _manifest_group_key(result):
         return None
     kind = manifest.get("payload_kind", "")
     name = manifest.get("group_name", "")
-    size = int(manifest.get("group_bytes", 0) or 0)
+    try:
+        size = int(manifest.get("group_bytes", 0) or 0)
+    except (TypeError, ValueError):
+        return None
     digest = manifest.get("article_digest", "")
     if not kind or not name or not digest:
         return None

--- a/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -71,6 +71,7 @@ def _split_http_url(url):
 
 
 def _origin_key(parts):
+    """Return the normalized origin tuple for parsed URL parts."""
     scheme = parts.scheme.lower()
     port = parts.port
     if port is None:
@@ -79,6 +80,7 @@ def _origin_key(parts):
 
 
 def _path_is_under_base(path, base_path):
+    """Return whether a URL path is within the configured base path."""
     prefix = (base_path or "").rstrip("/")
     if not prefix:
         return True
@@ -150,6 +152,7 @@ def _quality_key(result):
 
 
 def _manifest_group_key(result):
+    """Return the manifest grouping key used to find fallback peers."""
     manifest = result.get("_fallback_manifest")
     if not isinstance(manifest, dict):
         return None
@@ -169,6 +172,7 @@ def _manifest_group_key(result):
 
 
 def _article_digest(result):
+    """Return the manifest article digest attached to a result."""
     manifest = result.get("_fallback_manifest")
     if not isinstance(manifest, dict):
         return ""
@@ -176,6 +180,7 @@ def _article_digest(result):
 
 
 def _manifest_candidate_message_ids_are_healthy(candidate):
+    """Return whether a manifest candidate has usable article Message-IDs."""
     message_ids = candidate.get("message_ids") if isinstance(candidate, dict) else None
     if not isinstance(message_ids, list) or not message_ids:
         return False
@@ -191,6 +196,7 @@ def _manifest_candidate_message_ids_are_healthy(candidate):
 
 
 def _manifest_error(reason):
+    """Return an unsupported manifest for fallback grouping errors."""
     return make_empty_manifest(reason)
 
 
@@ -366,6 +372,7 @@ def fetch_content_length(url, auth_header, timeout=2):
 
 
 def _content_range_matches_request(content_range, start, end, content_length=0):
+    """Return whether a Content-Range header matches a requested range."""
     if not isinstance(content_range, str):
         return False
     match = _CONTENT_RANGE_RE.match(content_range.strip())

--- a/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -4,7 +4,6 @@
 """Conservative grouping for duplicate releases usable as fallback streams."""
 
 import hashlib
-import random
 import re
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
@@ -335,10 +334,14 @@ def fingerprint_ranges(content_length):
         return ranges
 
     max_start = content_length - _FINGERPRINT_BYTES
-    rng = random.Random(content_length)
     starts = {0, max_start}
+    counter = 0
     while len(starts) < _FINGERPRINT_SAMPLE_COUNT:
-        starts.add(rng.randint(0, max_start))
+        digest = hashlib.sha256(
+            "{}:{}".format(content_length, counter).encode("utf-8")
+        ).digest()
+        starts.add(int.from_bytes(digest[:8], "big") % (max_start + 1))
+        counter += 1
     return [(start, start + _FINGERPRINT_BYTES - 1) for start in sorted(starts)]
 
 

--- a/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -4,6 +4,7 @@
 """Conservative grouping for duplicate releases usable as fallback streams."""
 
 import hashlib
+import random
 import re
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
@@ -12,9 +13,11 @@ from urllib.request import Request, urlopen
 import xbmc
 import xbmcaddon
 
+from resources.lib.nzb_manifest import fetch_nzb_video_manifest
+
 _SAFE_JOB_RE = re.compile(r"^[A-Za-z0-9._ \[\]-]+$")
 _CONTENT_RANGE_RE = re.compile(r"^bytes\s+(\d+)-(\d+)/(\d+|\*)$")
-_FINGERPRINT_OFFSETS = (0.0, 0.25, 0.5, 0.75, 0.98)
+_FINGERPRINT_SAMPLE_COUNT = 1000
 _FINGERPRINT_BYTES = 4096
 
 _MAX_FALLBACKS = 5
@@ -147,6 +150,49 @@ def _quality_key(result):
     )
 
 
+def _manifest_group_key(result):
+    manifest = result.get("_fallback_manifest")
+    if not isinstance(manifest, dict):
+        return None
+    kind = manifest.get("payload_kind", "")
+    name = manifest.get("group_name", "")
+    size = int(manifest.get("group_bytes", 0) or 0)
+    digest = manifest.get("article_digest", "")
+    if not kind or not name or not digest:
+        return None
+    if kind == "video":
+        if size <= 0:
+            return None
+        return kind, name, size
+    if kind == "archive":
+        return kind, name
+    return None
+
+
+def _article_digest(result):
+    manifest = result.get("_fallback_manifest")
+    if not isinstance(manifest, dict):
+        return ""
+    return manifest.get("article_digest", "") or ""
+
+
+def _manifest_error(reason):
+    return {
+        "payload_kind": "",
+        "group_name": "",
+        "group_bytes": 0,
+        "video_name": "",
+        "normalized_video_name": "",
+        "video_bytes": 0,
+        "archive_base_name": "",
+        "article_digest": "",
+        "article_count": 0,
+        "skipped_candidate_count": 0,
+        "skipped_candidates": [],
+        "unsupported_reason": reason,
+    }
+
+
 def _fallback_settings():
     """Return (enabled, max_candidates) from Kodi settings."""
     addon = xbmcaddon.Addon()
@@ -176,13 +222,32 @@ def attach_fallback_candidates(results):
     if not enabled or max_candidates <= 0:
         return results
 
-    groups = {}
+    manifest_cache = {}
     for result in results:
+        manifest = result.get("_fallback_manifest")
+        if isinstance(manifest, dict):
+            result["_fallback_manifest_error"] = manifest.get("unsupported_reason", "")
+            continue
         link = result.get("link", "")
         if not isinstance(link, str) or not link.strip():
+            result["_fallback_manifest_error"] = "missing_link"
             continue
-        key = _quality_key(result)
-        if not key[0]:
+        if link not in manifest_cache:
+            try:
+                manifest_cache[link] = fetch_nzb_video_manifest(link)
+            except Exception:  # pylint: disable=broad-except
+                manifest_cache[link] = _manifest_error("fetch_error")
+        manifest = manifest_cache[link]
+        if not isinstance(manifest, dict):
+            manifest = _manifest_error("fetch_error")
+            manifest_cache[link] = manifest
+        result["_fallback_manifest"] = manifest
+        result["_fallback_manifest_error"] = manifest.get("unsupported_reason", "")
+
+    groups = {}
+    for result in results:
+        key = _manifest_group_key(result)
+        if key is None:
             continue
         groups.setdefault(key, []).append(result)
 
@@ -191,18 +256,24 @@ def attach_fallback_candidates(results):
             continue
         for result in group:
             link = result.get("link", "")
+            primary_digest = _article_digest(result)
             candidates = []
             seen_links = {link}
+            seen_article_digests = {primary_digest}
             for candidate in group:
                 candidate_link = candidate.get("link", "")
+                candidate_digest = _article_digest(candidate)
                 if (
                     candidate is result
                     or not candidate_link
                     or candidate_link in seen_links
+                    or not candidate_digest
+                    or candidate_digest in seen_article_digests
                 ):
                     continue
                 candidates.append(candidate)
                 seen_links.add(candidate_link)
+                seen_article_digests.add(candidate_digest)
                 if len(candidates) >= max_candidates:
                     break
             result["_fallback_candidates"] = candidates
@@ -254,15 +325,21 @@ def fingerprint_ranges(content_length):
     if content_length <= _FINGERPRINT_BYTES:
         return [(0, content_length - 1)]
 
-    ranges = []
-    for ratio in _FINGERPRINT_OFFSETS:
-        start = int(content_length * ratio)
-        start = min(start, max(0, content_length - _FINGERPRINT_BYTES))
-        end = min(content_length - 1, start + _FINGERPRINT_BYTES - 1)
-        pair = (start, end)
-        if pair not in ranges:
-            ranges.append(pair)
-    return ranges
+    if content_length <= _FINGERPRINT_SAMPLE_COUNT * _FINGERPRINT_BYTES:
+        ranges = []
+        start = 0
+        while start < content_length:
+            end = min(content_length - 1, start + _FINGERPRINT_BYTES - 1)
+            ranges.append((start, end))
+            start += _FINGERPRINT_BYTES
+        return ranges
+
+    max_start = content_length - _FINGERPRINT_BYTES
+    rng = random.Random(content_length)
+    starts = {0, max_start}
+    while len(starts) < _FINGERPRINT_SAMPLE_COUNT:
+        starts.add(rng.randint(0, max_start))
+    return [(start, start + _FINGERPRINT_BYTES - 1) for start in sorted(starts)]
 
 
 def fetch_content_length(url, auth_header, timeout=2):

--- a/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/plugin.video.nzbdav/resources/lib/http_util.py
@@ -107,6 +107,10 @@ HTTP_USER_AGENT = "NZB-DAV Kodi Addon"
 _HTTP_USER_AGENT = HTTP_USER_AGENT
 
 
+class HttpResponseTooLarge(ValueError):
+    """Raised when a response body exceeds the caller's byte limit."""
+
+
 def _response_status(resp):
     """Return an integer HTTP status from urllib-like responses, if exposed."""
     for attr in ("status", "code"):
@@ -121,7 +125,7 @@ def _response_status(resp):
     return None
 
 
-def http_get(url, timeout=15):
+def http_get(url, timeout=15, headers=None, max_bytes=None):
     """Perform an HTTP GET and return the response body as text.
 
     Invalid UTF-8 is decoded with replacement so callers receive one
@@ -132,11 +136,17 @@ def http_get(url, timeout=15):
     ``https``. urllib's default opener happily handles ``file://`` and
     ``ftp://`` and would otherwise return ``/etc/passwd`` if a user
     pasted that into a URL setting field.
+
+    Optional ``headers`` are merged with the shared User-Agent. ``max_bytes``
+    caps the response body and raises ``HttpResponseTooLarge`` when exceeded.
     """
     scheme = urlsplit(url).scheme.lower()
     if scheme not in _ALLOWED_HTTP_SCHEMES:
         raise ValueError("unsupported URL scheme: {!r}".format(scheme))
-    req = Request(url, headers={"User-Agent": _HTTP_USER_AGENT})
+    request_headers = {"User-Agent": _HTTP_USER_AGENT}
+    if headers:
+        request_headers.update(headers)
+    req = Request(url, headers=request_headers)
     # nosemgrep
     with urlopen(  # nosec B310 — scheme allowlist enforced above
         req, timeout=timeout
@@ -144,7 +154,26 @@ def http_get(url, timeout=15):
         status = _response_status(resp)
         if status is not None and not 200 <= status < 300:
             raise OSError("HTTP status {}".format(status))
-        return resp.read().decode("utf-8", errors="replace")
+        read_size = None
+        if max_bytes is not None:
+            max_bytes = int(max_bytes)
+            if max_bytes < 0:
+                raise ValueError("max_bytes must be non-negative")
+            try:
+                content_length = int(resp.headers.get("Content-Length", "0") or 0)
+            except (AttributeError, TypeError, ValueError):
+                content_length = 0
+            if content_length > max_bytes:
+                raise HttpResponseTooLarge(
+                    "HTTP response exceeds {} bytes".format(max_bytes)
+                )
+            read_size = max_bytes + 1
+        body = resp.read(read_size) if read_size is not None else resp.read()
+        if max_bytes is not None and len(body) > max_bytes:
+            raise HttpResponseTooLarge(
+                "HTTP response exceeds {} bytes".format(max_bytes)
+            )
+        return body.decode("utf-8", errors="replace")
 
 
 _PUBDATE_ERRORS = (OverflowError, TypeError, ValueError)

--- a/plugin.video.nzbdav/resources/lib/nzb_manifest.py
+++ b/plugin.video.nzbdav/resources/lib/nzb_manifest.py
@@ -6,9 +6,9 @@
 import hashlib
 import re
 import xml.etree.ElementTree as ET
-from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
-from urllib.request import Request, urlopen
+
+from resources.lib.http_util import HttpResponseTooLarge, http_get
 
 _MAX_NZB_BYTES = 2 * 1024 * 1024
 _VIDEO_EXTENSIONS = (".mkv", ".mp4", ".m4v", ".avi", ".ts", ".m2ts", ".mov", ".wmv")
@@ -269,20 +269,10 @@ def fetch_nzb_video_manifest(
     """Fetch and parse a candidate NZB manifest."""
     if not _valid_nzb_url(url):
         return _empty_manifest("invalid_url")
-    req = Request(url)
-    req.add_header("User-Agent", "NZB-DAV Kodi")
     try:
-        # nosemgrep
-        with urlopen(req, timeout=timeout) as resp:  # nosec B310
-            try:
-                content_length = int(resp.headers.get("Content-Length", "0") or 0)
-            except (TypeError, ValueError):
-                content_length = 0
-            if content_length > max_bytes:
-                return _empty_manifest("too_large")
-            body = resp.read(max_bytes + 1)
-    except (HTTPError, URLError, OSError, ValueError):
-        return _empty_manifest("fetch_error")
-    if len(body) > max_bytes:
+        body = http_get(url, timeout=timeout, max_bytes=max_bytes)
+    except HttpResponseTooLarge:
         return _empty_manifest("too_large")
+    except (OSError, ValueError):
+        return _empty_manifest("fetch_error")
     return extract_nzb_video_manifest(body, health_check=health_check)

--- a/plugin.video.nzbdav/resources/lib/nzb_manifest.py
+++ b/plugin.video.nzbdav/resources/lib/nzb_manifest.py
@@ -21,7 +21,8 @@ _ARCHIVE_RE = re.compile(r'"?([^"\\/]+?)(?:\.part\d+)?\.(?:rar|r\d{2,3})\b', re.
 _ALLOWED_NZB_SCHEMES = frozenset(("http", "https"))
 
 
-def _empty_manifest(reason, skipped_candidates=None):
+def make_empty_manifest(reason, skipped_candidates=None):
+    """Return the shared unsupported manifest shape."""
     skipped_candidates = skipped_candidates or []
     return {
         "payload_kind": "",
@@ -37,6 +38,10 @@ def _empty_manifest(reason, skipped_candidates=None):
         "skipped_candidates": skipped_candidates,
         "unsupported_reason": reason,
     }
+
+
+def _empty_manifest(reason, skipped_candidates=None):
+    return make_empty_manifest(reason, skipped_candidates)
 
 
 def normalize_video_filename(value):

--- a/plugin.video.nzbdav/resources/lib/nzb_manifest.py
+++ b/plugin.video.nzbdav/resources/lib/nzb_manifest.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""NZB manifest inspection for fallback grouping."""
+
+import hashlib
+import re
+import xml.etree.ElementTree as ET
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import Request, urlopen
+
+_MAX_NZB_BYTES = 2 * 1024 * 1024
+_VIDEO_EXTENSIONS = (".mkv", ".mp4", ".m4v", ".avi", ".ts", ".m2ts", ".mov", ".wmv")
+_IGNORED_VIDEO_PREFIXES = ("sample.", "sample-", "sample_")
+_FILENAME_RE = re.compile(r'"([^"]+\.(?:mkv|mp4|m4v|avi|ts|m2ts|mov|wmv))"', re.I)
+_BARE_FILENAME_RE = re.compile(
+    r"([^\s\"']+\.(?:mkv|mp4|m4v|avi|ts|m2ts|mov|wmv))", re.I
+)
+_ARCHIVE_RE = re.compile(r'"?([^"\\/]+?)(?:\.part\d+)?\.(?:rar|r\d{2,3})\b', re.I)
+_ALLOWED_NZB_SCHEMES = frozenset(("http", "https"))
+
+
+def _empty_manifest(reason, skipped_candidates=None):
+    skipped_candidates = skipped_candidates or []
+    return {
+        "payload_kind": "",
+        "group_name": "",
+        "group_bytes": 0,
+        "video_name": "",
+        "normalized_video_name": "",
+        "video_bytes": 0,
+        "archive_base_name": "",
+        "article_digest": "",
+        "article_count": 0,
+        "skipped_candidate_count": len(skipped_candidates),
+        "skipped_candidates": skipped_candidates,
+        "unsupported_reason": reason,
+    }
+
+
+def normalize_video_filename(value):
+    """Normalize a video filename for fallback grouping."""
+    if not isinstance(value, str):
+        return ""
+    value = value.strip().strip('"').strip("'")
+    if not value:
+        return ""
+    if "." in value:
+        stem, ext = value.rsplit(".", 1)
+        stem = re.sub(r"[\W_]+", " ", stem.lower())
+        return "{}.{}".format(" ".join(stem.split()), ext.lower())
+    return " ".join(re.sub(r"[\W_]+", " ", value.lower()).split())
+
+
+def _strip_namespace(tag):
+    if "}" in tag:
+        return tag.rsplit("}", 1)[1]
+    return tag
+
+
+def _children_by_name(elem, name):
+    return [child for child in list(elem) if _strip_namespace(child.tag) == name]
+
+
+def _find_video_name(subject):
+    if not isinstance(subject, str):
+        return ""
+    match = _FILENAME_RE.search(subject) or _BARE_FILENAME_RE.search(subject)
+    if not match:
+        return ""
+    name = match.group(1).strip()
+    lower = name.lower()
+    base = lower.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if base.startswith(_IGNORED_VIDEO_PREFIXES):
+        return ""
+    if not lower.endswith(_VIDEO_EXTENSIONS):
+        return ""
+    return name
+
+
+def _find_archive_base(subject):
+    if not isinstance(subject, str):
+        return ""
+    match = _ARCHIVE_RE.search(subject)
+    if not match:
+        return ""
+    base = match.group(1).strip().strip('"').strip("'")
+    base = re.sub(r"[\W_]+", " ", base.lower())
+    return " ".join(base.split())
+
+
+def _segment_rows(file_elem):
+    rows = []
+    for segments in _children_by_name(file_elem, "segments"):
+        for segment in _children_by_name(segments, "segment"):
+            try:
+                number = int(segment.attrib.get("number", "0") or 0)
+                size = int(segment.attrib.get("bytes", "0") or 0)
+            except ValueError:
+                continue
+            msgid = (segment.text or "").strip().strip("<>").lower()
+            if size <= 0 or not msgid:
+                continue
+            rows.append((number, size, msgid))
+    rows.sort(key=lambda item: (item[0], item[2]))
+    return rows
+
+
+def _digest_articles(rows):
+    digest = hashlib.sha256()
+    for _number, _size, msgid in rows:
+        digest.update(msgid.encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest() if rows else ""
+
+
+def _candidate_name(candidate):
+    return (
+        candidate.get("video_name")
+        or candidate.get("archive_base_name")
+        or candidate.get("group_name")
+        or ""
+    )
+
+
+def _candidate_is_healthy(candidate, health_check):
+    if health_check is None:
+        return True
+    try:
+        return bool(health_check(candidate))
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
+def _public_manifest(candidate, skipped_candidates):
+    manifest = dict(candidate)
+    manifest.pop("message_ids", None)
+    manifest["skipped_candidate_count"] = len(skipped_candidates)
+    manifest["skipped_candidates"] = skipped_candidates
+    return manifest
+
+
+def _select_healthy_candidate(candidates, health_check):
+    skipped_candidates = []
+    for candidate in candidates:
+        if _candidate_is_healthy(candidate, health_check):
+            return _public_manifest(candidate, skipped_candidates)
+        skipped_candidates.append(
+            {"name": _candidate_name(candidate), "reason": "message_id_health_failed"}
+        )
+    if skipped_candidates:
+        return _empty_manifest(
+            "all_candidate_files_failed_health_check",
+            skipped_candidates=skipped_candidates,
+        )
+    return _empty_manifest("no_video_file")
+
+
+def extract_nzb_video_manifest(nzb_bytes, health_check=None):
+    """Return main video-file or provisional archive metadata from an NZB XML."""
+    try:
+        root = ET.fromstring(nzb_bytes)
+    except (ET.ParseError, TypeError):
+        return _empty_manifest("invalid_xml")
+
+    video_candidates = []
+    archive_groups = {}
+    for file_elem in root.iter():
+        if _strip_namespace(file_elem.tag) != "file":
+            continue
+        rows = _segment_rows(file_elem)
+        video_name = _find_video_name(file_elem.attrib.get("subject", ""))
+        if video_name:
+            video_bytes = sum(row[1] for row in rows)
+            article_digest = _digest_articles(rows)
+            if video_bytes <= 0 or not article_digest:
+                continue
+            normalized = normalize_video_filename(video_name)
+            video_candidates.append(
+                {
+                    "payload_kind": "video",
+                    "group_name": normalized,
+                    "group_bytes": video_bytes,
+                    "video_name": video_name,
+                    "normalized_video_name": normalized,
+                    "video_bytes": video_bytes,
+                    "archive_base_name": "",
+                    "article_digest": article_digest,
+                    "article_count": len(rows),
+                    "message_ids": [row[2] for row in rows],
+                    "unsupported_reason": "",
+                }
+            )
+            continue
+        archive_base = _find_archive_base(file_elem.attrib.get("subject", ""))
+        if archive_base and rows:
+            archive_groups.setdefault(archive_base, []).extend(rows)
+
+    archive_candidates = []
+    for archive_base, rows in archive_groups.items():
+        rows.sort(key=lambda item: (item[0], item[2]))
+        article_digest = _digest_articles(rows)
+        if not article_digest:
+            continue
+        archive_candidates.append(
+            {
+                "payload_kind": "archive",
+                "group_name": archive_base,
+                "group_bytes": 0,
+                "video_name": "",
+                "normalized_video_name": "",
+                "video_bytes": 0,
+                "archive_base_name": archive_base,
+                "article_digest": article_digest,
+                "article_count": len(rows),
+                "message_ids": [row[2] for row in rows],
+                "unsupported_reason": "",
+            }
+        )
+
+    video_candidates.sort(
+        key=lambda item: (item["video_bytes"], item["article_count"]),
+        reverse=True,
+    )
+    archive_candidates.sort(key=lambda item: item["article_count"], reverse=True)
+    return _select_healthy_candidate(
+        video_candidates + archive_candidates, health_check
+    )
+
+
+def _valid_nzb_url(url):
+    if not isinstance(url, str) or any(ord(char) < 0x20 for char in url):
+        return False
+    try:
+        parts = urlsplit(url)
+        if parts.scheme.lower() not in _ALLOWED_NZB_SCHEMES:
+            return False
+        if not parts.netloc or not parts.hostname:
+            return False
+        if parts.username or parts.password:
+            return False
+        _port = parts.port
+    except ValueError:
+        return False
+    return True
+
+
+def fetch_nzb_video_manifest(
+    url, timeout=5, max_bytes=_MAX_NZB_BYTES, health_check=None
+):
+    """Fetch and parse a candidate NZB manifest."""
+    if not _valid_nzb_url(url):
+        return _empty_manifest("invalid_url")
+    req = Request(url)
+    req.add_header("User-Agent", "NZB-DAV Kodi")
+    try:
+        # nosemgrep
+        with urlopen(req, timeout=timeout) as resp:  # nosec B310
+            try:
+                content_length = int(resp.headers.get("Content-Length", "0") or 0)
+            except (TypeError, ValueError):
+                content_length = 0
+            if content_length > max_bytes:
+                return _empty_manifest("too_large")
+            body = resp.read(max_bytes + 1)
+    except (HTTPError, URLError, OSError, ValueError):
+        return _empty_manifest("fetch_error")
+    if len(body) > max_bytes:
+        return _empty_manifest("too_large")
+    return extract_nzb_video_manifest(body, health_check=health_check)

--- a/plugin.video.nzbdav/resources/lib/nzb_manifest.py
+++ b/plugin.video.nzbdav/resources/lib/nzb_manifest.py
@@ -41,6 +41,7 @@ def make_empty_manifest(reason, skipped_candidates=None):
 
 
 def _empty_manifest(reason, skipped_candidates=None):
+    """Return an unsupported manifest for internal parser call sites."""
     return make_empty_manifest(reason, skipped_candidates)
 
 
@@ -59,16 +60,19 @@ def normalize_video_filename(value):
 
 
 def _strip_namespace(tag):
+    """Return an XML tag name without its namespace prefix."""
     if "}" in tag:
         return tag.rsplit("}", 1)[1]
     return tag
 
 
 def _children_by_name(elem, name):
+    """Return direct XML children whose local tag name matches name."""
     return [child for child in list(elem) if _strip_namespace(child.tag) == name]
 
 
 def _find_video_name(subject):
+    """Extract a supported non-sample video filename from an NZB subject."""
     if not isinstance(subject, str):
         return ""
     match = _FILENAME_RE.search(subject) or _BARE_FILENAME_RE.search(subject)
@@ -85,6 +89,7 @@ def _find_video_name(subject):
 
 
 def _find_archive_base(subject):
+    """Extract a normalized archive base name from a RAR-style subject."""
     if not isinstance(subject, str):
         return ""
     match = _ARCHIVE_RE.search(subject)
@@ -96,6 +101,7 @@ def _find_archive_base(subject):
 
 
 def _segment_rows(file_elem):
+    """Return sorted NZB segment rows as number, byte size, and Message-ID."""
     rows = []
     for segments in _children_by_name(file_elem, "segments"):
         for segment in _children_by_name(segments, "segment"):
@@ -113,6 +119,7 @@ def _segment_rows(file_elem):
 
 
 def _digest_articles(rows):
+    """Return a stable digest over sorted article Message-IDs."""
     digest = hashlib.sha256()
     for _number, _size, msgid in rows:
         digest.update(msgid.encode("utf-8"))
@@ -121,6 +128,7 @@ def _digest_articles(rows):
 
 
 def _candidate_name(candidate):
+    """Return a human-readable candidate name for skip diagnostics."""
     return (
         candidate.get("video_name")
         or candidate.get("archive_base_name")
@@ -130,6 +138,7 @@ def _candidate_name(candidate):
 
 
 def _candidate_is_healthy(candidate, health_check):
+    """Return whether a candidate passes the optional health callback."""
     if health_check is None:
         return True
     try:
@@ -139,6 +148,7 @@ def _candidate_is_healthy(candidate, health_check):
 
 
 def _public_manifest(candidate, skipped_candidates):
+    """Return a public manifest without transient parser-only fields."""
     manifest = dict(candidate)
     manifest.pop("message_ids", None)
     manifest["skipped_candidate_count"] = len(skipped_candidates)
@@ -147,6 +157,7 @@ def _public_manifest(candidate, skipped_candidates):
 
 
 def _select_healthy_candidate(candidates, health_check):
+    """Return the first healthy manifest candidate or an unsupported manifest."""
     skipped_candidates = []
     for candidate in candidates:
         if _candidate_is_healthy(candidate, health_check):
@@ -235,6 +246,7 @@ def extract_nzb_video_manifest(nzb_bytes, health_check=None):
 
 
 def _valid_nzb_url(url):
+    """Return True for simple HTTP(S) NZB URLs that are safe to fetch."""
     if not isinstance(url, str) or any(ord(char) < 0x20 for char in url):
         return False
     try:

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 nzbdav contributors
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 from urllib.error import URLError
+from xml.sax.saxutils import quoteattr
 
 from resources.lib.fallback_streams import (
     _SAFE_JOB_RE,
@@ -23,11 +24,48 @@ def _mock_range_response(body, status=206, headers=None):
     resp.read = MagicMock(return_value=body)
     resp.status = status
     resp.getcode = MagicMock(return_value=status)
-    header_map = headers or {}
+    header_map = {str(key).lower(): value for key, value in (headers or {}).items()}
     resp.headers.get = MagicMock(
-        side_effect=lambda key, default=None: header_map.get(key, default)
+        side_effect=lambda key, default=None: header_map.get(str(key).lower(), default)
     )
     return resp
+
+
+def _mock_nzb_response(body, status=200, headers=None):
+    resp = MagicMock()
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    resp.status = status
+    resp.getcode = MagicMock(return_value=status)
+    resp.read = MagicMock(return_value=body)
+    header_map = {str(key).lower(): value for key, value in (headers or {}).items()}
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default=None: header_map.get(str(key).lower(), default)
+    )
+    return resp
+
+
+def _nzb_xml(files):
+    body = [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">',
+    ]
+    body.extend(files)
+    body.append("</nzb>")
+    return "\n".join(body).encode("utf-8")
+
+
+def _nzb_file(subject, segments):
+    segment_xml = "\n".join(
+        '<segment bytes="{}" number="{}">{}</segment>'.format(size, number, msgid)
+        for number, size, msgid in segments
+    )
+    return """
+    <file poster="poster" date="1777937305" subject={}>
+      <groups><group>alt.binaries.test</group></groups>
+      <segments>{}</segments>
+    </file>
+    """.format(quoteattr(subject), segment_xml)
 
 
 def _result(title, link, size, meta=None):
@@ -104,7 +142,7 @@ def test_manifest_grouping_uses_video_name_and_bytes_not_result_size(
         "https://b/nzb": _manifest("video", "example movie 2026 group.mkv", 8000, "b"),
         "https://c/nzb": _manifest("video", "example movie 2026 group.mkv", 9000, "c"),
     }
-    mock_fetch.side_effect = lambda url: manifests[url]
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
 
     results = [primary, duplicate, unrelated]
 
@@ -155,7 +193,7 @@ def test_same_article_mirrors_are_not_attached_as_fallbacks(mock_settings, mock_
         "https://idx/b.nzb": _manifest("video", "movie.mkv", 1000, "articles-a"),
         "https://idx/c.nzb": _manifest("video", "movie.mkv", 1000, "articles-c"),
     }
-    mock_fetch.side_effect = lambda url: manifests[url]
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
 
     attach_fallback_candidates([primary, mirror, repost])
 
@@ -176,12 +214,54 @@ def test_rar_only_manifests_are_grouped_provisionally_for_runtime_validation(
         "https://idx/a.nzb": _manifest("archive", "movie", 0, "articles-a"),
         "https://idx/b.nzb": _manifest("archive", "movie", 0, "articles-b"),
     }
-    mock_fetch.side_effect = lambda url: manifests[url]
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
 
     attach_fallback_candidates([primary, archive_fallback])
 
     assert primary["_fallback_candidates"] == [archive_fallback]
     assert archive_fallback["_fallback_candidates"] == [primary]
+
+
+@patch("resources.lib.nzb_manifest.urlopen")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_attach_fallbacks_skips_unhealthy_manifest_file_candidates(
+    mock_settings, mock_urlopen
+):
+    mock_settings.return_value = (True, 5)
+    primary = _result("Movie primary", "https://idx/a.nzb", 1)
+    fallback = _result("Movie fallback", "https://idx/b.nzb", 2)
+    bodies = {
+        "https://idx/a.nzb": _nzb_xml(
+            [
+                _nzb_file(
+                    '"Broken.Primary.mkv" yEnc (1/1)',
+                    [(1, 10000, "malformed id")],
+                ),
+                _nzb_file('"Movie.mkv" yEnc (1/1)', [(1, 8000, "good-a@id")]),
+            ]
+        ),
+        "https://idx/b.nzb": _nzb_xml(
+            [
+                _nzb_file(
+                    '"Broken.Fallback.mkv" yEnc (1/1)',
+                    [(1, 10000, "also malformed")],
+                ),
+                _nzb_file('"Movie.mkv" yEnc (1/1)', [(1, 8000, "good-b@id")]),
+            ]
+        ),
+    }
+    mock_urlopen.side_effect = lambda req, timeout=5: _mock_nzb_response(
+        bodies[req.full_url], headers={"Content-Length": str(len(bodies[req.full_url]))}
+    )
+
+    attach_fallback_candidates([primary, fallback])
+
+    assert primary["_fallback_manifest"]["video_name"] == "Movie.mkv"
+    assert fallback["_fallback_manifest"]["video_name"] == "Movie.mkv"
+    assert primary["_fallback_manifest"]["skipped_candidate_count"] == 1
+    assert fallback["_fallback_manifest"]["skipped_candidate_count"] == 1
+    assert primary["_fallback_candidates"] == [fallback]
+    assert fallback["_fallback_candidates"] == [primary]
 
 
 @patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
@@ -194,7 +274,7 @@ def test_manifest_fetches_are_cached_per_attach_call(mock_settings, mock_fetch):
 
     attach_fallback_candidates([first, second])
 
-    mock_fetch.assert_called_once_with("https://idx/same.nzb")
+    mock_fetch.assert_called_once_with("https://idx/same.nzb", health_check=ANY)
     assert first["_fallback_manifest_error"] == ""
     assert second["_fallback_manifest_error"] == ""
 
@@ -208,7 +288,7 @@ def test_manifest_fetch_exception_marks_one_result_failed_without_raising(
     broken = _result("Broken", "https://idx/broken.nzb", 1)
     working = _result("Working", "https://idx/working.nzb", 2)
 
-    def fetch(url):
+    def fetch(url, **_kwargs):
         if url.endswith("broken.nzb"):
             raise RuntimeError("message id failure")
         return _manifest("video", "movie.mkv", 1000, "articles-working")

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -139,6 +139,21 @@ def test_manifest_grouping_uses_video_name_and_bytes_not_result_size(
 
 
 @patch("resources.lib.fallback_streams._fallback_settings")
+def test_malformed_manifest_group_bytes_fails_closed_without_aborting(mock_settings):
+    mock_settings.return_value = (True, 5)
+    malformed = _result("Movie bad manifest", "https://idx/a.nzb", 1)
+    malformed["_fallback_manifest"] = _manifest("video", "movie.mkv", 1000, "a")
+    malformed["_fallback_manifest"]["group_bytes"] = "not-a-number"
+    valid = _result("Movie valid manifest", "https://idx/b.nzb", 2)
+    valid["_fallback_manifest"] = _manifest("video", "movie.mkv", 1000, "b")
+
+    attach_fallback_candidates([malformed, valid])
+
+    assert malformed["_fallback_candidates"] == []
+    assert valid["_fallback_candidates"] == []
+
+
+@patch("resources.lib.fallback_streams._fallback_settings")
 def test_disabled_setting_adds_empty_fallback_lists(mock_settings):
     mock_settings.return_value = (False, 2)
     results = [

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -53,8 +53,29 @@ def _fallback_setting(key):
     }.get(key, "")
 
 
+def _manifest(kind, name, size, digest, article_count=2):
+    manifest = {
+        "payload_kind": kind,
+        "group_name": name,
+        "group_bytes": size,
+        "video_name": name if kind == "video" else "",
+        "normalized_video_name": name if kind == "video" else "",
+        "video_bytes": size if kind == "video" else 0,
+        "archive_base_name": name if kind == "archive" else "",
+        "article_digest": digest,
+        "article_count": article_count,
+        "skipped_candidate_count": 0,
+        "skipped_candidates": [],
+        "unsupported_reason": "",
+    }
+    return manifest
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
 @patch("resources.lib.fallback_streams._fallback_settings")
-def test_exact_duplicate_title_attaches_distinct_fallback_candidates(mock_settings):
+def test_manifest_grouping_uses_video_name_and_bytes_not_result_size(
+    mock_settings, mock_fetch
+):
     mock_settings.return_value = (True, 2)
     primary = _result(
         "Example Movie 2026 1080p WEB-DL x265-GROUP",
@@ -78,6 +99,12 @@ def test_exact_duplicate_title_attaches_distinct_fallback_candidates(mock_settin
             "container": "mkv",
         },
     )
+    manifests = {
+        "https://a/nzb": _manifest("video", "example movie 2026 group.mkv", 8000, "a"),
+        "https://b/nzb": _manifest("video", "example movie 2026 group.mkv", 8000, "b"),
+        "https://c/nzb": _manifest("video", "example movie 2026 group.mkv", 9000, "c"),
+    }
+    mock_fetch.side_effect = lambda url: manifests[url]
 
     results = [primary, duplicate, unrelated]
 
@@ -116,26 +143,84 @@ def test_fallback_settings_default_to_enabled_with_five_candidates():
         assert _fallback_settings() == (True, 5)
 
 
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
 @patch("resources.lib.fallback_streams._fallback_settings")
-def test_size_mismatch_still_attaches_candidate_for_runtime_validation(mock_settings):
-    mock_settings.return_value = (True, 2)
-    results = [
-        _result(
-            "Example Movie 2026 1080p WEB-DL x265-GROUP",
-            "https://a/nzb",
-            1000,
-        ),
-        _result(
-            "Example Movie 2026 1080p WEB-DL x265-GROUP",
-            "https://b/nzb",
-            10_000_000,
-        ),
-    ]
+def test_same_article_mirrors_are_not_attached_as_fallbacks(mock_settings, mock_fetch):
+    mock_settings.return_value = (True, 5)
+    primary = _result("Movie", "https://idx/a.nzb", 1)
+    mirror = _result("Movie mirror", "https://idx/b.nzb", 2)
+    repost = _result("Movie repost", "https://idx/c.nzb", 3)
+    manifests = {
+        "https://idx/a.nzb": _manifest("video", "movie.mkv", 1000, "articles-a"),
+        "https://idx/b.nzb": _manifest("video", "movie.mkv", 1000, "articles-a"),
+        "https://idx/c.nzb": _manifest("video", "movie.mkv", 1000, "articles-c"),
+    }
+    mock_fetch.side_effect = lambda url: manifests[url]
 
-    attach_fallback_candidates(results)
+    attach_fallback_candidates([primary, mirror, repost])
 
-    assert results[0]["_fallback_candidates"] == [results[1]]
-    assert results[1]["_fallback_candidates"] == [results[0]]
+    assert primary["_fallback_candidates"] == [repost]
+    assert mirror["_fallback_candidates"] == [repost]
+    assert repost["_fallback_candidates"] == [primary]
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_rar_only_manifests_are_grouped_provisionally_for_runtime_validation(
+    mock_settings, mock_fetch
+):
+    mock_settings.return_value = (True, 5)
+    primary = _result("Movie", "https://idx/a.nzb", 1)
+    archive_fallback = _result("Movie", "https://idx/b.nzb", 2)
+    manifests = {
+        "https://idx/a.nzb": _manifest("archive", "movie", 0, "articles-a"),
+        "https://idx/b.nzb": _manifest("archive", "movie", 0, "articles-b"),
+    }
+    mock_fetch.side_effect = lambda url: manifests[url]
+
+    attach_fallback_candidates([primary, archive_fallback])
+
+    assert primary["_fallback_candidates"] == [archive_fallback]
+    assert archive_fallback["_fallback_candidates"] == [primary]
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_manifest_fetches_are_cached_per_attach_call(mock_settings, mock_fetch):
+    mock_settings.return_value = (True, 5)
+    first = _result("Movie", "https://idx/same.nzb", 1)
+    second = _result("Movie duplicate", "https://idx/same.nzb", 2)
+    mock_fetch.return_value = _manifest("video", "movie.mkv", 1000, "same-articles")
+
+    attach_fallback_candidates([first, second])
+
+    mock_fetch.assert_called_once_with("https://idx/same.nzb")
+    assert first["_fallback_manifest_error"] == ""
+    assert second["_fallback_manifest_error"] == ""
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_manifest_fetch_exception_marks_one_result_failed_without_raising(
+    mock_settings, mock_fetch
+):
+    mock_settings.return_value = (True, 5)
+    broken = _result("Broken", "https://idx/broken.nzb", 1)
+    working = _result("Working", "https://idx/working.nzb", 2)
+
+    def fetch(url):
+        if url.endswith("broken.nzb"):
+            raise RuntimeError("message id failure")
+        return _manifest("video", "movie.mkv", 1000, "articles-working")
+
+    mock_fetch.side_effect = fetch
+
+    attach_fallback_candidates([broken, working])
+
+    assert broken["_fallback_manifest_error"] == "fetch_error"
+    assert broken["_fallback_candidates"] == []
+    assert working["_fallback_manifest_error"] == ""
+    assert working["_fallback_candidates"] == []
 
 
 def test_build_fallback_job_name_unique_traceable_and_single_line():
@@ -214,18 +299,25 @@ def test_build_prepare_fallback_payload_preserves_completed_and_standby_jobs():
     ]
 
 
-def test_fingerprint_offsets_use_edges_and_middle():
-    assert fingerprint_ranges(100000) == [
-        (0, 4095),
-        (25000, 29095),
-        (50000, 54095),
-        (75000, 79095),
-        (95904, 99999),
-    ]
+def test_fingerprint_ranges_uses_1000_deterministic_4096_byte_samples_for_large_files():
+    content_length = 10 * 1024 * 1024 * 1024
+
+    ranges = fingerprint_ranges(content_length)
+
+    assert len(ranges) == 1000
+    assert len(set(ranges)) == 1000
+    assert ranges == fingerprint_ranges(content_length)
+    assert ranges[0] == (0, 4095)
+    assert ranges[-1] == (content_length - 4096, content_length - 1)
+    assert all((end - start + 1) == 4096 for start, end in ranges)
 
 
 def test_fingerprint_ranges_handles_small_files():
     assert fingerprint_ranges(1024) == [(0, 1023)]
+
+
+def test_fingerprint_ranges_chunks_whole_file_when_smaller_than_sample_budget():
+    assert fingerprint_ranges(5000) == [(0, 4095), (4096, 4999)]
 
 
 @patch("resources.lib.fallback_streams.urlopen", side_effect=URLError("timeout"))

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -31,20 +31,6 @@ def _mock_range_response(body, status=206, headers=None):
     return resp
 
 
-def _mock_nzb_response(body, status=200, headers=None):
-    resp = MagicMock()
-    resp.__enter__ = MagicMock(return_value=resp)
-    resp.__exit__ = MagicMock(return_value=False)
-    resp.status = status
-    resp.getcode = MagicMock(return_value=status)
-    resp.read = MagicMock(return_value=body)
-    header_map = {str(key).lower(): value for key, value in (headers or {}).items()}
-    resp.headers.get = MagicMock(
-        side_effect=lambda key, default=None: header_map.get(str(key).lower(), default)
-    )
-    return resp
-
-
 def _nzb_xml(files):
     body = [
         '<?xml version="1.0" encoding="utf-8"?>',
@@ -222,10 +208,10 @@ def test_rar_only_manifests_are_grouped_provisionally_for_runtime_validation(
     assert archive_fallback["_fallback_candidates"] == [primary]
 
 
-@patch("resources.lib.nzb_manifest.urlopen")
+@patch("resources.lib.nzb_manifest.http_get")
 @patch("resources.lib.fallback_streams._fallback_settings")
 def test_attach_fallbacks_skips_unhealthy_manifest_file_candidates(
-    mock_settings, mock_urlopen
+    mock_settings, mock_http_get
 ):
     mock_settings.return_value = (True, 5)
     primary = _result("Movie primary", "https://idx/a.nzb", 1)
@@ -250,9 +236,7 @@ def test_attach_fallbacks_skips_unhealthy_manifest_file_candidates(
             ]
         ),
     }
-    mock_urlopen.side_effect = lambda req, timeout=5: _mock_nzb_response(
-        bodies[req.full_url], headers={"Content-Length": str(len(bodies[req.full_url]))}
-    )
+    mock_http_get.side_effect = lambda url, **_kwargs: bodies[url].decode("utf-8")
 
     attach_fallback_candidates([primary, fallback])
 

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -3,7 +3,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from resources.lib.http_util import http_get, notify, redact_url
+from resources.lib.http_util import HttpResponseTooLarge, http_get, notify, redact_url
 
 
 @patch("resources.lib.http_util.urlopen")
@@ -74,6 +74,59 @@ def test_http_get_passes_timeout(mock_urlopen):
     http_get("http://example.com/api", timeout=30)
     _, kwargs = mock_urlopen.call_args
     assert kwargs.get("timeout") == 30
+
+
+@patch("resources.lib.http_util.urlopen")
+def test_http_get_passes_extra_headers_and_reads_with_max_bytes(mock_urlopen):
+    """http_get should merge caller headers and cap reads when requested."""
+    mock_resp = MagicMock()
+    mock_resp.headers.get.return_value = "0"
+    mock_resp.read.return_value = b"ok"
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_urlopen.return_value = mock_resp
+
+    result = http_get("http://example.com/api", headers={"X-Test": "1"}, max_bytes=2)
+
+    assert result == "ok"
+
+    request = mock_urlopen.call_args[0][0]
+    assert request.get_header("User-agent") == "NZB-DAV Kodi Addon"
+    assert request.get_header("X-test") == "1"
+    mock_resp.read.assert_called_once_with(3)
+
+
+@patch("resources.lib.http_util.urlopen")
+def test_http_get_rejects_oversized_content_length(mock_urlopen):
+    """Content-Length larger than max_bytes should fail before body read."""
+    import pytest
+
+    mock_resp = MagicMock()
+    mock_resp.headers.get.return_value = "5"
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_urlopen.return_value = mock_resp
+
+    with pytest.raises(HttpResponseTooLarge):
+        http_get("http://example.com/api", max_bytes=4)
+    mock_resp.read.assert_not_called()
+
+
+@patch("resources.lib.http_util.urlopen")
+def test_http_get_rejects_body_larger_than_max_bytes(mock_urlopen):
+    """Bodies without Content-Length should still be capped after read."""
+    import pytest
+
+    mock_resp = MagicMock()
+    mock_resp.headers.get.return_value = "0"
+    mock_resp.read.return_value = b"12345"
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_urlopen.return_value = mock_resp
+
+    with pytest.raises(HttpResponseTooLarge):
+        http_get("http://example.com/api", max_bytes=4)
+    mock_resp.read.assert_called_once_with(5)
 
 
 @patch("resources.lib.http_util.urlopen")

--- a/tests/test_nzb_manifest.py
+++ b/tests/test_nzb_manifest.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+from unittest.mock import MagicMock, patch
+from urllib.error import URLError
+from xml.sax.saxutils import escape, quoteattr
+
+from resources.lib.nzb_manifest import (
+    extract_nzb_video_manifest,
+    fetch_nzb_video_manifest,
+    normalize_video_filename,
+)
+
+
+def _nzb_xml(files):
+    body = [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">',
+    ]
+    body.extend(files)
+    body.append("</nzb>")
+    return "\n".join(body).encode("utf-8")
+
+
+def _file(subject, segments):
+    segment_xml = "\n".join(
+        '<segment bytes="{}" number="{}">{}</segment>'.format(
+            size, number, escape(msgid)
+        )
+        for number, size, msgid in segments
+    )
+    return """
+    <file poster="poster" date="1777937305" subject={}>
+      <groups><group>alt.binaries.test</group></groups>
+      <segments>{}</segments>
+    </file>
+    """.format(quoteattr(subject), segment_xml)
+
+
+def _mock_response(body, status=200, headers=None):
+    resp = MagicMock()
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    resp.status = status
+    resp.getcode = MagicMock(return_value=status)
+    resp.read = MagicMock(return_value=body)
+    header_map = headers or {}
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default=None: header_map.get(key, default)
+    )
+    return resp
+
+
+def test_normalize_video_filename_is_case_and_separator_insensitive():
+    assert (
+        normalize_video_filename("Movie.Name.2026.2160p-GROUP.mkv")
+        == "movie name 2026 2160p group.mkv"
+    )
+    assert (
+        normalize_video_filename('"Movie Name 2026 2160p-GROUP.MKV"')
+        == "movie name 2026 2160p group.mkv"
+    )
+
+
+def test_extracts_main_video_file_manifest_from_nzb():
+    xml = _nzb_xml(
+        [
+            _file('"Movie.Name.2026.2160p-GROUP.nfo" yEnc (1/1)', [(1, 100, "nfo@id")]),
+            _file(
+                '"Movie.Name.2026.2160p-GROUP.mkv" yEnc (1/2)',
+                [(1, 1000, "part1@id"), (2, 2000, "part2@id")],
+            ),
+        ]
+    )
+
+    manifest = extract_nzb_video_manifest(xml)
+
+    assert manifest["payload_kind"] == "video"
+    assert manifest["video_name"] == "Movie.Name.2026.2160p-GROUP.mkv"
+    assert manifest["normalized_video_name"] == "movie name 2026 2160p group.mkv"
+    assert manifest["group_name"] == "movie name 2026 2160p group.mkv"
+    assert manifest["group_bytes"] == 3000
+    assert manifest["video_bytes"] == 3000
+    assert manifest["article_count"] == 2
+    assert manifest["article_digest"]
+    assert manifest["skipped_candidate_count"] == 0
+    assert manifest["skipped_candidates"] == []
+    assert "message_ids" not in manifest
+    assert manifest["unsupported_reason"] == ""
+
+
+def test_selects_largest_supported_video_entry_and_ignores_samples():
+    xml = _nzb_xml(
+        [
+            _file(
+                '"Sample.Movie.Name.2026-GROUP.mkv" yEnc (1/1)',
+                [(1, 1000, "sample@id")],
+            ),
+            _file(
+                '"Movie.Name.2026-GROUP.mkv" yEnc (1/2)',
+                [(1, 5000, "a@id"), (2, 5000, "b@id")],
+            ),
+            _file('"Movie.Name.2026-GROUP.par2" yEnc (1/1)', [(1, 90000, "par2@id")]),
+        ]
+    )
+
+    manifest = extract_nzb_video_manifest(xml)
+
+    assert manifest["video_name"] == "Movie.Name.2026-GROUP.mkv"
+    assert manifest["video_bytes"] == 10000
+
+
+def test_health_check_failure_skips_first_video_candidate():
+    xml = _nzb_xml(
+        [
+            _file(
+                '"Broken.Movie.2026-GROUP.mkv" yEnc (1/2)',
+                [(1, 5000, "bad@id"), (2, 5000, "bad2@id")],
+            ),
+            _file(
+                '"Working.Movie.2026-GROUP.mkv" yEnc (1/2)',
+                [(1, 4000, "good@id"), (2, 4000, "good2@id")],
+            ),
+        ]
+    )
+    checked = []
+
+    def health_check(candidate):
+        checked.append(candidate["video_name"] or candidate["archive_base_name"])
+        return "bad@id" not in candidate["message_ids"]
+
+    manifest = extract_nzb_video_manifest(xml, health_check=health_check)
+
+    assert checked == ["Broken.Movie.2026-GROUP.mkv", "Working.Movie.2026-GROUP.mkv"]
+    assert manifest["video_name"] == "Working.Movie.2026-GROUP.mkv"
+    assert manifest["video_bytes"] == 8000
+    assert manifest["skipped_candidate_count"] == 1
+    assert manifest["skipped_candidates"] == [
+        {"name": "Broken.Movie.2026-GROUP.mkv", "reason": "message_id_health_failed"}
+    ]
+    assert manifest["unsupported_reason"] == ""
+
+
+def test_health_check_failure_skips_first_archive_group_candidate():
+    xml = _nzb_xml(
+        [
+            _file('"Broken.part001.rar" yEnc (1/1)', [(1, 1000, "bad-rar@id")]),
+            _file('"Working.part001.rar" yEnc (1/1)', [(1, 1000, "good-rar@id")]),
+        ]
+    )
+
+    manifest = extract_nzb_video_manifest(
+        xml,
+        health_check=lambda candidate: "bad-rar@id" not in candidate["message_ids"],
+    )
+
+    assert manifest["payload_kind"] == "archive"
+    assert manifest["archive_base_name"] == "working"
+    assert manifest["skipped_candidate_count"] == 1
+    assert manifest["unsupported_reason"] == ""
+
+
+def test_all_candidates_failing_health_check_is_unsupported_without_raising():
+    xml = _nzb_xml(
+        [
+            _file('"Broken.Movie.2026-GROUP.mkv" yEnc (1/1)', [(1, 1000, "bad@id")]),
+            _file(
+                '"Also.Broken.Movie.2026-GROUP.mkv" yEnc (1/1)',
+                [(1, 1000, "bad2@id")],
+            ),
+        ]
+    )
+
+    manifest = extract_nzb_video_manifest(xml, health_check=lambda _candidate: False)
+
+    assert manifest["unsupported_reason"] == "all_candidate_files_failed_health_check"
+    assert manifest["skipped_candidate_count"] == 2
+
+
+def test_same_articles_have_same_digest_even_if_segment_order_changes():
+    first = _nzb_xml(
+        [_file('"Movie.mkv" yEnc (1/2)', [(1, 1000, "<A@ID>"), (2, 1000, "<B@ID>")])]
+    )
+    second = _nzb_xml(
+        [_file('"Movie.mkv" yEnc (1/2)', [(2, 1000, "b@id"), (1, 1000, "a@id")])]
+    )
+
+    assert (
+        extract_nzb_video_manifest(first)["article_digest"]
+        == extract_nzb_video_manifest(second)["article_digest"]
+    )
+
+
+def test_different_uploads_have_different_article_digest():
+    first = _nzb_xml(
+        [_file('"Movie.mkv" yEnc (1/2)', [(1, 1000, "a@id"), (2, 1000, "b@id")])]
+    )
+    second = _nzb_xml(
+        [_file('"Movie.mkv" yEnc (1/2)', [(1, 1000, "c@id"), (2, 1000, "d@id")])]
+    )
+
+    assert (
+        extract_nzb_video_manifest(first)["article_digest"]
+        != extract_nzb_video_manifest(second)["article_digest"]
+    )
+
+
+def test_rar_only_nzb_produces_provisional_archive_manifest():
+    xml = _nzb_xml(
+        [
+            _file('"Movie.part001.rar" yEnc (1/1)', [(1, 1000, "rar1@id")]),
+            _file('"Movie.part002.rar" yEnc (1/1)', [(1, 1000, "rar2@id")]),
+        ]
+    )
+
+    manifest = extract_nzb_video_manifest(xml)
+
+    assert manifest["payload_kind"] == "archive"
+    assert manifest["archive_base_name"] == "movie"
+    assert manifest["group_name"] == "movie"
+    assert manifest["group_bytes"] == 0
+    assert manifest["video_name"] == ""
+    assert manifest["video_bytes"] == 0
+    assert manifest["article_digest"]
+    assert manifest["unsupported_reason"] == ""
+
+
+def test_invalid_xml_is_unsupported_without_raising():
+    manifest = extract_nzb_video_manifest(b"<nzb><file></nzb>")
+
+    assert manifest["unsupported_reason"] == "invalid_xml"
+
+
+@patch("resources.lib.nzb_manifest.urlopen")
+def test_fetch_nzb_video_manifest_fetches_and_parses_valid_nzb(mock_urlopen):
+    xml = _nzb_xml([_file('"Movie.mkv" yEnc (1/1)', [(1, 1000, "a@id")])])
+    mock_urlopen.return_value = _mock_response(xml, headers={"Content-Length": "1234"})
+
+    manifest = fetch_nzb_video_manifest("https://idx/getnzb/123")
+
+    assert manifest["video_name"] == "Movie.mkv"
+    req = mock_urlopen.call_args[0][0]
+    assert req.full_url == "https://idx/getnzb/123"
+    assert req.headers["User-agent"] == "NZB-DAV Kodi"
+
+
+@patch("resources.lib.nzb_manifest.urlopen")
+def test_fetch_nzb_video_manifest_passes_candidate_health_check(mock_urlopen):
+    xml = _nzb_xml(
+        [
+            _file('"Broken.Movie.mkv" yEnc (1/1)', [(1, 1000, "bad@id")]),
+            _file('"Working.Movie.mkv" yEnc (1/1)', [(1, 900, "good@id")]),
+        ]
+    )
+    mock_urlopen.return_value = _mock_response(xml, headers={"Content-Length": "1234"})
+
+    manifest = fetch_nzb_video_manifest(
+        "https://idx/getnzb/123",
+        health_check=lambda candidate: "bad@id" not in candidate["message_ids"],
+    )
+
+    assert manifest["video_name"] == "Working.Movie.mkv"
+    assert manifest["skipped_candidate_count"] == 1
+
+
+@patch("resources.lib.nzb_manifest.urlopen")
+def test_fetch_nzb_video_manifest_rejects_invalid_url(mock_urlopen):
+    manifest = fetch_nzb_video_manifest("file:///etc/passwd")
+
+    assert manifest["unsupported_reason"] == "invalid_url"
+    mock_urlopen.assert_not_called()
+
+
+@patch("resources.lib.nzb_manifest.urlopen", side_effect=URLError("timeout"))
+def test_fetch_nzb_video_manifest_returns_fetch_error(_mock_urlopen):
+    manifest = fetch_nzb_video_manifest("https://idx/getnzb/123")
+
+    assert manifest["unsupported_reason"] == "fetch_error"
+
+
+@patch("resources.lib.nzb_manifest.urlopen")
+def test_fetch_nzb_video_manifest_rejects_oversized_nzb(mock_urlopen):
+    mock_urlopen.return_value = _mock_response(
+        b"<nzb/>",
+        headers={"Content-Length": str(2 * 1024 * 1024 + 1)},
+    )
+
+    manifest = fetch_nzb_video_manifest("https://idx/getnzb/123")
+
+    assert manifest["unsupported_reason"] == "too_large"

--- a/tests/test_nzb_manifest.py
+++ b/tests/test_nzb_manifest.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 nzbdav contributors
 
-from unittest.mock import MagicMock, patch
-from urllib.error import URLError
+from unittest.mock import patch
 from xml.sax.saxutils import escape, quoteattr
 
+from resources.lib.http_util import HttpResponseTooLarge
 from resources.lib.nzb_manifest import (
     extract_nzb_video_manifest,
     fetch_nzb_video_manifest,
@@ -35,20 +35,6 @@ def _file(subject, segments):
       <segments>{}</segments>
     </file>
     """.format(quoteattr(subject), segment_xml)
-
-
-def _mock_response(body, status=200, headers=None):
-    resp = MagicMock()
-    resp.__enter__ = MagicMock(return_value=resp)
-    resp.__exit__ = MagicMock(return_value=False)
-    resp.status = status
-    resp.getcode = MagicMock(return_value=status)
-    resp.read = MagicMock(return_value=body)
-    header_map = {str(key).lower(): value for key, value in (headers or {}).items()}
-    resp.headers.get = MagicMock(
-        side_effect=lambda key, default=None: header_map.get(str(key).lower(), default)
-    )
-    return resp
 
 
 def test_normalize_video_filename_is_case_and_separator_insensitive():
@@ -231,28 +217,30 @@ def test_invalid_xml_is_unsupported_without_raising():
     assert manifest["unsupported_reason"] == "invalid_xml"
 
 
-@patch("resources.lib.nzb_manifest.urlopen")
-def test_fetch_nzb_video_manifest_fetches_and_parses_valid_nzb(mock_urlopen):
+@patch("resources.lib.nzb_manifest.http_get")
+def test_fetch_nzb_video_manifest_fetches_and_parses_valid_nzb(mock_http_get):
     xml = _nzb_xml([_file('"Movie.mkv" yEnc (1/1)', [(1, 1000, "a@id")])])
-    mock_urlopen.return_value = _mock_response(xml, headers={"Content-Length": "1234"})
+    mock_http_get.return_value = xml.decode("utf-8")
 
     manifest = fetch_nzb_video_manifest("https://idx/getnzb/123")
 
     assert manifest["video_name"] == "Movie.mkv"
-    req = mock_urlopen.call_args[0][0]
-    assert req.full_url == "https://idx/getnzb/123"
-    assert req.headers["User-agent"] == "NZB-DAV Kodi"
+    mock_http_get.assert_called_once_with(
+        "https://idx/getnzb/123",
+        timeout=5,
+        max_bytes=2 * 1024 * 1024,
+    )
 
 
-@patch("resources.lib.nzb_manifest.urlopen")
-def test_fetch_nzb_video_manifest_passes_candidate_health_check(mock_urlopen):
+@patch("resources.lib.nzb_manifest.http_get")
+def test_fetch_nzb_video_manifest_passes_candidate_health_check(mock_http_get):
     xml = _nzb_xml(
         [
             _file('"Broken.Movie.mkv" yEnc (1/1)', [(1, 1000, "bad@id")]),
             _file('"Working.Movie.mkv" yEnc (1/1)', [(1, 900, "good@id")]),
         ]
     )
-    mock_urlopen.return_value = _mock_response(xml, headers={"Content-Length": "1234"})
+    mock_http_get.return_value = xml.decode("utf-8")
 
     manifest = fetch_nzb_video_manifest(
         "https://idx/getnzb/123",
@@ -263,28 +251,26 @@ def test_fetch_nzb_video_manifest_passes_candidate_health_check(mock_urlopen):
     assert manifest["skipped_candidate_count"] == 1
 
 
-@patch("resources.lib.nzb_manifest.urlopen")
-def test_fetch_nzb_video_manifest_rejects_invalid_url(mock_urlopen):
+@patch("resources.lib.nzb_manifest.http_get")
+def test_fetch_nzb_video_manifest_rejects_invalid_url(mock_http_get):
     manifest = fetch_nzb_video_manifest("file:///etc/passwd")
 
     assert manifest["unsupported_reason"] == "invalid_url"
-    mock_urlopen.assert_not_called()
+    mock_http_get.assert_not_called()
 
 
-@patch("resources.lib.nzb_manifest.urlopen", side_effect=URLError("timeout"))
-def test_fetch_nzb_video_manifest_returns_fetch_error(_mock_urlopen):
+@patch("resources.lib.nzb_manifest.http_get", side_effect=OSError("timeout"))
+def test_fetch_nzb_video_manifest_returns_fetch_error(_mock_http_get):
     manifest = fetch_nzb_video_manifest("https://idx/getnzb/123")
 
     assert manifest["unsupported_reason"] == "fetch_error"
 
 
-@patch("resources.lib.nzb_manifest.urlopen")
-def test_fetch_nzb_video_manifest_rejects_oversized_nzb(mock_urlopen):
-    mock_urlopen.return_value = _mock_response(
-        b"<nzb/>",
-        headers={"Content-Length": str(2 * 1024 * 1024 + 1)},
-    )
-
+@patch(
+    "resources.lib.nzb_manifest.http_get",
+    side_effect=HttpResponseTooLarge("too large"),
+)
+def test_fetch_nzb_video_manifest_rejects_oversized_nzb(_mock_http_get):
     manifest = fetch_nzb_video_manifest("https://idx/getnzb/123")
 
     assert manifest["unsupported_reason"] == "too_large"

--- a/tests/test_nzb_manifest.py
+++ b/tests/test_nzb_manifest.py
@@ -44,9 +44,9 @@ def _mock_response(body, status=200, headers=None):
     resp.status = status
     resp.getcode = MagicMock(return_value=status)
     resp.read = MagicMock(return_value=body)
-    header_map = headers or {}
+    header_map = {str(key).lower(): value for key, value in (headers or {}).items()}
     resp.headers.get = MagicMock(
-        side_effect=lambda key, default=None: header_map.get(key, default)
+        side_effect=lambda key, default=None: header_map.get(str(key).lower(), default)
     )
     return resp
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -693,6 +693,23 @@ def _stub_setting(value):
 
 
 def _attach_primary_duplicate_fallbacks(results):
+    for index, result in enumerate(results):
+        result["_fallback_candidates"] = []
+        result["_fallback_manifest"] = {
+            "payload_kind": "video",
+            "group_name": "the matrix 1999 1080p bluray x264 group.mkv",
+            "group_bytes": 8589934592,
+            "video_name": "The.Matrix.1999.1080p.BluRay.x264-GROUP.mkv",
+            "normalized_video_name": "the matrix 1999 1080p bluray x264 group.mkv",
+            "video_bytes": 8589934592,
+            "archive_base_name": "",
+            "article_digest": "articles-{}".format(index),
+            "article_count": 100,
+            "skipped_candidate_count": 0,
+            "skipped_candidates": [],
+            "unsupported_reason": "",
+        }
+        result["_fallback_manifest_error"] = ""
     from resources.lib.fallback_streams import attach_fallback_candidates
 
     with patch("resources.lib.fallback_streams._fallback_settings") as mock_settings:

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -6156,6 +6156,48 @@ def test_select_live_fallback_rejects_same_length_different_fingerprint():
     )
 
 
+def test_live_fallback_selection_checks_all_attached_candidates_until_one_matches():
+    handler = _make_handler()
+    sources = [
+        {
+            "nzo_id": "nzo1",
+            "stream_url": "http://webdav/fallback1.mkv",
+            "failed": False,
+        },
+        {
+            "nzo_id": "nzo2",
+            "stream_url": "http://webdav/fallback2.mkv",
+            "failed": False,
+        },
+        {
+            "nzo_id": "nzo3",
+            "stream_url": "http://webdav/fallback3.mkv",
+            "failed": False,
+        },
+        {
+            "nzo_id": "nzo4",
+            "stream_url": "http://webdav/fallback4.mkv",
+            "failed": False,
+        },
+        {
+            "nzo_id": "nzo5",
+            "stream_url": "http://webdav/fallback5.mkv",
+            "failed": False,
+        },
+    ]
+    ctx = {"fallback_sources": sources}
+
+    with patch.object(handler, "_refresh_standby_fallback_sources"), patch.object(
+        handler,
+        "_fallback_source_matches",
+        side_effect=[False, False, False, False, True],
+    ) as mock_matches:
+        assert handler._select_live_fallback_source(ctx, 0, 9) == sources[4]
+
+    assert mock_matches.call_count == 5
+    assert [source["failed"] for source in sources] == [True, True, True, True, False]
+
+
 def test_select_live_fallback_refreshes_completed_standby_job():
     """Standby nzo_id entries can become usable without restarting playback."""
     handler = _make_handler()

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -6029,9 +6029,9 @@ def _mock_urlopen_response(chunks, status=206, headers=None):
     resp.read = MagicMock(side_effect=data)
     resp.status = status
     resp.getcode = MagicMock(return_value=status)
-    header_map = headers or {}
+    header_map = {str(key).lower(): value for key, value in (headers or {}).items()}
     resp.headers.get = MagicMock(
-        side_effect=lambda key, default=None: header_map.get(key, default)
+        side_effect=lambda key, default=None: header_map.get(str(key).lower(), default)
     )
     resp.close = MagicMock()
     return resp


### PR DESCRIPTION
## Summary
- add NZB manifest parsing/fetching for fallback grouping by selected video payload or provisional archive payload
- reject same-article mirrored NZBs with Article Message-ID digests and keep RAR-only NZBs eligible for runtime validation
- strengthen fallback byte validation to 1000 deterministic 4096-byte samples and keep trying attached fallback candidates until one validates
- update README, changelog, addon news, and tests for the new fallback behavior

## Verification
- just test
- just lint