### PR TITLE
[HARD TO MERGE] Recover PR #109: bump CodeQL action to 4.35.5

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -41,7 +41,7 @@ jobs:
           -f sarif -o bandit.sarif --exit-zero
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           sarif_file: bandit.sarif
         if: always()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,12 +35,12 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -70,7 +70,7 @@ jobs:
           PY
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           sarif_file: semgrep.sarif
         if: always()


### PR DESCRIPTION
Replacement for closed/unmerged PR #109:

- Original PR: https://github.com/Appz4Fun/nzbdavkodi/pull/109
- Original branch: `dependabot/github_actions/github/codeql-action-4.35.5`
- Original intent: bump `github/codeql-action` from 4.35.3 to 4.35.5

What I did:

- Rebuilt the dependency update on current `main`.
- Updated the four current workflow uses of `github/codeql-action` to the original Dependabot target commit `9e0d7b8d25671d64c341c19c0152d693099fb5ba`.
- Left unrelated workflow pins and newer workflow structure untouched.

Why the original PR is hard to merge:

- The old Dependabot branch is based on stale workflow history and includes a huge amount of unrelated repository churn in its raw patch context.
- Current `main` now pins actions by commit SHA, so simply reopening the old branch would not be a clean one-dependency update.
- The original patch crossed multiple workflow generations; only the current CodeQL action references were safe to carry forward.

Validation:

- Verified the current workflow pins point at `9e0d7b8d25671d64c341c19c0152d693099fb5ba`.
- `just lint` -> passed
- `just test` -> 1412 passed, 4 skipped, 13 deselected
