### PR TITLE
[HARD TO MERGE] Recover PR #105: automatic indexer caps refresh

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/direct_indexers.py
+++ b/repo/plugin.video.nzbdav/resources/lib/direct_indexers.py
@@ -3,7 +3,9 @@
 
 """Direct Newznab-compatible indexer provider."""
 
+import threading
 from concurrent.futures import ThreadPoolExecutor, wait
+from datetime import datetime, timedelta, timezone
 from urllib.error import URLError
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 from xml.etree import ElementTree as ET
@@ -29,8 +31,8 @@ from resources.lib.http_util import (
 from resources.lib.http_util import (
     redact_url as _redact_url,
 )
-from resources.lib.indexer_store import load_indexers
-from resources.lib.newznab_caps import normalize_api_endpoint
+from resources.lib.indexer_store import load_indexers, save_indexers
+from resources.lib.newznab_caps import fetch_caps, normalize_api_endpoint
 from resources.lib.search_planner import plan_newznab_search
 
 PRESET_INDEXERS = (
@@ -54,6 +56,8 @@ _DIRECT_REQUEST_ERRORS = (
 )
 _DIRECT_FANOUT_MAX_WORKERS = 4
 _DIRECT_FANOUT_TIMEOUT = 20
+_CAPS_TTL = timedelta(hours=24)
+_CAPS_REFRESH_LOCK = threading.Lock()
 
 
 def _setting_enabled(addon, setting_id):
@@ -121,13 +125,16 @@ def _configured_json_indexer(item):
     ):
         return None
     indexer_id = item.get("id") or item.get("preset_id")
-    return {
+    configured = {
         "id": indexer_id,
         "label": item.get("name") or indexer_id,
         "api_url": item["api_url"],
         "api_key": item["api_key"],
         "caps": item.get("caps", {}),
     }
+    if "checked_at" in item:
+        configured["checked_at"] = item.get("checked_at", "")
+    return configured
 
 
 def get_legacy_configured_indexers(addon=None):
@@ -316,6 +323,94 @@ def _indexer_timeout_error(indexer, timeout_seconds):
     )
 
 
+def _utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _format_caps_checked_at(moment):
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_caps_checked_at(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return None
+
+
+def _caps_are_stale(indexer, now=None):
+    caps = indexer.get("caps", {})
+    search_types = caps.get("search_types") if isinstance(caps, dict) else None
+    if not search_types:
+        return True
+    checked_at = _parse_caps_checked_at(indexer.get("checked_at", ""))
+    if checked_at is None:
+        return True
+    current = _parse_caps_checked_at(now) if isinstance(now, str) else now
+    current = current or _utcnow()
+    return current - checked_at >= _CAPS_TTL
+
+
+def _stored_indexer_from_runtime(indexer):
+    indexer_id = indexer.get("id", "")
+    return {
+        "id": indexer_id,
+        "preset_id": indexer_id,
+        "name": indexer.get("label", "") or indexer_id,
+        "api_url": indexer.get("api_url", ""),
+        "api_key": indexer.get("api_key", ""),
+        "enabled": True,
+        "caps": indexer.get("caps", {}),
+        "checked_at": indexer.get("checked_at", ""),
+    }
+
+
+def _persist_refreshed_caps(indexer):
+    with _CAPS_REFRESH_LOCK:
+        stored = load_indexers()
+        matched = False
+        updated = []
+        target_id = str(indexer.get("id", "") or "").strip()
+        for item in stored:
+            item_id = str(item.get("id") or item.get("preset_id") or "").strip()
+            if item_id == target_id:
+                updated.append(_stored_indexer_from_runtime(indexer))
+                matched = True
+            else:
+                updated.append(item)
+        if not matched:
+            updated.append(_stored_indexer_from_runtime(indexer))
+        save_indexers(updated)
+
+
+def _refresh_indexer_caps(indexer):
+    caps, error = fetch_caps(indexer["api_url"], indexer["api_key"], timeout=15)
+    if error:
+        return indexer, error
+    updated = dict(indexer)
+    updated["caps"] = caps
+    updated["checked_at"] = _format_caps_checked_at(_utcnow())
+    _persist_refreshed_caps(updated)
+    return updated, None
+
+
+def _maybe_refresh_caps(indexer):
+    if not _caps_are_stale(indexer):
+        return indexer
+    updated, error = _refresh_indexer_caps(indexer)
+    if error:
+        xbmc.log(
+            "NZB-DAV: Direct indexer {} caps refresh failed: {}".format(
+                indexer["label"], _redact_text(error)
+            ),
+            xbmc.LOGWARNING,
+        )
+        return indexer
+    return updated
+
+
 def _worker_count(total_count):
     return max(1, min(total_count, _DIRECT_FANOUT_MAX_WORKERS))
 
@@ -380,6 +475,7 @@ def _fetch_indexer(indexer, params, error_prefix):
 def _search_one_indexer(
     indexer, search_type, title, max_results, year="", imdb="", season="", episode=""
 ):
+    indexer = _maybe_refresh_caps(indexer)
     plan = plan_newznab_search(
         provider_kind="direct",
         host=indexer["api_url"],
@@ -463,15 +559,10 @@ def search_direct_indexers(search_type, title, year="", imdb="", season="", epis
 
 
 def _check_one_indexer_caps(indexer):
-    params = {"apikey": indexer["api_key"], "t": "caps", "o": "xml"}
-    url = build_search_url(indexer["api_url"], params)
-    try:
-        response = _http_get(url, timeout=15)
-        if "<caps" in response or "<server" in response or "<rss" in response:
-            return True, None
-        return False, "Direct indexer {} unexpected response".format(indexer["label"])
-    except _DIRECT_REQUEST_ERRORS as error:
-        return False, _indexer_unavailable_error(indexer, error)
+    _updated, error = _refresh_indexer_caps(indexer)
+    if error:
+        return False, _indexer_unavailable_error(indexer, RuntimeError(error))
+    return True, None
 
 
 def test_configured_indexers():

--- a/repo/plugin.video.nzbdav/resources/lib/indexer_store.py
+++ b/repo/plugin.video.nzbdav/resources/lib/indexer_store.py
@@ -89,6 +89,8 @@ def normalize_indexer(item):
         "enabled": enabled,
         "caps": normalize_caps(item.get("caps")),
     }
+    if "checked_at" in item:
+        normalized["checked_at"] = _text(item.get("checked_at"))
     if item.get("deleted"):
         normalized["deleted"] = True
     return normalized

--- a/tests/test_direct_indexers.py
+++ b/tests/test_direct_indexers.py
@@ -4,6 +4,19 @@
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _caps_fetch_fails_closed_by_default(monkeypatch):
+    from resources.lib import direct_indexers
+
+    monkeypatch.setattr(
+        direct_indexers,
+        "fetch_caps",
+        lambda *_args, **_kwargs: ({}, "caps unavailable"),
+    )
+
 
 def _addon_with_settings(values):
     addon = MagicMock()
@@ -325,6 +338,188 @@ ONE_RESULT_RSS = """<?xml version="1.0" encoding="UTF-8"?>
 </item>
 </channel>
 </rss>"""
+
+CAPS_MOVIE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+<searching>
+<search available="yes" supportedParams="q" />
+<movie-search available="yes" supportedParams="q,imdbid" />
+</searching>
+</caps>"""
+
+
+def test_caps_are_stale_when_missing_empty_or_expired():
+    from resources.lib.direct_indexers import _caps_are_stale
+
+    fresh = "2026-05-17T12:00:00Z"
+    now = "2026-05-17T13:00:00Z"
+
+    assert _caps_are_stale({}, now=now)
+    assert _caps_are_stale({"caps": {}}, now=now)
+    assert _caps_are_stale(
+        {
+            "caps": {"search_types": [], "supported_params": {}, "categories": []},
+            "checked_at": fresh,
+        },
+        now=now,
+    )
+    assert _caps_are_stale(
+        {
+            "caps": {"search_types": ["movie"]},
+            "checked_at": "2026-05-16T11:59:59Z",
+        },
+        now=now,
+    )
+    assert not _caps_are_stale(
+        {"caps": {"search_types": ["movie"]}, "checked_at": fresh},
+        now=now,
+    )
+
+
+@patch("resources.lib.direct_indexers.load_indexers")
+@patch("resources.lib.direct_indexers.save_indexers")
+@patch("resources.lib.direct_indexers.get_configured_indexers")
+@patch("resources.lib.direct_indexers.xbmcaddon")
+@patch("resources.lib.direct_indexers._http_get")
+@patch("resources.lib.direct_indexers.fetch_caps")
+def test_search_direct_indexers_refreshes_stale_caps_and_saves(
+    mock_fetch_caps,
+    mock_http,
+    mock_xbmcaddon,
+    mock_configured,
+    mock_save_indexers,
+    mock_load_indexers,
+):
+    from resources.lib.direct_indexers import search_direct_indexers
+
+    refreshed_caps = {
+        "search_types": ["movie", "search"],
+        "supported_params": {"movie": ["imdbid"], "search": ["q"]},
+        "categories": [],
+    }
+    mock_fetch_caps.return_value = (refreshed_caps, None)
+    mock_configured.return_value = [
+        {
+            "id": "nzbgeek",
+            "label": "NZBGeek",
+            "api_url": "https://api.nzbgeek.info/api",
+            "api_key": "geek-key",
+            "caps": {},
+        }
+    ]
+    mock_load_indexers.return_value = []
+    mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
+    mock_http.return_value = ONE_RESULT_RSS
+
+    results, error = search_direct_indexers(
+        "movie", "The Matrix", year="1999", imdb="tt0133093"
+    )
+
+    assert error is None
+    assert len(results) == 1
+    call_url = mock_http.call_args[0][0]
+    assert "t=movie" in call_url
+    assert "imdbid=0133093" in call_url
+    assert "q=The+Matrix" not in call_url
+    mock_fetch_caps.assert_called_once_with(
+        "https://api.nzbgeek.info/api", "geek-key", timeout=15
+    )
+    saved = mock_save_indexers.call_args[0][0]
+    assert saved[0]["id"] == "nzbgeek"
+    assert saved[0]["name"] == "NZBGeek"
+    assert saved[0]["api_url"] == "https://api.nzbgeek.info/api"
+    assert saved[0]["api_key"] == "geek-key"
+    assert saved[0]["enabled"] is True
+    assert saved[0]["caps"] == refreshed_caps
+    assert saved[0]["checked_at"].endswith("Z")
+
+
+@patch("resources.lib.direct_indexers.load_indexers")
+@patch("resources.lib.direct_indexers.save_indexers")
+@patch("resources.lib.direct_indexers.get_configured_indexers")
+@patch("resources.lib.direct_indexers.xbmcaddon")
+@patch("resources.lib.direct_indexers._http_get")
+@patch("resources.lib.direct_indexers.fetch_caps")
+def test_search_direct_indexers_falls_back_when_caps_refresh_fails(
+    mock_fetch_caps,
+    mock_http,
+    mock_xbmcaddon,
+    mock_configured,
+    mock_save_indexers,
+    mock_load_indexers,
+):
+    from resources.lib.direct_indexers import search_direct_indexers
+
+    mock_fetch_caps.return_value = ({}, "caps down")
+    mock_configured.return_value = [
+        {
+            "id": "nzbgeek",
+            "label": "NZBGeek",
+            "api_url": "https://api.nzbgeek.info/api",
+            "api_key": "geek-key",
+            "caps": {},
+        }
+    ]
+    mock_load_indexers.return_value = []
+    mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
+    mock_http.return_value = ONE_RESULT_RSS
+
+    results, error = search_direct_indexers(
+        "movie", "The Matrix", year="1999", imdb="tt0133093"
+    )
+
+    assert error is None
+    assert len(results) == 1
+    call_url = mock_http.call_args[0][0]
+    assert "t=movie" in call_url
+    assert "imdbid=0133093" in call_url
+    mock_save_indexers.assert_not_called()
+
+
+@patch("resources.lib.direct_indexers.load_indexers")
+@patch("resources.lib.direct_indexers.save_indexers")
+@patch("resources.lib.direct_indexers.fetch_caps")
+def test_check_one_indexer_caps_fetches_and_persists_caps(
+    mock_fetch_caps, mock_save_indexers, mock_load_indexers
+):
+    from resources.lib.direct_indexers import _check_one_indexer_caps
+
+    refreshed_caps = {"search_types": ["search"], "supported_params": {"search": ["q"]}}
+    mock_fetch_caps.return_value = (refreshed_caps, None)
+    mock_load_indexers.return_value = [
+        {
+            "id": "custom1",
+            "name": "Old Name",
+            "api_url": "https://old.example/api",
+            "api_key": "old-key",
+            "enabled": True,
+            "caps": {},
+        }
+    ]
+
+    ok, error = _check_one_indexer_caps(
+        {
+            "id": "custom1",
+            "label": "Custom",
+            "api_url": "https://custom.example/api",
+            "api_key": "custom-key",
+            "caps": {},
+        }
+    )
+
+    assert ok is True
+    assert error is None
+    mock_fetch_caps.assert_called_once_with(
+        "https://custom.example/api", "custom-key", timeout=15
+    )
+    saved = mock_save_indexers.call_args[0][0]
+    assert saved[0]["id"] == "custom1"
+    assert saved[0]["name"] == "Custom"
+    assert saved[0]["api_url"] == "https://custom.example/api"
+    assert saved[0]["api_key"] == "custom-key"
+    assert saved[0]["enabled"] is True
+    assert saved[0]["caps"] == refreshed_caps
+    assert saved[0]["checked_at"].endswith("Z")
 
 
 @patch("resources.lib.direct_indexers.get_configured_indexers")
@@ -680,9 +875,9 @@ def test_search_direct_indexers_all_failures_return_error(
 
 
 @patch("resources.lib.direct_indexers.get_configured_indexers")
-@patch("resources.lib.direct_indexers._http_get")
+@patch("resources.lib.direct_indexers.fetch_caps")
 def test_test_configured_indexers_marks_incomplete_futures_timed_out(
-    mock_http, mock_configured
+    mock_fetch_caps, mock_configured
 ):
     from resources.lib.direct_indexers import test_configured_indexers
 
@@ -697,9 +892,9 @@ def test_test_configured_indexers_marks_incomplete_futures_timed_out(
 
     def slow_caps(*_args, **_kwargs):
         time.sleep(0.2)
-        return "<caps></caps>"
+        return ({"search_types": ["search"]}, None)
 
-    mock_http.side_effect = slow_caps
+    mock_fetch_caps.side_effect = slow_caps
 
     with patch(
         "resources.lib.direct_indexers._DIRECT_FANOUT_TIMEOUT", 0.05, create=True
@@ -717,8 +912,8 @@ def test_test_configured_indexers_marks_incomplete_futures_timed_out(
 
 
 @patch("resources.lib.direct_indexers.get_configured_indexers")
-@patch("resources.lib.direct_indexers._http_get")
-def test_test_configured_indexers_counts_caps_success(mock_http, mock_configured):
+@patch("resources.lib.direct_indexers.fetch_caps")
+def test_test_configured_indexers_counts_caps_success(mock_fetch_caps, mock_configured):
     from resources.lib.direct_indexers import test_configured_indexers
 
     mock_configured.return_value = [
@@ -735,7 +930,10 @@ def test_test_configured_indexers_counts_caps_success(mock_http, mock_configured
             "api_key": "two",
         },
     ]
-    mock_http.side_effect = ["<caps></caps>", RuntimeError("down")]
+    mock_fetch_caps.side_effect = [
+        ({"search_types": ["search"]}, None),
+        ({}, "down"),
+    ]
 
     ok_count, total_count, errors = test_configured_indexers()
 

--- a/tests/test_indexer_store.py
+++ b/tests/test_indexer_store.py
@@ -147,6 +147,7 @@ def test_save_and_load_indexers_round_trip(tmp_path):
                 "api_key": "secret",
                 "enabled": True,
                 "caps": {"search_types": ["movie"]},
+                "checked_at": "2026-05-17T12:34:56Z",
             }
         ],
         str(path),
@@ -156,6 +157,7 @@ def test_save_and_load_indexers_round_trip(tmp_path):
     assert loaded[0]["id"] == "nzbgeek"
     assert loaded[0]["enabled"] is True
     assert loaded[0]["caps"]["search_types"] == ["movie"]
+    assert loaded[0]["checked_at"] == "2026-05-17T12:34:56Z"
 
 
 def test_save_and_load_indexers_preserves_deleted_marker(tmp_path):


### PR DESCRIPTION
Replacement for closed/unmerged PR #105:

- Original PR: https://github.com/Appz4Fun/nzbdavkodi/pull/105
- Original branch: `ralph/indexer-caps-auto-fetch`

What I did:

- Rebuilt the automatic direct-indexer caps refresh behavior on current `main`.
- Added `checked_at` preservation for managed indexers so caps freshness survives JSON save/load.
- Added a 24-hour stale-caps check for direct indexers.
- Refreshes stale/missing caps with `fetch_caps()` before search planning, then persists refreshed caps under a lock.
- Keeps the existing conservative search fallback when caps refresh fails.
- Updates the manual direct-indexer test action to fetch and persist parsed caps instead of only checking for a raw caps response.
- Added focused regression coverage for stale detection, successful refresh persistence, refresh failure fallback, and manual test persistence.

Why the original PR is hard to merge:

- The old branch has a very large stale diff that touches generated release zips, docs, workflows, and repository metadata in addition to the intended runtime change.
- Current `main` already moved direct-indexer parsing and manager behavior forward, so replaying the branch would overwrite newer layout and tests.
- The useful part was runtime behavior in `direct_indexers.py` plus `checked_at` storage, so this PR reconstructs that behavior without carrying unrelated branch history.

Validation:

- Red test run before implementation: 6 failed for the reconstructed #105 regression nodes.
- `python3 -m pytest tests/test_direct_indexers.py tests/test_indexer_store.py tests/test_indexer_manager.py tests/test_webdav.py::test_find_video_file_overlaps_first_sibling_probe_for_post_picker_start -q` -> 80 passed
- `just lint` -> passed
- `just test` -> 1416 passed, 4 skipped, 13 deselected

Note:

- An earlier full-suite run hit one unrelated WebDAV timing assertion. The touched code is only direct-indexer/storage code; rerunning that WebDAV node passed, and the final full suite also passed.
