### PR TITLE
⚡ Bolt: Pre-compile regular expressions in filter.py

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/filter.py
+++ b/repo/plugin.video.nzbdav/resources/lib/filter.py
@@ -4,6 +4,7 @@
 """Result filtering and sorting using PTT for title parsing."""
 
 import math
+import re
 from types import SimpleNamespace
 
 import xbmc
@@ -731,10 +732,35 @@ def _sort_results(results, settings):
         return sorted(results, key=_relevance_key)
 
 
+# Pre-compiled regular expressions for _fallback_parse to improve performance
+_RES_RE = re.compile(r"(?i)\b(2160p|1080p|1080i|720p|480p|4K)\b")
+_CODEC_RE = re.compile(r"(?i)\b(x265|h\.?265|hevc|x264|h\.?264|avc|av1|vp9)\b")
+_ATMOS_RE = re.compile(r"(?i)\batmos\b")
+_TRUEHD_RE = re.compile(r"(?i)\btruehd\b")
+_DTSHD_RE = re.compile(r"(?i)\bdts[-. ]?hd[-. ]?ma\b")
+_DDP_RE = re.compile(r"(?i)\bddp?5[. ]1|eac3|dd\+|dolby.digital.plus\b")
+_DD_RE = re.compile(r"(?i)\bac3|dd[. ]?5[. ]1|dolby.digital\b")
+_AAC_RE = re.compile(r"(?i)\baac\b")
+_DTS_RE = re.compile(r"(?i)\bdts\b")
+_DV_RE = re.compile(r"(?i)\b(dv|dovi|dolby[. ]?vision)\b")
+_HDR10PLUS_RE = re.compile(r"(?i)\b(hdr10\+|hdr10plus)\b")
+_HDR10_RE = re.compile(r"(?i)\bhdr10\b")
+_HLG_RE = re.compile(r"(?i)\bhlg\b")
+_QUALITY_RE = re.compile(
+    r"(?i)\b(remux|blu[-. ]?ray|bdrip|web[-. ]?dl|webrip|hdtv|dvdrip|hdrip)\b"
+)
+_ED_RE = re.compile(
+    r"(?i)\b(uncut|unrated|director'?s[. ]?cut|extended[. ]?cut"
+    r"|recut|theatrical|imax|special[. ]?edition)\b"
+)
+_CHANNELS_RE = re.compile(r"\b(7\.1|5\.1|2\.0)\b")
+_YEAR_RE = re.compile(r"[. (](\d{4})[. )]")
+_UPSCALED_RE = re.compile(r"(?i)\bupscale[d]?\b")
+_GROUP_RE = re.compile(r"-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\.[a-z]{2,4})?$")
+
+
 def _fallback_parse(title):
     """Simple regex fallback when PTT fails or returns empty."""
-    import re
-
     result = {
         "resolution": "",
         "codec": "",
@@ -752,52 +778,50 @@ def _fallback_parse(title):
     t = title.replace("[", ".").replace("]", ".").replace("(", ".").replace(")", ".")
 
     # Resolution
-    m = re.search(r"(?i)\b(2160p|1080p|1080i|720p|480p|4K)\b", t)
+    m = _RES_RE.search(t)
     if m:
         result["resolution"] = m.group(1)
 
     # Codec
-    m = re.search(r"(?i)\b(x265|h\.?265|hevc|x264|h\.?264|avc|av1|vp9)\b", t)
+    m = _CODEC_RE.search(t)
     if m:
         result["codec"] = m.group(1).lower()
 
     # Audio
     audio = []
-    if re.search(r"(?i)\batmos\b", t):
+    if _ATMOS_RE.search(t):
         audio.append("Atmos")
-    if re.search(r"(?i)\btruehd\b", t):
+    if _TRUEHD_RE.search(t):
         audio.append("TrueHD")
-    if re.search(r"(?i)\bdts[-. ]?hd[-. ]?ma\b", t):
+    if _DTSHD_RE.search(t):
         audio.append("DTS-HD MA")
-    if re.search(r"(?i)\bddp?5[. ]1|eac3|dd\+|dolby.digital.plus\b", t):
+    if _DDP_RE.search(t):
         audio.append("DD+")
-    if re.search(r"(?i)\bac3|dd[. ]?5[. ]1|dolby.digital\b", t):
+    if _DD_RE.search(t):
         audio.append("DD")
-    if re.search(r"(?i)\baac\b", t):
+    if _AAC_RE.search(t):
         audio.append("AAC")
-    if re.search(r"(?i)\bdts\b", t) and not audio:
+    if _DTS_RE.search(t) and not audio:
         audio.append("DTS")
     result["audio"] = audio
 
     # HDR
     hdr = []
-    if re.search(r"(?i)\b(dv|dovi|dolby[. ]?vision)\b", t):
+    if _DV_RE.search(t):
         hdr.append("DV")
     # HDR10+ alternation needs both branches anchored to a leading word
     # boundary so we don't pick up substrings inside another token.
-    if re.search(r"(?i)\b(hdr10\+|hdr10plus)\b", t):
+    if _HDR10PLUS_RE.search(t):
         hdr.append("HDR10+")
     # `hdr10` without the optional `0` would match `hdr1`; require the digit.
-    elif re.search(r"(?i)\bhdr10\b", t):
+    elif _HDR10_RE.search(t):
         hdr.append("HDR10")
-    if re.search(r"(?i)\bhlg\b", t):
+    if _HLG_RE.search(t):
         hdr.append("HLG")
     result["hdr"] = hdr
 
     # Quality / Source
-    m = re.search(
-        r"(?i)\b(remux|blu[-. ]?ray|bdrip|web[-. ]?dl|webrip|hdtv|dvdrip|hdrip)\b", t
-    )
+    m = _QUALITY_RE.search(t)
     if m:
         raw_q = m.group(1).upper().replace(" ", "").replace(".", "").replace("-", "")
         if "REMUX" in raw_q:
@@ -814,16 +838,12 @@ def _fallback_parse(title):
             result["quality"] = raw_q
 
     # Edition
-    _ed_re = (
-        r"(?i)\b(uncut|unrated|director'?s[. ]?cut|extended[. ]?cut"
-        r"|recut|theatrical|imax|special[. ]?edition)\b"
-    )
-    m = re.search(_ed_re, t)
+    m = _ED_RE.search(t)
     if m:
         result["edition"] = m.group(1).replace(".", " ")
 
     # Channels
-    m = re.search(r"\b(7\.1|5\.1|2\.0)\b", t)
+    m = _CHANNELS_RE.search(t)
     if m:
         result["channels"] = m.group(1)
 
@@ -832,19 +852,19 @@ def _fallback_parse(title):
     # time we forget to bump it (TODO.md §H.2-M44 was the previous
     # bump — 2030 turned out to be too tight). 2100 is well past any
     # plausible release window for content this addon would index.
-    m = re.search(r"[. (](\d{4})[. )]", t)
+    m = _YEAR_RE.search(t)
     if m:
         yr = int(m.group(1))
         if 1920 <= yr <= 2100:
             result["year"] = yr
 
     # Upscaled
-    if re.search(r"(?i)\bupscale[d]?\b", t):
+    if _UPSCALED_RE.search(t):
         result["upscaled"] = True
 
     # Group (last segment after hyphen). Scene groups can contain hyphens and
     # underscores, e.g. GROUP-NAME or GROUP_NAME.
-    m = re.search(r"-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\.[a-z]{2,4})?$", title)
+    m = _GROUP_RE.search(title)
     if m:
         result["group"] = m.group(1)
 


### PR DESCRIPTION
⚡ What: Pre-compile regular expressions used in `_fallback_parse` to module level.
🎯 Why: `_fallback_parse` uses many inline regexes. Calling `re.search` repeatedly with a string pattern requires caching or recompiling overhead on every call. Pre-compiling to module-level constants significantly speeds up this often-called function.
📊 Impact: Reduced parsing overhead inside `_fallback_parse` for performance.
🔬 Measurement: Verified functionality stays exactly the same via the test suite and parsing behaves correctly.

---
*PR created automatically by Jules for task [11435679617310198518](https://jules.google.com/task/11435679617310198518) started by @xbmc4lyfe*