### PR TITLE
Skip Pages deploys for prerelease tags

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,6 +58,13 @@ jobs:
           WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || '' }}
         run: |
           selected_tag="$WORKFLOW_HEAD_BRANCH"
+          stable_tag_re='^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ "$selected_tag" == v* && ! "$selected_tag" =~ $stable_tag_re ]]; then
+            echo "skip_deploy=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping Pages deploy for non-stable release tag: $selected_tag"
+            exit 0
+          fi
+          echo "skip_deploy=false" >> "$GITHUB_OUTPUT"
           if [[ "$selected_tag" == v* ]]; then
             python3 scripts/select_stable_release.py releases.json --tag "$selected_tag" >> "$GITHUB_OUTPUT"
           else
@@ -65,6 +72,7 @@ jobs:
           fi
 
       - name: Download selected addon release
+        if: ${{ steps.stable_release.outputs.skip_deploy != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -84,6 +92,7 @@ jobs:
           done
 
       - name: Generate Pages repository
+        if: ${{ steps.stable_release.outputs.skip_deploy != 'true' }}
         run: |
           rm -rf pages-dist
           python3 scripts/generate_repo.py \
@@ -92,10 +101,12 @@ jobs:
             --smoke-check
 
       - name: Upload Pages artifact
+        if: ${{ steps.stable_release.outputs.skip_deploy != 'true' }}
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./pages-dist
 
       - name: Deploy to GitHub Pages
+        if: ${{ steps.stable_release.outputs.skip_deploy != 'true' }}
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,6 +58,7 @@ jobs:
           WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || '' }}
         run: |
           selected_tag="$WORKFLOW_HEAD_BRANCH"
+          # Keep in sync with _STABLE_SEMVER_RE in scripts/select_stable_release.py.
           stable_tag_re='^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ "$selected_tag" == v* && ! "$selected_tag" =~ $stable_tag_re ]]; then
             echo "skip_deploy=true" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ TODO.md                             # Active backlog
 7. The Pages workflow republishes the tagged stable release into Kodi repository metadata.
 8. Kodi picks up the update automatically from the GitHub Pages repository.
 
-Prerelease tags such as `v0.X.0-beta.1` may create GitHub Release artifacts, but
+Prerelease tags such as `v1.2.3-beta.1` may create GitHub Release artifacts, but
 the Pages workflow skips publishing them to the public Kodi repository.
 
 ---

--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ TODO.md                             # Active backlog
 7. The Pages workflow republishes the tagged stable release into Kodi repository metadata.
 8. Kodi picks up the update automatically from the GitHub Pages repository.
 
+Prerelease tags such as `v0.X.0-beta.1` may create GitHub Release artifacts, but
+the Pages workflow skips publishing them to the public Kodi repository.
+
 ---
 
 ## Compatibility

--- a/tests/test_justfile.py
+++ b/tests/test_justfile.py
@@ -151,6 +151,28 @@ def test_pages_workflow_deploys_repository_metadata_on_main_push():
     assert "scripts/generate_repo.py" in contents
 
 
+def test_pages_workflow_skips_prerelease_release_runs_without_deploying():
+    root = Path(__file__).resolve().parents[1]
+    contents = (root / ".github" / "workflows" / "pages.yml").read_text(
+        encoding="utf-8"
+    )
+    skip_guard = "if: ${{ steps.stable_release.outputs.skip_deploy != 'true' }}"
+
+    def assert_step_has_skip_guard(step_name):
+        pattern = (r"- name: {}\n" r"(?:        [^\n]*\n)*?" r"        {}\n").format(
+            re.escape(step_name), re.escape(skip_guard)
+        )
+        assert re.search(pattern, contents) is not None
+
+    assert "skip_deploy=true" in contents
+    assert "Skipping Pages deploy for non-stable release tag" in contents
+    assert "skip_deploy=false" in contents
+    assert_step_has_skip_guard("Download selected addon release")
+    assert_step_has_skip_guard("Generate Pages repository")
+    assert_step_has_skip_guard("Upload Pages artifact")
+    assert_step_has_skip_guard("Deploy to GitHub Pages")
+
+
 def test_release_workflow_does_not_generate_unpublished_repository_metadata():
     root = Path(__file__).resolve().parents[1]
     contents = (root / ".github" / "workflows" / "release.yml").read_text(


### PR DESCRIPTION
## Summary

This stacked PR prevents prerelease GitHub Release runs from publishing to the public Kodi repository on GitHub Pages.

It builds on `cleanup/pages-release-publishing`, which moved Kodi repository generation into the Pages workflow and added exact stable-tag selection for release-triggered Pages runs.

## What changed

- Adds a stable semver guard in `.github/workflows/pages.yml` before selecting/downloading the addon release.
- Treats workflow-run tags like `v1.2.3-beta.1` as non-stable release tags and exits the selection step with `skip_deploy=true`.
- Skips all deploy-producing Pages steps when `skip_deploy=true`:
  - `Download selected addon release`
  - `Generate Pages repository`
  - `Upload Pages artifact`
  - `Deploy to GitHub Pages`
- Keeps stable releases publishing normally, including tags such as `v1.2.3` and stable semver tags with build metadata such as `v1.2.3+build.4`.
- Documents the release behavior in `README.md`.
- Adds workflow regression coverage in `tests/test_justfile.py` so the skip output and deploy-step guards do not get dropped accidentally.

## Why

Prerelease tags may still be useful for building and attaching GitHub Release artifacts, but they should not update the Kodi repository metadata that installed users receive through GitHub Pages. Without this guard, a prerelease Release workflow completion could trigger Pages and make prerelease metadata public to Kodi clients.

## Notes for Review

This PR is intentionally stacked on `cleanup/pages-release-publishing`, not `main`.

The conflict from rebasing onto the updated base branch was resolved by preserving the base branch's shell hardening: `github.event.workflow_run.head_branch` is passed through `WORKFLOW_HEAD_BRANCH` in `env`, and the prerelease check now evaluates `selected_tag="$WORKFLOW_HEAD_BRANCH"`.

## Verification

- `python -m pytest tests/test_justfile.py tests/test_select_stable_release.py -q`
  - `39 passed in 0.39s`
- `just test`
  - `1496 passed, 5 skipped, 13 deselected in 52.36s`
- `just lint`
  - `ruff` passed
  - `black --check` passed
  - `pylint` rated `10.00/10`
