### PR TITLE
🎨 Palette: Enable alternating row colors in results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -74,7 +74,7 @@
         <control type="image">
           <left>0</left><top>0</top><width>1910</width><height>66</height>
           <texture>white.png</texture>
-          <colordiffuse>FF0C0C10</colordiffuse>
+          <colordiffuse>$INFO[ListItem.Property(row_bg)]</colordiffuse>
         </control>
 
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->


### PR DESCRIPTION
🎨 Palette: Enable alternating row colors in results list

💡 What: Updated the `colordiffuse` value for unfocused list items in `results-dialog.xml` to consume the `row_bg` property dynamically provided by the Python backend.
🎯 Why: Makes the results list much easier to scan visually, as adjacent rows can sometimes blur together when searching for a specific resolution or codec. The backend already provided `row_bg` for alternating stripes (`_BG_A` / `_BG_B`), but the XML view hardcoded a single dark color, bypassing the backend logic.
♿ Accessibility: Increases readability by breaking up a dense list of search results with alternating row colors.

---
*PR created automatically by Jules for task [393778038066727177](https://jules.google.com/task/393778038066727177) started by @xbmc4lyfe*