### PR TITLE
🎨 Palette: Add explicit directional navigation to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,8 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onleft>60</onleft>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +235,8 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onleft>50</onleft>
+      <onright>50</onright>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
💡 **What:** Added `<onleft>` and `<onright>` tags to the main list and scrollbar in `results-dialog.xml`.
🎯 **Why:** Kodi custom interfaces do not automatically infer horizontal navigation paths. Users relying on a keyboard or remote control were unable to move focus to the scrollbar to navigate large lists quickly.
♿ **Accessibility:** This directly improves keyboard/remote control navigation and usability.
📸 **Before/After:** No visual change, strictly an interaction fix.

---
*PR created automatically by Jules for task [12254246880809246934](https://jules.google.com/task/12254246880809246934) started by @xbmc4lyfe*