### PR TITLE
[HARD TO MERGE] Recover PR #117: optimize bookmark deletion query

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -275,8 +275,10 @@ def _clear_kodi_playback_state(params=None):
                 # files/settings/streamdetails rows stay intact — Kodi will
                 # treat the file as "never resumed" on the next play, which is
                 # exactly the state we want.
-                for id_file in target_ids:
-                    cur.execute("DELETE FROM bookmark WHERE idFile = ?", (id_file,))
+                cur.executemany(
+                    "DELETE FROM bookmark WHERE idFile = ?",
+                    [(id_file,) for id_file in target_ids],
+                )
 
         xbmc.log(
             "NZB-DAV: Cleared bookmark for {} file(s)".format(len(target_ids)),

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -733,6 +733,76 @@ def test_clear_kodi_playback_state_escapes_like_wildcards(mock_xbmc, tmp_path):
 
 
 @patch("resources.lib.resolver.xbmc")
+def test_clear_kodi_playback_state_deletes_bookmarks_with_executemany(
+    mock_xbmc, tmp_path
+):
+    import sqlite3
+
+    mock_xbmc.Player.return_value.isPlayingVideo.return_value = False
+    db = _build_fake_videos_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    cur = conn.cursor()
+    tmdb_base = "plugin://plugin.video.themoviedb.helper/?info=play"
+    for i in range(1, 4):
+        cur.execute(
+            "INSERT INTO files (idFile, idPath, strFilename) VALUES (?, 1, ?)",
+            (i, tmdb_base + "&tmdb_type=movie&tmdb_id=389"),
+        )
+        cur.execute(
+            "INSERT INTO bookmark (idFile, timeInSeconds) VALUES (?, 100.0)", (i,)
+        )
+    conn.commit()
+    conn.close()
+
+    execute_calls = []
+    executemany_calls = []
+
+    class TrackingCursor(sqlite3.Cursor):
+        def execute(self, sql, parameters=()):
+            if sql == "DELETE FROM bookmark WHERE idFile = ?":
+                execute_calls.append((sql, parameters))
+            return super().execute(sql, parameters)
+
+        def executemany(self, sql, seq_of_parameters):
+            params = list(seq_of_parameters)
+            if sql == "DELETE FROM bookmark WHERE idFile = ?":
+                executemany_calls.append((sql, params))
+            return super().executemany(sql, params)
+
+    class TrackingConnection(
+        sqlite3.Connection
+    ):  # pylint: disable=too-few-public-methods
+        def cursor(self, *args, **kwargs):
+            kwargs["factory"] = TrackingCursor
+            return super().cursor(*args, **kwargs)
+
+    real_connect = sqlite3.connect
+
+    def connect_tracking(path, *args, **kwargs):
+        kwargs["factory"] = TrackingConnection
+        return real_connect(path, *args, **kwargs)
+
+    with patch("sqlite3.connect", side_effect=connect_tracking):
+        with patch("resources.lib.resolver.xbmcvfs") as mock_vfs:
+            mock_vfs.translatePath.return_value = str(tmp_path) + "/"
+            _clear_kodi_playback_state({"tmdb_id": "389", "type": "movie"})
+
+    assert not execute_calls
+    assert executemany_calls == [
+        (
+            "DELETE FROM bookmark WHERE idFile = ?",
+            [(1,), (2,), (3,)],
+        )
+    ]
+
+    conn = sqlite3.connect(str(db))
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM bookmark")
+    assert cur.fetchone()[0] == 0
+    conn.close()
+
+
+@patch("resources.lib.resolver.xbmc")
 def test_clear_kodi_playback_state_handles_db_busy(mock_xbmc, tmp_path):
     """A sqlite3.OperationalError (DB locked) must be caught, not propagated."""
     import sqlite3


### PR DESCRIPTION
Recovery for original PR #117: https://github.com/Appz4Fun/nzbdavkodi/pull/117

What I did
- Rebuilt the intended bookmark-delete optimization on top of current main.
- Replaced the per-id `cursor.execute(...)` loop in `_clear_kodi_playback_state()` with one `cursor.executemany(...)` call.
- Added a regression test proving matching bookmarks are still deleted and the delete path uses `executemany()` rather than repeated `execute()` calls.

Why this was hard to merge into main
- The original PR branch history was polluted with unrelated fallback, release, workflow, and repo-layout changes.
- Its raw file list did not represent the stated change; replaying the branch would remove or rewrite unrelated current-main work.
- Current main had moved far beyond the original branch, so this had to be reconstructed from the PR body and current resolver code.

Validation
- `python3 -m pytest tests/test_resolver.py::test_clear_kodi_playback_state_deletes_bookmarks_with_executemany tests/test_resolver.py::test_clear_kodi_playback_state_deletes_tmdb_helper_url tests/test_resolver.py::test_clear_kodi_playback_state_deletes_own_plugin_url -q`
- `just lint`
- `just test` (1412 passed, 4 skipped, 13 deselected)
