### PR TITLE
Separate release and Pages metadata publishing

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,7 +54,13 @@ jobs:
 
       - name: Select latest stable addon release
         id: stable_release
-        run: python3 scripts/select_stable_release.py releases.json >> "$GITHUB_OUTPUT"
+        run: |
+          selected_tag="${{ github.event.workflow_run.head_branch || '' }}"
+          if [[ "$selected_tag" == v* ]]; then
+            python3 scripts/select_stable_release.py releases.json --tag "$selected_tag" >> "$GITHUB_OUTPUT"
+          else
+            python3 scripts/select_stable_release.py releases.json >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download selected addon release
         env:
@@ -81,7 +87,6 @@ jobs:
           python3 scripts/generate_repo.py \
             --output-dir pages-dist \
             --addon-zip release-addon.zip \
-            --release-asset-url "${{ steps.stable_release.outputs.download_url }}" \
             --smoke-check
 
       - name: Upload Pages artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,8 +54,10 @@ jobs:
 
       - name: Select latest stable addon release
         id: stable_release
+        env:
+          WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || '' }}
         run: |
-          selected_tag="${{ github.event.workflow_run.head_branch || '' }}"
+          selected_tag="$WORKFLOW_HEAD_BRANCH"
           if [[ "$selected_tag" == v* ]]; then
             python3 scripts/select_stable_release.py releases.json --tag "$selected_tag" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Build addon zip
         run: python3 scripts/build_zip.py
 
-      - name: Generate repository metadata
-        run: python3 scripts/generate_repo.py
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:

--- a/README.md
+++ b/README.md
@@ -339,11 +339,13 @@ repo/plugin.video.nzbdav/
 scripts/
   build_zip.py           # Addon zip builder
   generate_repo.py       # Kodi repo metadata generator
+  select_stable_release.py  # Pages workflow release selector
 repo/
   repository.nzbdav/     # Repository addon descriptor pointing to Pages metadata
 .github/workflows/
   ci.yml                 # Test + lint on push/PR (Python 3.10/3.12)
-  release.yml            # Build + deploy on version tags
+  release.yml            # Build GitHub Releases on version tags
+  pages.yml              # Publish Kodi repository metadata to GitHub Pages
   pylint.yml             # Pylint analysis (Python 3.8 to validate runtime compat)
   codeql.yml             # CodeQL analysis
   bandit.yml             # Bandit security scan
@@ -363,7 +365,7 @@ TODO.md                             # Active backlog
 4. Commit: `git commit -m "release: v0.X.0"`
 5. Tag and push: `git tag v0.X.0 && git push origin main v0.X.0`
 6. GitHub Actions builds the zip and creates a GitHub Release.
-7. The Pages workflow republishes the latest stable release into Kodi repository metadata.
+7. The Pages workflow republishes the tagged stable release into Kodi repository metadata.
 8. Kodi picks up the update automatically from the GitHub Pages repository.
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,6 @@ Only two areas are active right now:
 
 - Add a local Python 3.10 + 3.12 test matrix, or document why CI-only is enough.
 - Add a true Python 3.8 import/runtime check, or keep relying on `.pylintrc` `py-version=3.8`.
-- Add a build/repo smoke target for Pages parity without making `just ci` too noisy.
 
 ## Future Bug-Hunt Seeds
 

--- a/scripts/generate_repo.py
+++ b/scripts/generate_repo.py
@@ -46,13 +46,6 @@ def _strip_repo_metadata_news(root):
                 metadata.remove(news)
 
 
-def _github_release_asset_url(addon_id, version):
-    zip_name = "{}-{}.zip".format(addon_id, version)
-    return "https://github.com/Appz4Fun/nzbdavkodi/releases/download/v{}/{}".format(
-        version, zip_name
-    )
-
-
 def _addon_zip_relative_path(addon_id, version):
     zip_name = "{}-{}.zip".format(addon_id, version)
     return "{}/{}".format(addon_id, zip_name)
@@ -271,19 +264,9 @@ def _build_repository_zip(output_dir, repository_addon_dir):
 def generate_repo(
     output_dir="pages-dist",
     addon_zip=None,
-    release_asset_url=None,
     repository_addon_dir="repo/repository.nzbdav",
 ):
-    """Generate Pages metadata.
-
-    release_asset_url is deprecated and ignored; addon zips are copied into
-    the repository datadir and referenced by repository-relative paths.
-    """
-    if release_asset_url:
-        print(
-            "generate_repo: release_asset_url is deprecated and ignored",
-            file=sys.stderr,
-        )
+    """Generate Pages metadata."""
 
     if not os.path.isdir(repository_addon_dir):
         raise SystemExit(
@@ -473,11 +456,6 @@ def main(argv=None):
         "--addon-zip", default=None, help="Use this addon release zip for metadata"
     )
     parser.add_argument(
-        "--release-asset-url",
-        default=None,
-        help="Deprecated/no-op; addon zips are copied into the Pages datadir",
-    )
-    parser.add_argument(
         "--repository-addon-dir",
         default="repo/repository.nzbdav",
         help="Repository addon directory to include and package",
@@ -491,7 +469,6 @@ def main(argv=None):
     generate_repo(
         output_dir=args.output_dir,
         addon_zip=args.addon_zip,
-        release_asset_url=args.release_asset_url,
         repository_addon_dir=args.repository_addon_dir,
     )
     if args.smoke_check:

--- a/scripts/select_stable_release.py
+++ b/scripts/select_stable_release.py
@@ -124,7 +124,7 @@ def _validated_release(release, tag):
     }, None
 
 
-def select_stable_release(releases):
+def select_stable_release(releases, requested_tag=None):
     """Return tagName, assetName, and downloadUrl for the highest stable release."""
     stable = []
     releases = _flatten_paginated_releases(releases)
@@ -136,6 +136,22 @@ def select_stable_release(releases):
         if key is None:
             continue
         stable.append((key, release, tag))
+
+    if requested_tag:
+        if _stable_semver_key(requested_tag) is None:
+            raise SystemExit(
+                "Requested release {} is not a stable semver release".format(
+                    requested_tag
+                )
+            )
+        for _key, release, tag in stable:
+            if tag != requested_tag:
+                continue
+            selected, error = _validated_release(release, tag)
+            if selected:
+                return selected
+            raise SystemExit(error)
+        raise SystemExit("Requested release {} was not found".format(requested_tag))
 
     if not stable:
         raise SystemExit("No stable {} release found".format(ADDON_ID))
@@ -159,12 +175,17 @@ def main(argv=None):
         description="Select the latest stable plugin.video.nzbdav release asset."
     )
     parser.add_argument("releases_json", help="Path to gh release JSON output")
+    parser.add_argument(
+        "--tag",
+        default=None,
+        help="Select this exact stable release tag instead of the highest stable tag",
+    )
     args = parser.parse_args(argv)
 
     with open(args.releases_json, "r", encoding="utf-8") as fh:
         releases = json.load(fh)
 
-    selected = select_stable_release(releases)
+    selected = select_stable_release(releases, requested_tag=args.tag)
     print("tag={}".format(selected["tagName"]))
     print("asset_name={}".format(selected["assetName"]))
     print("download_url={}".format(selected["downloadUrl"]))

--- a/tests/test_generate_repo.py
+++ b/tests/test_generate_repo.py
@@ -135,10 +135,13 @@ def test_generate_repo_without_addon_zip_omits_missing_plugin_metadata(
     tmp_path, monkeypatch
 ):
     module = _load_generate_repo_module()
-    monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.chdir(tmp_path)
 
     output_dir = tmp_path / "pages"
-    module.generate_repo(output_dir=str(output_dir))
+    module.generate_repo(
+        output_dir=str(output_dir),
+        repository_addon_dir=str(REPO_ADDON_DIR),
+    )
 
     tree = _parse_generated_addons_xml(output_dir)
     assert tree.find("./addon[@id='plugin.video.nzbdav']") is None
@@ -313,44 +316,6 @@ def test_generate_repo_can_publish_release_zip_instead_of_worktree_addon(
     assert checksum_path.read_text(encoding="ascii") == "{}  {}".format(
         expected, "plugin.video.nzbdav-1.0.3.zip"
     )
-
-
-def test_generate_repo_uses_kodi_relative_addon_path_with_explicit_release_asset_url(
-    tmp_path, monkeypatch, capsys
-):
-    module = _load_generate_repo_module()
-    monkeypatch.chdir(REPO_ROOT)
-    release_zip = tmp_path / "plugin.video.nzbdav-1.0.3.zip"
-    release_addon_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nzbdav" name="NZB-DAV" version="1.0.3" />
-"""
-    with zipfile.ZipFile(release_zip, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("plugin.video.nzbdav/addon.xml", release_addon_xml)
-
-    output_dir = tmp_path / "pages"
-    release_asset_url = (
-        "https://github.com/Appz4Fun/nzbdavkodi/releases/download/"
-        "1.0.3/plugin.video.nzbdav-1.0.3.zip"
-    )
-    module.generate_repo(
-        output_dir=str(output_dir),
-        addon_zip=str(release_zip),
-        release_asset_url=release_asset_url,
-    )
-    captured = capsys.readouterr()
-
-    tree = _parse_generated_addons_xml(output_dir)
-    addon = tree.find("./addon[@id='plugin.video.nzbdav']")
-    assert addon is not None
-    metadata = addon.find("./extension[@point='xbmc.addon.metadata']")
-    assert metadata is not None
-    assert metadata.findtext("path") == (
-        "plugin.video.nzbdav/plugin.video.nzbdav-1.0.3.zip"
-    )
-    assert (
-        output_dir / "plugin.video.nzbdav" / "plugin.video.nzbdav-1.0.3.zip"
-    ).read_bytes() == release_zip.read_bytes()
-    assert "release_asset_url is deprecated and ignored" in captured.err
 
 
 def test_generate_repo_writes_release_path_to_all_metadata_extensions(

--- a/tests/test_justfile.py
+++ b/tests/test_justfile.py
@@ -132,18 +132,31 @@ def test_pages_workflow_deploys_repository_metadata_on_main_push():
         'gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/releases?per_page=100"'
         in contents
     )
-    assert "python3 scripts/select_stable_release.py releases.json" in contents
+    assert "selected_tag=" in contents
+    assert "github.event.workflow_run.head_branch" in contents
+    assert (
+        'python3 scripts/select_stable_release.py releases.json --tag "$selected_tag"'
+        in contents
+    )
     assert "--clobber" in contents
     assert "rm -rf pages-dist" in contents
     assert "--output-dir pages-dist" in contents
     assert "--addon-zip release-addon.zip" in contents
-    assert (
-        '--release-asset-url "${{ steps.stable_release.outputs.download_url }}"'
-        in contents
-    )
+    assert "--release-asset-url" not in contents
     assert "--smoke-check" in contents
     assert "--repository-addon-dir" not in contents
     assert "scripts/generate_repo.py" in contents
+
+
+def test_release_workflow_does_not_generate_unpublished_repository_metadata():
+    root = Path(__file__).resolve().parents[1]
+    contents = (root / ".github" / "workflows" / "release.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Create GitHub Release" in contents
+    assert "Generate repository metadata" not in contents
+    assert "scripts/generate_repo.py" not in contents
 
 
 def test_extreme_functional_test_recipe_preserves_exported_env_overrides():

--- a/tests/test_justfile.py
+++ b/tests/test_justfile.py
@@ -134,6 +134,9 @@ def test_pages_workflow_deploys_repository_metadata_on_main_push():
     )
     assert "selected_tag=" in contents
     assert "github.event.workflow_run.head_branch" in contents
+    assert "WORKFLOW_HEAD_BRANCH:" in contents
+    assert 'selected_tag="$WORKFLOW_HEAD_BRANCH"' in contents
+    assert 'selected_tag="${{ github.event.workflow_run.head_branch' not in contents
     assert (
         'python3 scripts/select_stable_release.py releases.json --tag "$selected_tag"'
         in contents

--- a/tests/test_select_stable_release.py
+++ b/tests/test_select_stable_release.py
@@ -150,6 +150,45 @@ def test_tolerates_github_snake_case_release_fields():
     assert selected["tagName"] == "v1.0.0"
 
 
+def test_selects_requested_stable_release_tag_instead_of_highest():
+    module = _load_select_stable_release_module()
+    releases = [
+        _release("v1.0.0"),
+        _release("v2.0.0"),
+    ]
+
+    selected = module.select_stable_release(releases, requested_tag="v1.0.0")
+
+    assert selected == {
+        "tagName": "v1.0.0",
+        "assetName": "plugin.video.nzbdav-1.0.0.zip",
+        "downloadUrl": "https://example.test/v1.0.0.zip",
+    }
+
+
+def test_requested_release_tag_must_be_stable():
+    module = _load_select_stable_release_module()
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.select_stable_release(
+            [_release("v1.0.0-beta.1")],
+            requested_tag="v1.0.0-beta.1",
+        )
+
+    assert str(excinfo.value) == (
+        "Requested release v1.0.0-beta.1 is not a stable semver release"
+    )
+
+
+def test_requested_release_tag_must_exist():
+    module = _load_select_stable_release_module()
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.select_stable_release([_release("v1.0.0")], requested_tag="v2.0.0")
+
+    assert str(excinfo.value) == "Requested release v2.0.0 was not found"
+
+
 def test_rejects_asset_name_that_does_not_match_release_tag():
     module = _load_select_stable_release_module()
     assets = [
@@ -255,4 +294,22 @@ def test_main_accepts_slurped_paginated_release_pages(tmp_path, capsys):
         "tag=v1.2.0\n"
         "asset_name=plugin.video.nzbdav-1.2.0.zip\n"
         "download_url=https://example.test/v1.2.0.zip\n"
+    )
+
+
+def test_main_accepts_requested_tag(tmp_path, capsys):
+    module = _load_select_stable_release_module()
+    releases_path = tmp_path / "releases.json"
+    releases_path.write_text(
+        json.dumps([_release("v1.0.0"), _release("v1.2.0")]),
+        encoding="utf-8",
+    )
+
+    exit_code = module.main([str(releases_path), "--tag", "v1.0.0"])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == (
+        "tag=v1.0.0\n"
+        "asset_name=plugin.video.nzbdav-1.0.0.zip\n"
+        "download_url=https://example.test/v1.0.0.zip\n"
     )


### PR DESCRIPTION
## Summary
- keep the tag release workflow focused on building the addon zip and creating the GitHub Release
- move Kodi repository metadata publishing fully into the Pages workflow
- let the Pages workflow republish the exact tagged stable release when triggered from a `v*` release branch/tag context
- remove the deprecated `--release-asset-url` path from `generate_repo.py` now that Pages metadata uses copied repository-relative zip paths
- update tests and docs around the release selector, workflow responsibilities, and removed deprecated option

## Why
The previous flow blurred two separate jobs: creating a release asset and publishing Kodi repository metadata. That made it easier for Pages publishing to select the wrong “latest stable” release during tag-driven runs, or to carry along obsolete release-asset URL plumbing even though repository metadata now points at files copied into the Pages datadir.

This branch makes the handoff deterministic: release tags publish the GitHub Release asset, and the Pages workflow consumes the intended stable tag when available. For non-tag-triggered Pages runs, it still falls back to the highest stable addon release.

## Notable Changes
- `.github/workflows/release.yml`: removes repository metadata generation from the release job.
- `.github/workflows/pages.yml`: detects a `v*` workflow-run branch/tag and passes it to `select_stable_release.py --tag`; also stops passing the removed `--release-asset-url` option.
- `scripts/select_stable_release.py`: adds exact stable tag selection with validation for prerelease, missing tag, and missing/mismatched asset cases.
- `scripts/generate_repo.py`: removes the deprecated release asset URL option and warning path.
- Tests: add coverage for exact tag selection and workflow expectations; remove coverage for the deprecated URL option.
- Docs: update README release workflow descriptions and drop the completed TODO item.

## Verification
- `just lint`
- `just test` -> 1495 passed, 5 skipped, 13 deselected
