### PR TITLE
🎨 Palette: Add scrollbar to results dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ gha-creds-*.json
 
 # Extreme functional test reports
 docs/reports/
+venv/

--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -64,8 +64,9 @@
 
     <!-- Results list — 2 lines per item, 66px each -->
     <control type="list" id="50">
-      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <left>0</left><top>60</top><width>1910</width><height>975</height>
       <orientation>vertical</orientation>
+      <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
@@ -225,6 +226,18 @@
           <texture>white.png</texture><colordiffuse>FF18181C</colordiffuse>
         </control>
       </focusedlayout>
+    </control>
+
+    <!-- Scrollbar for the results list -->
+    <control type="scrollbar" id="60">
+      <left>1910</left><top>60</top><width>10</width><height>975</height>
+      <orientation>vertical</orientation>
+      <showonepage>false</showonepage>
+      <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
+      <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
+      <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>
+      <textureslidernib></textureslidernib>
+      <textureslidernibfocus></textureslidernibfocus>
     </control>
 
     <!-- Footer background -->

--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -70,9 +70,9 @@
       <scrolltime>200</scrolltime>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
-      <itemlayout width="1920" height="66">
+      <itemlayout width="1910" height="66">
         <control type="image">
-          <left>0</left><top>0</top><width>1920</width><height>66</height>
+          <left>0</left><top>0</top><width>1910</width><height>66</height>
           <texture>white.png</texture>
           <colordiffuse>FF0C0C10</colordiffuse>
         </control>
@@ -143,15 +143,15 @@
 
         <!-- Row separator -->
         <control type="image">
-          <left>0</left><top>65</top><width>1920</width><height>1</height>
+          <left>0</left><top>65</top><width>1910</width><height>1</height>
           <texture>white.png</texture><colordiffuse>FF18181C</colordiffuse>
         </control>
       </itemlayout>
 
       <!-- ==================== FOCUSED ROW ==================== -->
-      <focusedlayout width="1920" height="66">
+      <focusedlayout width="1910" height="66">
         <control type="image">
-          <left>0</left><top>0</top><width>1920</width><height>66</height>
+          <left>0</left><top>0</top><width>1910</width><height>66</height>
           <texture>white.png</texture>
           <colordiffuse>FF182538</colordiffuse>
         </control>
@@ -222,7 +222,7 @@
 
         <!-- Row separator -->
         <control type="image">
-          <left>0</left><top>65</top><width>1920</width><height>1</height>
+          <left>0</left><top>65</top><width>1910</width><height>1</height>
           <texture>white.png</texture><colordiffuse>FF18181C</colordiffuse>
         </control>
       </focusedlayout>

--- a/tests/test_results_dialog_skin.py
+++ b/tests/test_results_dialog_skin.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Structural assertions over the bundled results dialog skin XML."""
+
+import os
+import xml.etree.ElementTree as ET
+
+_DIALOG_XML_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "repo",
+    "plugin.video.nzbdav",
+    "resources",
+    "skins",
+    "Default",
+    "1080i",
+    "results-dialog.xml",
+)
+
+
+def _control(root, control_type, control_id):
+    for control in root.findall("./controls/control"):
+        if control.get("type") == control_type and control.get("id") == control_id:
+            return control
+    return None
+
+
+def test_results_dialog_scrollbar_is_linked_to_results_list():
+    root = ET.parse(_DIALOG_XML_PATH).getroot()
+
+    results_list = _control(root, "list", "50")
+    scrollbar = _control(root, "scrollbar", "60")
+
+    assert results_list is not None, "results list control id=50 missing"
+    assert scrollbar is not None, "results scrollbar control id=60 missing"
+    assert results_list.findtext("pagecontrol") == "60"
+    assert scrollbar.findtext("orientation") == "vertical"
+    assert scrollbar.findtext("showonepage") == "false"


### PR DESCRIPTION
💡 What: Added a vertical scrollbar to the search results dialog (`results-dialog.xml`) and linked it to the results list.
🎯 Why: The default Kodi list component can be difficult to navigate if it has many results without a visible scrollbar to indicate current position or total length. This improves navigability and usability, especially for large lists of results.
♿ Accessibility: Provides a clear visual indicator of scroll position and overall list length.

---
*PR created automatically by Jules for task [3834177054015742693](https://jules.google.com/task/3834177054015742693) started by @xbmc4lyfe*