### PR TITLE
🧪 Add tests for extend_options and fix mutable default arg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,4 @@ markers = [
     "functional: dev-box tests that use live services plus local playback simulation; skipped by default, run via `just functional-test`",
     "extreme: extreme functional test (20+ minutes, real services); skipped by default, run via `just extreme-functional-test`",
 ]
+pythonpath = "plugin.video.nzbdav"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,3 @@ markers = [
     "functional: dev-box tests that use live services plus local playback simulation; skipped by default, run via `just functional-test`",
     "extreme: extreme functional test (20+ minutes, real services); skipped by default, run via `just extreme-functional-test`",
 ]
-pythonpath = "plugin.video.nzbdav"

--- a/repo/plugin.video.nzbdav/resources/lib/ptt/parse.py
+++ b/repo/plugin.video.nzbdav/resources/lib/ptt/parse.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 import re as regex
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from .transformers import none
 
@@ -89,13 +89,16 @@ BEFORE_TITLE_MATCH_REGEX = re.compile(r"^\[([^[\]]+)]")
 DEBUG_HANDLER = False
 
 
-def extend_options(options: Dict[str, Any] = {}) -> Dict[str, Any]:
+def extend_options(options: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """
     Extend the options dictionary with default values.
 
     :param options: The original options dictionary.
     :return: The extended options dictionary.
     """
+    if options is None:
+        options = {}
+
     default_options = {
         "skipIfAlreadyFound": True,
         "skipFromTitle": False,

--- a/tests/test_ptt_parse.py
+++ b/tests/test_ptt_parse.py
@@ -3,17 +3,25 @@
 
 from resources.lib.ptt.parse import extend_options
 
+DEFAULT_OPTIONS = {
+    "skipIfAlreadyFound": True,
+    "skipFromTitle": False,
+    "skipIfFirst": False,
+    "remove": False,
+}
 
-def test_extend_options_empty():
+
+def expected_options(**overrides):
+    expected = DEFAULT_OPTIONS.copy()
+    expected.update(overrides)
+    return expected
+
+
+def test_extend_options_mutates_provided_empty_dict():
     options = {}
     result = extend_options(options)
-    assert result == {
-        "skipIfAlreadyFound": True,
-        "skipFromTitle": False,
-        "skipIfFirst": False,
-        "remove": False,
-    }
-    # extend_options mutates the options dictionary and returns it
+    assert result == expected_options()
+    # Preserve existing behavior for callers that pass a dict: fill it in place.
     assert result is options
 
 
@@ -23,15 +31,10 @@ def test_extend_options_default_arg():
     result2 = extend_options()
     assert "mutation" not in result2, "Default argument mutation detected!"
 
-    assert result2 == {
-        "skipIfAlreadyFound": True,
-        "skipFromTitle": False,
-        "skipIfFirst": False,
-        "remove": False,
-    }
+    assert result2 == expected_options()
 
 
-def test_extend_options_override_defaults():
+def test_extend_options_preserves_full_overrides_in_place():
     options = {
         "skipIfAlreadyFound": False,
         "skipFromTitle": True,
@@ -39,34 +42,23 @@ def test_extend_options_override_defaults():
         "remove": True,
     }
     result = extend_options(options)
-    assert result == {
-        "skipIfAlreadyFound": False,
-        "skipFromTitle": True,
-        "skipIfFirst": True,
-        "remove": True,
-    }
-    # extend_options mutates the options dictionary and returns it
+    assert result == expected_options(
+        skipIfAlreadyFound=False,
+        skipFromTitle=True,
+        skipIfFirst=True,
+        remove=True,
+    )
+    # Preserve existing behavior for callers that pass a dict: fill it in place.
     assert result is options
 
 
 def test_extend_options_partial_override():
     options = {"remove": True}
     result = extend_options(options)
-    assert result == {
-        "skipIfAlreadyFound": True,
-        "skipFromTitle": False,
-        "skipIfFirst": False,
-        "remove": True,
-    }
+    assert result == expected_options(remove=True)
 
 
 def test_extend_options_extra_keys():
     options = {"extra_key": "value"}
     result = extend_options(options)
-    assert result == {
-        "skipIfAlreadyFound": True,
-        "skipFromTitle": False,
-        "skipIfFirst": False,
-        "remove": False,
-        "extra_key": "value",
-    }
+    assert result == expected_options(extra_key="value")

--- a/tests/test_ptt_parse.py
+++ b/tests/test_ptt_parse.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+import pytest
+from resources.lib.ptt.parse import extend_options
+
+def test_extend_options_empty():
+    options = {}
+    result = extend_options(options)
+    assert result == {
+        "skipIfAlreadyFound": True,
+        "skipFromTitle": False,
+        "skipIfFirst": False,
+        "remove": False,
+    }
+    assert result is options
+
+def test_extend_options_default_arg():
+    result1 = extend_options()
+    result1["mutation"] = True
+    result2 = extend_options()
+    assert "mutation" not in result2, "Default argument mutation detected!"
+
+    assert result2 == {
+        "skipIfAlreadyFound": True,
+        "skipFromTitle": False,
+        "skipIfFirst": False,
+        "remove": False,
+    }
+
+def test_extend_options_override_defaults():
+    options = {
+        "skipIfAlreadyFound": False,
+        "skipFromTitle": True,
+        "skipIfFirst": True,
+        "remove": True,
+    }
+    result = extend_options(options)
+    assert result == {
+        "skipIfAlreadyFound": False,
+        "skipFromTitle": True,
+        "skipIfFirst": True,
+        "remove": True,
+    }
+    assert result is options
+
+def test_extend_options_partial_override():
+    options = {"remove": True}
+    result = extend_options(options)
+    assert result == {
+        "skipIfAlreadyFound": True,
+        "skipFromTitle": False,
+        "skipIfFirst": False,
+        "remove": True,
+    }
+
+def test_extend_options_extra_keys():
+    options = {"extra_key": "value"}
+    result = extend_options(options)
+    assert result == {
+        "skipIfAlreadyFound": True,
+        "skipFromTitle": False,
+        "skipIfFirst": False,
+        "remove": False,
+        "extra_key": "value",
+    }

--- a/tests/test_ptt_parse.py
+++ b/tests/test_ptt_parse.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 nzbdav contributors
 
-import pytest
 from resources.lib.ptt.parse import extend_options
+
 
 def test_extend_options_empty():
     options = {}
@@ -13,7 +13,9 @@ def test_extend_options_empty():
         "skipIfFirst": False,
         "remove": False,
     }
+    # extend_options mutates the options dictionary and returns it
     assert result is options
+
 
 def test_extend_options_default_arg():
     result1 = extend_options()
@@ -27,6 +29,7 @@ def test_extend_options_default_arg():
         "skipIfFirst": False,
         "remove": False,
     }
+
 
 def test_extend_options_override_defaults():
     options = {
@@ -42,7 +45,9 @@ def test_extend_options_override_defaults():
         "skipIfFirst": True,
         "remove": True,
     }
+    # extend_options mutates the options dictionary and returns it
     assert result is options
+
 
 def test_extend_options_partial_override():
     options = {"remove": True}
@@ -53,6 +58,7 @@ def test_extend_options_partial_override():
         "skipIfFirst": False,
         "remove": True,
     }
+
 
 def test_extend_options_extra_keys():
     options = {"extra_key": "value"}


### PR DESCRIPTION
🎯 **What:** The `extend_options` function in `plugin.video.nzbdav/resources/lib/ptt/parse.py` lacked tests and used a mutable default argument (`{}`), which is a classic Python anti-pattern that can lead to unintended side effects across function calls.
📊 **Coverage:** A new test file `tests/test_ptt_parse.py` was created to cover:
  - Calling with an empty dictionary.
  - Calling without arguments, verifying the default options are applied, and explicitly checking that the default argument is not mutated.
  - Calling with partial and complete overrides of default options.
  - Calling with extra keys.
✨ **Result:** The mutable default argument was fixed by using `None` and initializing a new dictionary inside the function. The tests now pass and ensure the function behaves correctly under all tested scenarios, improving the reliability and coverage of the codebase.

---
*PR created automatically by Jules for task [17885270595234344128](https://jules.google.com/task/17885270595234344128) started by @xbmc4lyfe*