### PR TITLE
🎨 Palette: Improve text contrast in search results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/results_dialog.py
+++ b/repo/plugin.video.nzbdav/resources/lib/results_dialog.py
@@ -106,7 +106,7 @@ class ResultsDialog(xbmcgui.WindowXMLDialog):
             if hdr_list:
                 li.setProperty("hdr", _c(" ".join(hdr_list), "FFFBBF24"))
             else:
-                li.setProperty("hdr", _c("SDR", "FF333333"))
+                li.setProperty("hdr", _c("SDR", "FF6B7280"))
 
             # Codec
             codec = meta.get("codec", "")

--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -34,7 +34,7 @@
       <left>20</left><top>34</top><width>600</width><height>20</height>
       <label>NZB-DAV · NZBHydra2</label>
       <font>font10</font>
-      <textcolor>FF666666</textcolor>
+      <textcolor>FF9CA3AF</textcolor>
     </control>
 
     <!-- Header: Source count -->
@@ -51,7 +51,7 @@
       <left>1400</left><top>34</top><width>500</width><height>20</height>
       <label>$INFO[Window.Property(sort_info)]</label>
       <font>font10</font>
-      <textcolor>FF555555</textcolor>
+      <textcolor>FF9CA3AF</textcolor>
       <align>right</align>
     </control>
 
@@ -244,7 +244,7 @@
       <left>20</left><top>1040</top><width>800</width><height>30</height>
       <label>$INFO[Window.Property(filter_info)]</label>
       <font>font10</font>
-      <textcolor>FF4A5568</textcolor>
+      <textcolor>FF9CA3AF</textcolor>
       <aligny>center</aligny>
     </control>
 
@@ -253,7 +253,7 @@
       <left>800</left><top>1040</top><width>1100</width><height>30</height>
       <label>[Enter] Download &amp; Play     [Esc] Back</label>
       <font>font10</font>
-      <textcolor>FF4A5568</textcolor>
+      <textcolor>FF9CA3AF</textcolor>
       <align>right</align>
       <aligny>center</aligny>
     </control>


### PR DESCRIPTION
💡 What: Increased the luminance of secondary text elements in the Kodi results dialog (e.g. from `#333333` and `#4A5568` to `#6B7280` and `#9CA3AF`).
🎯 Why: Dark gray text on a dark background (`#0C0C10` or `#141417`) has extremely poor contrast (around ~1.5:1), making it very hard to read on TV screens. This improves readability of subtitles, sort hints, filter text, and the "SDR" badge.
♿ Accessibility: Improves color contrast ratio to meet basic legibility standards.

---
*PR created automatically by Jules for task [14001647232175244247](https://jules.google.com/task/14001647232175244247) started by @xbmc4lyfe*