### PR TITLE
🎨 Palette: Add explicit keyboard navigation between list and scrollbar

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,10 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onup>50</onup>
+      <ondown>50</ondown>
+      <onleft>50</onleft>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +237,10 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onup>60</onup>
+      <ondown>60</ondown>
+      <onleft>50</onleft>
+      <onright>60</onright>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
💡 What: Added explicit directional `<onup>`, `<ondown>`, `<onleft>`, and `<onright>` tags to the `results-dialog.xml` skin file.
🎯 Why: In Kodi XML skin files, directional navigation paths must be manually mapped for adjacent UI controls. Without explicit map coordinates to other interactable control IDs, users with remote controls and keyboards get stuck; in this file, they couldn't traverse left and right between the main results list and its scrollbar. Adding mappings directly prevents focus from skipping, skipping, or jumping improperly and traps navigation properly within the context bounds.
♿ Accessibility: The keyboard mappings directly enable proper focus, screen navigation, and boundaries without needing a mouse to access UI scrollbar elements in the result dialog screen.

I also added an entry on the importance of directional tags in `.Jules/palette.md` for our continued Palette journal.

---
*PR created automatically by Jules for task [17060121723262366439](https://jules.google.com/task/17060121723262366439) started by @xbmc4lyfe*