### PR TITLE
Fix make-dev on macOS bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `just make-dev` now works on macOS Bash 3.2 when no pip compatibility flags
+  are needed, instead of failing under `set -u` on an empty `pip_flags` array.
 - Test harness now isolates stream-proxy prevalidation and remux idle-timeout
   checks on Windows, locates Git Bash for install-script checks, falls back when
   `SIGKILL` is unavailable, and avoids POSIX-only HLS workdir assumptions.

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ make-dev:
     if python3 -m pip install --help | grep -q -- "--break-system-packages"; then
         pip_flags+=(--break-system-packages)
     fi
-    python3 -m pip install "${pip_flags[@]}" -r requirements-test.txt "ruff>=0.15" "black>=24"
+    python3 -m pip install ${pip_flags[@]+"${pip_flags[@]}"} -r requirements-test.txt "ruff>=0.15" "black>=24"
 
     if [[ "$(uname -s)" == "Darwin" ]]; then
         if ! command -v brew >/dev/null 2>&1; then

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ make-dev:
     if python3 -m pip install --help | grep -q -- "--break-system-packages"; then
         pip_flags+=(--break-system-packages)
     fi
-    python3 -m pip install ${pip_flags[@]+"${pip_flags[@]}"} -r requirements-test.txt "ruff>=0.15" "black>=24"
+    python3 -m pip install ${pip_flags+"${pip_flags[@]}"} -r requirements-test.txt "ruff>=0.15" "black>=24"
 
     if [[ "$(uname -s)" == "Darwin" ]]; then
         if ! command -v brew >/dev/null 2>&1; then

--- a/tests/test_justfile.py
+++ b/tests/test_justfile.py
@@ -37,6 +37,15 @@ def test_make_dev_installs_dependencies_for_all_just_recipes():
     assert "ffmpeg -version" in body
 
 
+def test_make_dev_pip_flags_expansion_is_bash32_nounset_safe():
+    justfile_text = Path("justfile").read_text(encoding="utf-8")
+
+    body = _recipe_body(justfile_text, "make-dev")
+
+    assert 'pip install "${pip_flags[@]}" -r requirements-test.txt' not in body
+    assert '${pip_flags[@]+"${pip_flags[@]}"}' in body
+
+
 def test_functional_test_recipe_is_dev_only_and_not_in_default_test():
     justfile_text = Path("justfile").read_text(encoding="utf-8")
 

--- a/tests/test_justfile.py
+++ b/tests/test_justfile.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2026 nzbdav contributors
 
 import re
+import subprocess
 from pathlib import Path
 
 
@@ -43,7 +44,19 @@ def test_make_dev_pip_flags_expansion_is_bash32_nounset_safe():
     body = _recipe_body(justfile_text, "make-dev")
 
     assert 'pip install "${pip_flags[@]}" -r requirements-test.txt' not in body
-    assert '${pip_flags[@]+"${pip_flags[@]}"}' in body
+    assert '${pip_flags+"${pip_flags[@]}"}' in body
+
+    bash = Path("/bin/bash")
+    if bash.exists():
+        subprocess.run(
+            [
+                str(bash),
+                "-uc",
+                'pip_flags=(); args=(${pip_flags+"${pip_flags[@]}"}); '
+                "[[ ${#args[@]} -eq 0 ]]",
+            ],
+            check=True,
+        )
 
 
 def test_functional_test_recipe_is_dev_only_and_not_in_default_test():


### PR DESCRIPTION
## Summary
- Make the make-dev pip flags expansion safe under macOS Bash 3.2 with set -u
- Add a regression test for the justfile recipe
- Document the fix in CHANGELOG.md

## Verification
- PATH="/Users/mark/Documents/git/nzbdavkodi/.venv/bin:/Users/mark/.codex/tmp/arg0/codex-arg0l2el6J:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/homebrew/bin:/Applications/Warp.app/Contents/Resources/bin" just lint
- PATH="/Users/mark/Documents/git/nzbdavkodi/.venv/bin:/Users/mark/.codex/tmp/arg0/codex-arg0l2el6J:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/homebrew/bin:/Applications/Warp.app/Contents/Resources/bin" just test