### PR TITLE
🎨 Palette: Add keyboard navigation to results dialog scrollbar

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,7 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +234,7 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onleft>50</onleft>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
💡 **What:** Added `<onright>60</onright>` to the main list control and `<onleft>50</onleft>` to the scrollbar control in `results-dialog.xml`.
🎯 **Why:** Kodi's skinning engine does not automatically infer directional navigation paths between custom UI controls. Previously, users navigating with a keyboard or a standard TV remote control (D-pad) could not reach the scrollbar to scroll faster through large lists. Explicitly linking the controls solves this accessibility issue.
♿ **Accessibility:** Improves keyboard and remote control navigation accessibility.

---
*PR created automatically by Jules for task [7198460061828919545](https://jules.google.com/task/7198460061828919545) started by @xbmc4lyfe*