### PR TITLE
Fix TMDBHelper DL picker tagging and layout

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/nzbdav_api.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzbdav_api.py
@@ -758,7 +758,7 @@ def completed_jobs_lookup_done(completed_jobs):
     return getattr(completed_jobs, "_lookup_done", False) is True
 
 
-def get_completed_jobs():
+def get_completed_jobs(settings_getter=None):
     """Fetch completed downloads from nzbdav history keyed by exact name.
 
     Returns:
@@ -766,13 +766,14 @@ def get_completed_jobs():
         mapping on any error or when no completed jobs exist.
 
     Side effects:
-        Reads nzbdav settings from Kodi via xbmcaddon.Addon("plugin.video.nzbdav").
+        Reads nzbdav settings from Kodi via xbmcaddon.Addon("plugin.video.nzbdav")
+        unless ``settings_getter`` is supplied.
         Performs an HTTP GET to nzbdav /api?mode=history on every call; avoid
         calling this in tight loops.
         Logs the number of names loaded at debug level.
     """
     try:
-        base_url, api_key = _get_settings()
+        base_url, api_key = _get_settings(settings_getter=settings_getter)
     except Exception as e:  # pylint: disable=broad-except
         xbmc.log(
             "NZB-DAV: Settings read failed in get_completed_jobs: {}".format(

--- a/repo/plugin.video.nzbdav/resources/lib/results_dialog.py
+++ b/repo/plugin.video.nzbdav/resources/lib/results_dialog.py
@@ -56,6 +56,10 @@ ACTION_CONTEXT_MENU = 117
 LIST_ID = 50
 
 
+def _available_text():
+    return _c(_AVAILABLE_LABEL, "FF22C55E")
+
+
 class ResultsDialog(xbmcgui.WindowXMLDialog):
     """Full-screen NZB results selection dialog."""
 
@@ -139,7 +143,7 @@ class ResultsDialog(xbmcgui.WindowXMLDialog):
 
             # Already downloaded indicator
             if result.get("_available"):
-                li.setProperty("available", _c(_AVAILABLE_LABEL, "FF00FF88"))
+                li.setProperty("available", _available_text())
 
             # Alternating row background
             li.setProperty("row_bg", _BG_A if i % 2 == 0 else _BG_B)

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -1484,9 +1484,9 @@ def _handle_script_play(params):
     )
     resolver_params["_fallback_candidate_loader"] = fallback_loader
     resolver_params["_settings_getter"] = _get_script_setting
-    completed_job = selected.get(
-        "_completed_job"
-    ) or _script_completed_job_for_selection(selected)
+    completed_job = selected.get("_completed_job")
+    if not completed_job and not _completed_lookup_was_done(completed_jobs):
+        completed_job = _script_completed_job_for_selection(selected)
     if completed_job:
         resolver_params["_completed_job"] = completed_job
     elif _completed_lookup_was_done(completed_jobs):

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -646,7 +646,7 @@ def _search_all_providers(
     return deduped, None
 
 
-def _tag_available(results):
+def _tag_available(results, settings_getter=None):
     """
     Mark result entries that already exist in nzbdav by setting the `_available` flag.
 
@@ -657,7 +657,7 @@ def _tag_available(results):
     """
     if not results:
         return {}
-    completed = get_completed_jobs()
+    completed = get_completed_jobs(settings_getter=settings_getter)
     if not completed:
         return completed
     for result in results:
@@ -1453,7 +1453,16 @@ def _handle_script_play(params):
         _script_play_stage("resolve returned")
         return
 
-    _script_play_stage("tag available skipped")
+    completed_jobs = None
+    try:
+        completed_jobs = _tag_available(filtered, settings_getter=_get_script_setting)
+        _script_play_stage("tag available done")
+    except Exception as error:  # pylint: disable=broad-except
+        xbmc.log(
+            "NZB-DAV: Script completed-history tagging failed: {}".format(error),
+            xbmc.LOGDEBUG,
+        )
+        _script_play_stage("tag available failed")
 
     from resources.lib.results_dialog import show_results_dialog
 
@@ -1474,14 +1483,14 @@ def _handle_script_play(params):
         selected, filtered, settings_getter=_get_script_setting
     )
     resolver_params["_fallback_candidate_loader"] = fallback_loader
-    resolver_params["_completed_job_lookup_done"] = True
     resolver_params["_settings_getter"] = _get_script_setting
     completed_job = selected.get(
         "_completed_job"
     ) or _script_completed_job_for_selection(selected)
     if completed_job:
-        resolver_params.pop("_completed_job_lookup_done", None)
         resolver_params["_completed_job"] = completed_job
+    elif _completed_lookup_was_done(completed_jobs):
+        resolver_params["_completed_job_lookup_done"] = True
     _attach_selected_indexer(resolver_params, selected)
     _script_play_stage("resolve start '{}'".format(selected.get("title", "")))
     resolve_and_play(selected["link"], selected["title"], params=resolver_params)

--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -78,12 +78,12 @@
 
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->
         <control type="label">
-          <left>6</left><top>4</top><width>20</width><height>30</height>
+          <left>6</left><top>4</top><width>32</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(available)]</label><aligny>center</aligny>
         </control>
         <control type="label">
-          <left>24</left><top>4</top><width>1146</width><height>30</height>
+          <left>40</left><top>4</top><width>1140</width><height>30</height>
           <font>font13</font><textcolor>FFD4D4D8</textcolor>
           <label>$INFO[ListItem.Label]</label><aligny>center</aligny>
         </control>
@@ -157,12 +157,12 @@
 
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->
         <control type="label">
-          <left>6</left><top>4</top><width>20</width><height>30</height>
+          <left>6</left><top>4</top><width>32</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(available)]</label><aligny>center</aligny>
         </control>
         <control type="label">
-          <left>24</left><top>4</top><width>1146</width><height>30</height>
+          <left>40</left><top>4</top><width>1140</width><height>30</height>
           <font>font13</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Label]</label><aligny>center</aligny>
         </control>

--- a/tests/test_nzbdav_api.py
+++ b/tests/test_nzbdav_api.py
@@ -757,6 +757,11 @@ def test_get_completed_jobs_marks_successful_empty_lookup(mock_http, mock_settin
 
     assert jobs == {}
     assert completed_jobs_lookup_done(jobs) is True
+    mock_http.assert_called_once()
+    history_url = mock_http.call_args.args[0]
+    assert history_url.startswith("http://nzbdav:3000/api?")
+    assert "mode=history" in history_url
+    assert "apikey=testkey" in history_url
 
 
 @patch("resources.lib.nzbdav_api._get_settings")

--- a/tests/test_nzbdav_api.py
+++ b/tests/test_nzbdav_api.py
@@ -729,6 +729,7 @@ def test_get_completed_jobs_returns_completed_job_map(mock_http, mock_settings):
 @patch("resources.lib.nzbdav_api._get_settings")
 @patch("resources.lib.nzbdav_api._http_get")
 def test_get_completed_jobs_uses_supplied_settings_getter(mock_http, mock_settings):
+    mock_settings.return_value = ("http://nzbdav:3000", "scriptkey")
     mock_http.return_value = json.dumps({"history": {"slots": []}})
 
     def settings_getter(key, default=""):
@@ -740,6 +741,10 @@ def test_get_completed_jobs_uses_supplied_settings_getter(mock_http, mock_settin
     get_completed_jobs(settings_getter=settings_getter)
 
     mock_settings.assert_called_once_with(settings_getter=settings_getter)
+    history_url = mock_http.call_args.args[0]
+    assert history_url.startswith("http://nzbdav:3000/api?")
+    assert "mode=history" in history_url
+    assert "apikey=scriptkey" in history_url
 
 
 @patch("resources.lib.nzbdav_api._get_settings")

--- a/tests/test_nzbdav_api.py
+++ b/tests/test_nzbdav_api.py
@@ -728,6 +728,22 @@ def test_get_completed_jobs_returns_completed_job_map(mock_http, mock_settings):
 
 @patch("resources.lib.nzbdav_api._get_settings")
 @patch("resources.lib.nzbdav_api._http_get")
+def test_get_completed_jobs_uses_supplied_settings_getter(mock_http, mock_settings):
+    mock_http.return_value = json.dumps({"history": {"slots": []}})
+
+    def settings_getter(key, default=""):
+        return {
+            "nzbdav_url": "http://nzbdav:3000",
+            "nzbdav_api_key": "scriptkey",
+        }.get(key, default)
+
+    get_completed_jobs(settings_getter=settings_getter)
+
+    mock_settings.assert_called_once_with(settings_getter=settings_getter)
+
+
+@patch("resources.lib.nzbdav_api._get_settings")
+@patch("resources.lib.nzbdav_api._http_get")
 def test_get_completed_jobs_marks_successful_empty_lookup(mock_http, mock_settings):
     mock_settings.return_value = ("http://nzbdav:3000", "testkey")
     mock_http.return_value = json.dumps({"history": {"slots": []}})

--- a/tests/test_results_dialog.py
+++ b/tests/test_results_dialog.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from resources.lib.results_dialog import (
     _AVAILABLE_LABEL,
+    _available_text,
     _format_date,
     _format_size,
     _lang_short,
@@ -35,6 +36,10 @@ def _make_result(**overrides):
 def test_available_label_is_ascii_for_skin_compatibility():
     assert _AVAILABLE_LABEL == "DL"
     assert _AVAILABLE_LABEL.isascii()
+
+
+def test_available_label_renders_green():
+    assert _available_text() == "[COLOR FF22C55E]DL[/COLOR]"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_results_dialog_layout.py
+++ b/tests/test_results_dialog_layout.py
@@ -10,6 +10,7 @@ import pytest
 
 _RESULTS_DIALOG_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "repo",
     "plugin.video.nzbdav",
     "resources",
     "skins",
@@ -19,8 +20,8 @@ _RESULTS_DIALOG_PATH = os.path.join(
 )
 
 
-@pytest.fixture(scope="module")
-def results_dialog_root():
+@pytest.fixture(name="results_dialog_root", scope="module")
+def _results_dialog_root():
     return ET.parse(_RESULTS_DIALOG_PATH).getroot()
 
 

--- a/tests/test_results_dialog_layout.py
+++ b/tests/test_results_dialog_layout.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Structural assertions over the custom results dialog skin."""
+
+import os
+import xml.etree.ElementTree as ET
+
+import pytest
+
+_RESULTS_DIALOG_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "plugin.video.nzbdav",
+    "resources",
+    "skins",
+    "Default",
+    "1080i",
+    "results-dialog.xml",
+)
+
+
+@pytest.fixture(scope="module")
+def results_dialog_root():
+    return ET.parse(_RESULTS_DIALOG_PATH).getroot()
+
+
+def _property_label_control(layout, property_name):
+    needle = "$INFO[ListItem.Property({})]".format(property_name)
+    for control in layout.findall("control"):
+        label = control.findtext("label")
+        if label == needle:
+            return control
+    raise AssertionError("missing property label {}".format(property_name))
+
+
+def _list_item_label_control(layout):
+    for control in layout.findall("control"):
+        if control.findtext("label") == "$INFO[ListItem.Label]":
+            return control
+    raise AssertionError("missing filename label")
+
+
+def test_results_dialog_has_no_temporary_debug_controls(results_dialog_root):
+    debug_band_colors = {
+        "FFFF00FF",
+        "FF2563EB",
+        "FFEF4444",
+        "FFF59E0B",
+        "FFA855F7",
+        "FF14B8A6",
+    }
+
+    for control in results_dialog_root.iter("control"):
+        assert control.findtext("label") != "LAYOUT DEBUG"
+        assert control.findtext("colordiffuse") not in debug_band_colors
+
+
+def test_results_dialog_dl_indicator_has_room_in_both_row_layouts(
+    results_dialog_root,
+):
+    list_control = results_dialog_root.find(".//control[@type='list'][@id='50']")
+    layouts = [
+        list_control.find("itemlayout"),
+        list_control.find("focusedlayout"),
+    ]
+
+    for layout in layouts:
+        available = _property_label_control(layout, "available")
+        filename = _list_item_label_control(layout)
+        age = _property_label_control(layout, "age")
+        indexer = _property_label_control(layout, "indexer")
+
+        assert int(available.findtext("width")) == 32
+        assert int(filename.findtext("left")) == 40
+        assert int(filename.findtext("width")) == 1140
+        assert int(age.findtext("left")) == 1320
+        assert int(age.findtext("width")) == 140
+        assert int(indexer.findtext("left")) == 1470
+        assert int(indexer.findtext("width")) == 200

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2055,6 +2055,56 @@ def test_handle_script_play_picker_fallback_loader_uses_script_settings_getter(
 @patch("resources.lib.filter.filter_results")
 @patch("resources.lib.router._search_all_providers")
 @patch("resources.lib.nzbdav_api.find_completed_by_name")
+@patch("resources.lib.router._tag_available")
+def test_handle_script_play_empty_completed_snapshot_skips_post_picker_history_lookup(
+    mock_tag,
+    mock_find_completed,
+    mock_search,
+    mock_filter,
+    mock_dialog,
+    mock_resolve_and_play,
+    mock_set_resolved,
+    mock_end,
+    mock_addon,
+):
+    from resources.lib.router import _handle_script_play
+
+    class SuccessfulCompletedJobs(dict):
+        _lookup_done = True
+
+    chosen = {"title": "Wuthering.Heights.2026.mkv", "link": "http://hydra/nzb/wh"}
+    mock_tag.return_value = SuccessfulCompletedJobs()
+    mock_find_completed.return_value = None
+    mock_search.return_value = ([chosen], None)
+    mock_filter.return_value = ([chosen], [chosen])
+    mock_dialog.return_value = chosen
+
+    _handle_script_play(
+        {
+            "type": "movie",
+            "title": "Wuthering Heights",
+            "year": "2026",
+            "tmdb_id": "1316092",
+        }
+    )
+
+    mock_find_completed.assert_not_called()
+    resolver_params = dict(mock_resolve_and_play.call_args.kwargs["params"])
+    assert resolver_params["_completed_job_lookup_done"] is True
+    assert "_completed_job" not in resolver_params
+    mock_addon.assert_not_called()
+    mock_end.assert_not_called()
+    mock_set_resolved.assert_not_called()
+
+
+@patch("xbmcaddon.Addon", side_effect=RuntimeError("Kodi settings unavailable"))
+@patch("xbmcplugin.endOfDirectory")
+@patch("xbmcplugin.setResolvedUrl")
+@patch("resources.lib.resolver.resolve_and_play")
+@patch("resources.lib.results_dialog.show_results_dialog")
+@patch("resources.lib.filter.filter_results")
+@patch("resources.lib.router._search_all_providers")
+@patch("resources.lib.nzbdav_api.find_completed_by_name")
 def test_handle_script_play_attaches_completed_job_for_selected_result(
     mock_find_completed,
     mock_search,

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1667,6 +1667,21 @@ def test_tag_available_attaches_completed_job_hint(mock_completed_jobs):
     assert "_completed_job" not in results[1]
 
 
+@patch("resources.lib.router.get_completed_jobs")
+def test_tag_available_uses_supplied_settings_getter(mock_completed_jobs):
+    def settings_getter(key, default=""):
+        return default
+
+    mock_completed_jobs.return_value = {}
+
+    _tag_available(
+        [{"title": "Matrix.1999.mkv", "link": "http://hydra/nzb/x"}],
+        settings_getter=settings_getter,
+    )
+
+    mock_completed_jobs.assert_called_once_with(settings_getter=settings_getter)
+
+
 @patch("xbmcaddon.Addon")
 @patch("xbmcplugin.setResolvedUrl")
 @patch("xbmcgui.ListItem")
@@ -1905,17 +1920,17 @@ def test_handle_script_play_uses_picker_without_plugin_handle_resolution(
     resolver_params = dict(kwargs["params"])
     assert callable(resolver_params.pop("_settings_getter"))
     assert callable(resolver_params.pop("_fallback_candidate_loader"))
+    _, tag_kwargs = mock_tag.call_args
+    assert tag_kwargs["settings_getter"] is not None
     assert resolver_params == {
         "type": "movie",
         "title": "The Odyssey",
         "year": "2026",
         "tmdb_id": "1368337",
         "_fallback_candidates": [],
-        "_completed_job_lookup_done": True,
         "_selected_indexer": "NZBFinder",
     }
     mock_addon.assert_not_called()
-    mock_tag.assert_not_called()
     mock_end.assert_not_called()
     mock_set_resolved.assert_not_called()
 


### PR DESCRIPTION
Summary:
- Pass script settings into completed-history lookup for TMDBHelper RunScript playback.
- Tag already-completed nzbdav results so the picker shows the DL marker.
- Preserve completed-history lookup hints only when the picker lookup actually succeeds.
- Adjust picker columns so DL, filename, age, and indexer render correctly.
- Add regression coverage for completed-history settings propagation and picker XML layout.

Testing:
- python3 -m ruff check plugin.video.nzbdav/ tests/ --exclude='plugin.video.nzbdav/resources/lib/ptt/'
- black --check plugin.video.nzbdav/ tests/ --exclude='plugin.video.nzbdav/resources/lib/ptt/'
- just test
- Built and validated the addon in a live Kodi/CoreELEC environment.