### PR TITLE
🎨 Palette: Explicit directional navigation tags in Kodi UI

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -65,6 +65,10 @@
     <!-- Results list — 2 lines per item, 66px each -->
     <control type="list" id="50">
       <left>0</left><top>60</top><width>1910</width><height>975</height>
+      <onleft>60</onleft>
+      <onright>60</onright>
+      <onup>50</onup>
+      <ondown>50</ondown>
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
@@ -231,6 +235,10 @@
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>
+      <onleft>50</onleft>
+      <onright>50</onright>
+      <onup>60</onup>
+      <ondown>60</ondown>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>


### PR DESCRIPTION
Added `<onleft>`, `<onright>`, `<onup>`, and `<ondown>` tags to the main list and scrollbar controls in `results-dialog.xml` to enable proper keyboard and remote control accessibility between these two adjacent interactive elements. Kodi doesn't automatically infer navigation between custom controls.

---
*PR created automatically by Jules for task [9965187989885424733](https://jules.google.com/task/9965187989885424733) started by @xbmc4lyfe*