### PR TITLE
🎨 Palette: Add keyboard navigation between list and scrollbar

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -67,6 +67,8 @@
       <left>0</left><top>60</top><width>1910</width><height>975</height>
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
+      <onleft>60</onleft>
+      <onright>60</onright>
       <scrolltime>200</scrolltime>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
@@ -232,6 +234,8 @@
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
+      <onleft>50</onleft>
+      <onright>50</onright>
       <showonepage>false</showonepage>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>

--- a/tests/test_results_dialog_skin.py
+++ b/tests/test_results_dialog_skin.py
@@ -36,3 +36,9 @@ def test_results_dialog_scrollbar_is_linked_to_results_list():
     assert results_list.findtext("pagecontrol") == "60"
     assert scrollbar.findtext("orientation") == "vertical"
     assert scrollbar.findtext("showonepage") == "false"
+
+    # Verify directional remote/keyboard navigation is mapped correctly
+    assert results_list.findtext("onleft") == "60"
+    assert results_list.findtext("onright") == "60"
+    assert scrollbar.findtext("onleft") == "50"
+    assert scrollbar.findtext("onright") == "50"


### PR DESCRIPTION
Added bidirectional explicit `onleft` and `onright` navigation tags to the search results list (id=50) and its associated scrollbar (id=60) inside `results-dialog.xml`. This change ensures that users can jump between the list and scrollbar using keyboard arrows or remote D-pads, greatly improving screen navigation accessibility.
Also added test coverage to verify that these directional navigation paths are maintained.

---
*PR created automatically by Jules for task [1875866599820595271](https://jules.google.com/task/1875866599820595271) started by @xbmc4lyfe*