### PR TITLE
🎨 Palette: Add explicit directional navigation between list and scrollbar

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,8 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onleft>60</onleft>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -232,6 +234,8 @@
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
+      <onleft>50</onleft>
+      <onright>50</onright>
       <showonepage>false</showonepage>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>


### PR DESCRIPTION
💡 What: Added explicit directional navigation tags `<onleft>` and `<onright>` between the main results list (ID 50) and its scrollbar (ID 60) in the Kodi XML skin file.
🎯 Why: Kodi does not automatically infer horizontal navigation paths between custom UI elements. Without these tags, keyboard and remote users were unable to focus the scrollbar to navigate long lists efficiently.
♿ Accessibility: Ensures that keyboard and remote control users can fully interact with the results dialog's scrollbar.

---
*PR created automatically by Jules for task [16425557892881985082](https://jules.google.com/task/16425557892881985082) started by @xbmc4lyfe*