### PR TITLE
perf: add timing telemetry

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -21,6 +21,7 @@ from xml.etree import ElementTree as ET
 import xbmc
 import xbmcaddon
 
+from resources.lib import telemetry
 from resources.lib.nzb_manifest import fetch_nzb_video_manifest, make_empty_manifest
 
 
@@ -1082,10 +1083,26 @@ def _pool_has_distinct_nzb_links(results):
 
 def _ensure_fallback_manifests(results):
     """Fetch missing NZB manifests for fallback grouping."""
+    started = time.monotonic()
     manifest_cache = {}
+    input_count = 0
     for result in results:
+        input_count += 1
         _ensure_fallback_manifest(result, manifest_cache)
+    telemetry.log_timing(
+        "fallback_manifests",
+        (time.monotonic() - started) * 1000.0,
+        input=input_count,
+        fetched=len(manifest_cache),
+    )
     return manifest_cache
+
+
+def _safe_len(value):
+    try:
+        return len(value)
+    except TypeError:
+        return "unknown"
 
 
 def _ensure_fallback_manifest(result, manifest_cache):
@@ -1539,14 +1556,23 @@ def attach_fallback_candidates_for_selection(selected, results, fallback_setting
             seen_prefetch_links.add(candidate_link)
             yield candidate
 
+    started = time.monotonic()
+    selected_manifest_fetch = not selected_manifest_ready
     _attach_selection_candidates_streaming(
         selected,
         _prefetch_candidates(),
         candidates,
         seen_candidate_links,
         seen_article_digests,
-        include_selected_manifest=not selected_manifest_ready,
+        include_selected_manifest=selected_manifest_fetch,
         max_candidates=max_candidates,
+    )
+    telemetry.log_timing(
+        "fallback_selection_manifests",
+        (time.monotonic() - started) * 1000.0,
+        attached=len(candidates),
+        pool=_safe_len(results or []),
+        selected_manifest_fetch=selected_manifest_fetch,
     )
     selected["_fallback_candidates"] = candidates
     return selected

--- a/repo/plugin.video.nzbdav/resources/lib/filter.py
+++ b/repo/plugin.video.nzbdav/resources/lib/filter.py
@@ -5,11 +5,14 @@
 
 import math
 import re
+import time
 from types import SimpleNamespace
 
 import xbmc
 import xbmcaddon
 import xbmcgui
+
+from resources.lib import telemetry
 
 # ---------------------------------------------------------------------------
 # Known release groups — master list for multiselect dialogs
@@ -598,6 +601,7 @@ def filter_results(results, settings_getter=None):
     ``filtered`` is the subset that passed every filter, truncated
     to ``settings["max_results"]`` if that is non-zero.
     """
+    started = time.monotonic()
     settings = _get_filter_settings(settings_getter=settings_getter)
 
     all_parsed = []
@@ -626,6 +630,13 @@ def filter_results(results, settings_getter=None):
             len(all_parsed), len(filtered)
         )
     xbmc.log(message, xbmc.LOGDEBUG)
+    telemetry.log_timing(
+        "filter_results",
+        (time.monotonic() - started) * 1000.0,
+        input=len(all_parsed),
+        matched=matched_count,
+        shown=len(filtered),
+    )
     return filtered, all_parsed
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -7,6 +7,7 @@
 import base64
 import os
 import re
+import time
 from itertools import chain
 from urllib import request as urllib_request
 from urllib.parse import parse_qs, unquote, urlencode, urlparse, urlsplit, urlunsplit
@@ -17,6 +18,7 @@ import xbmcaddon
 import xbmcgui
 import xbmcplugin
 
+from resources.lib import telemetry
 from resources.lib.fallback_streams import (
     FALLBACK_CANDIDATES_DISABLED,
     attach_fallback_candidates_for_selection,
@@ -562,20 +564,36 @@ def _search_all_providers(
         from resources.lib.hydra import search_hydra
 
         _script_play_stage("hydra search start")
-        hydra_results, hydra_error = search_hydra(
-            search_type,
-            title,
-            year=year,
-            imdb=imdb,
-            season=season,
-            episode=episode,
-            settings_getter=settings_getter,
-        )
-        _script_play_stage(
-            "hydra search done count={} error={}".format(
-                len(hydra_results or []), bool(hydra_error)
+        provider_started = time.monotonic()
+        hydra_results = []
+        hydra_error = None
+        provider_failed = False
+        try:
+            hydra_results, hydra_error = search_hydra(
+                search_type,
+                title,
+                year=year,
+                imdb=imdb,
+                season=season,
+                episode=episode,
+                settings_getter=settings_getter,
             )
-        )
+            _script_play_stage(
+                "hydra search done count={} error={}".format(
+                    len(hydra_results or []), bool(hydra_error)
+                )
+            )
+        except Exception:
+            provider_failed = True
+            raise
+        finally:
+            telemetry.log_timing(
+                "provider_search",
+                (time.monotonic() - provider_started) * 1000.0,
+                provider="hydra",
+                count=len(hydra_results or []),
+                error=provider_failed or bool(hydra_error),
+            )
         if hydra_error:
             xbmc.log(
                 "NZB-DAV: NZBHydra2 search error: {}".format(hydra_error),
@@ -589,14 +607,35 @@ def _search_all_providers(
         from resources.lib.prowlarr import search_prowlarr
 
         _script_play_stage("prowlarr search start")
-        prowlarr_results, prowlarr_error = search_prowlarr(
-            search_type, title, year=year, imdb=imdb, season=season, episode=episode
-        )
-        _script_play_stage(
-            "prowlarr search done count={} error={}".format(
-                len(prowlarr_results or []), bool(prowlarr_error)
+        provider_started = time.monotonic()
+        prowlarr_results = []
+        prowlarr_error = None
+        provider_failed = False
+        try:
+            prowlarr_results, prowlarr_error = search_prowlarr(
+                search_type,
+                title,
+                year=year,
+                imdb=imdb,
+                season=season,
+                episode=episode,
             )
-        )
+            _script_play_stage(
+                "prowlarr search done count={} error={}".format(
+                    len(prowlarr_results or []), bool(prowlarr_error)
+                )
+            )
+        except Exception:
+            provider_failed = True
+            raise
+        finally:
+            telemetry.log_timing(
+                "provider_search",
+                (time.monotonic() - provider_started) * 1000.0,
+                provider="prowlarr",
+                count=len(prowlarr_results or []),
+                error=provider_failed or bool(prowlarr_error),
+            )
         if prowlarr_error:
             xbmc.log(
                 "NZB-DAV: Prowlarr search error: {}".format(prowlarr_error),
@@ -610,14 +649,35 @@ def _search_all_providers(
         from resources.lib.direct_indexers import search_direct_indexers
 
         _script_play_stage("direct indexers search start")
-        direct_results, direct_error = search_direct_indexers(
-            search_type, title, year=year, imdb=imdb, season=season, episode=episode
-        )
-        _script_play_stage(
-            "direct indexers search done count={} error={}".format(
-                len(direct_results or []), bool(direct_error)
+        provider_started = time.monotonic()
+        direct_results = []
+        direct_error = None
+        provider_failed = False
+        try:
+            direct_results, direct_error = search_direct_indexers(
+                search_type,
+                title,
+                year=year,
+                imdb=imdb,
+                season=season,
+                episode=episode,
             )
-        )
+            _script_play_stage(
+                "direct indexers search done count={} error={}".format(
+                    len(direct_results or []), bool(direct_error)
+                )
+            )
+        except Exception:
+            provider_failed = True
+            raise
+        finally:
+            telemetry.log_timing(
+                "provider_search",
+                (time.monotonic() - provider_started) * 1000.0,
+                provider="direct_indexers",
+                count=len(direct_results or []),
+                error=provider_failed or bool(direct_error),
+            )
         if direct_error:
             xbmc.log(
                 "NZB-DAV: Direct indexer search error: {}".format(direct_error),

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -58,6 +58,7 @@ except (ImportError, ModuleNotFoundError):
     build_faststart_layout = None  # type: ignore[assignment]
     fetch_remote_mp4_layout = None  # type: ignore[assignment]
 
+from resources.lib import telemetry
 from resources.lib.dv_source import probe_dolby_vision_source
 from resources.lib.http_util import HTTP_USER_AGENT
 from resources.lib.http_util import notify as _notify
@@ -6278,6 +6279,7 @@ class StreamProxy:
         stream_info_dict contains duration_seconds, total_bytes, seekable, remux,
         faststart, and virtual_size.
         """
+        started = time.monotonic()
         _validate_url(remote_url)
         auth_header = _validate_auth_header(auth_header)
         fallback_sources = _normalize_fallback_sources(fallback_sources)
@@ -6701,6 +6703,13 @@ class StreamProxy:
         }
         _attach_fallback_context_fields(
             stream_info, ctx.get("fallback_sources", fallback_sources)
+        )
+        telemetry.log_timing(
+            "prepare_stream",
+            (time.monotonic() - started) * 1000.0,
+            content_type=ctx.get("content_type"),
+            faststart=ctx.get("faststart", False),
+            remux=ctx.get("remux", False),
         )
         return local_url, stream_info
 

--- a/repo/plugin.video.nzbdav/resources/lib/telemetry.py
+++ b/repo/plugin.video.nzbdav/resources/lib/telemetry.py
@@ -1,0 +1,30 @@
+"""Lightweight timing telemetry helpers."""
+
+import time
+from contextlib import contextmanager
+
+import xbmc
+
+
+def log_timing(label, elapsed_ms, **fields):
+    """Log one timing sample without letting Kodi logging failures escape."""
+    parts = [
+        "NZB-DAV: timing {}".format(label),
+        "elapsed_ms={:.1f}".format(elapsed_ms),
+    ]
+    for key in sorted(fields):
+        parts.append("{}={}".format(key, fields[key]))
+    try:
+        xbmc.log(" ".join(parts), xbmc.LOGDEBUG)
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+
+@contextmanager
+def timed_block(label, **fields):
+    """Measure a block and emit one debug timing line."""
+    started = time.monotonic()
+    try:
+        yield
+    finally:
+        log_timing(label, (time.monotonic() - started) * 1000.0, **fields)

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -163,6 +163,41 @@ def test_manifest_grouping_uses_video_name_and_bytes_not_result_size(
     assert unrelated["_fallback_candidates"] == []
 
 
+@patch("resources.lib.fallback_streams.telemetry.log_timing")
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_attach_fallback_candidates_logs_manifest_timing(
+    mock_settings, mock_fetch, mock_log_timing
+):
+    mock_settings.return_value = (True, 2)
+    primary = _result(
+        "Example Movie 2026 1080p WEB-DL x265-GROUP",
+        "https://a/nzb",
+        1000,
+    )
+    duplicate = _result(
+        "Example Movie 2026 1080p WEB-DL x265-GROUP",
+        "https://b/nzb",
+        "1001",
+    )
+    manifests = {
+        "https://a/nzb": _manifest("video", "example movie 2026 group.mkv", 8000, "a"),
+        "https://b/nzb": _manifest("video", "example movie 2026 group.mkv", 8000, "b"),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    attach_fallback_candidates([primary, duplicate])
+
+    assert mock_log_timing.call_count == 1
+    label, elapsed_ms = mock_log_timing.call_args.args
+    assert label == "fallback_manifests"
+    assert elapsed_ms >= 0
+    assert mock_log_timing.call_args.kwargs == {
+        "input": 2,
+        "fetched": 2,
+    }
+
+
 @patch("resources.lib.fallback_streams._fallback_settings")
 def test_malformed_manifest_group_bytes_fails_closed_without_aborting(mock_settings):
     mock_settings.return_value = (True, 5)
@@ -890,6 +925,56 @@ def test_selection_fallback_prefilter_skips_manifest_fetch_for_unrelated_candida
         "https://idx/selected.nzb",
         "https://idx/related.nzb",
     ]
+
+
+@patch("resources.lib.fallback_streams.telemetry.log_timing")
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_selection_fallback_logs_manifest_timing(
+    mock_settings, mock_fetch, mock_log_timing
+):
+    mock_settings.return_value = (True, 5)
+    selected = _result(
+        "The.Matrix.1999.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/selected-timing.nzb",
+        60000000000,
+        meta={
+            "resolution": "2160p",
+            "quality": "REMUX",
+            "codec": "x265/HEVC",
+            "hdr": ["Dolby Vision"],
+            "audio": ["TrueHD", "Atmos"],
+            "container": "mkv",
+        },
+    )
+    related = _result(
+        "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALT",
+        "https://idx/related-timing.nzb",
+        60000000000,
+        meta=selected["_meta"],
+    )
+    manifests = {
+        "https://idx/selected-timing.nzb": _manifest(
+            "video", "the matrix 1999 remux.mkv", 60000000000, "selected"
+        ),
+        "https://idx/related-timing.nzb": _manifest(
+            "video", "the matrix 1999 remux.mkv", 60000000000, "related"
+        ),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    attach_fallback_candidates_for_selection(selected, [selected, related])
+
+    assert selected["_fallback_candidates"] == [related]
+    assert mock_log_timing.call_count == 1
+    label, elapsed_ms = mock_log_timing.call_args.args
+    assert label == "fallback_selection_manifests"
+    assert elapsed_ms >= 0
+    assert mock_log_timing.call_args.kwargs == {
+        "attached": 1,
+        "pool": 2,
+        "selected_manifest_fetch": True,
+    }
 
 
 @patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -771,6 +771,33 @@ def test_filter_results_log_counts_before_max_results_truncation(
     assert "Filtered 2 -> 2 results (showing 1)" in logged
 
 
+@patch("resources.lib.filter.telemetry.log_timing")
+@patch("resources.lib.filter._get_filter_settings")
+def test_filter_results_logs_timing(
+    mock_settings,
+    mock_log_timing,
+):
+    mock_settings.return_value = _all_pass_settings()
+    results = [
+        {"title": "Movie.2024.1080p.BluRay.x264-GRP", "size": "5000000000"},
+        {"title": "Other.2024.720p.BluRay.x264-GRP", "size": "3000000000"},
+    ]
+
+    filtered, all_parsed = filter_results(results)
+
+    assert len(filtered) == 2
+    assert len(all_parsed) == 2
+    assert mock_log_timing.call_count == 1
+    label, elapsed_ms = mock_log_timing.call_args.args
+    assert label == "filter_results"
+    assert elapsed_ms >= 0
+    assert mock_log_timing.call_args.kwargs == {
+        "input": 2,
+        "matched": 2,
+        "shown": 2,
+    }
+
+
 # --- _get_filter_settings tests (direct coverage of the Kodi-settings reader) ---
 
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -409,6 +409,139 @@ def test_search_all_providers_uses_script_settings_getter_without_kodi_addon(
     assert hydra_search.call_args.kwargs["settings_getter"] is setting
 
 
+@patch("resources.lib.router.telemetry.log_timing")
+def test_search_all_providers_logs_provider_timing(mock_log_timing):
+    from resources.lib.router import _search_all_providers
+
+    def setting(provider_key):
+        def getter(key, default=""):
+            return {
+                "nzbhydra_enabled": "true" if provider_key == "hydra" else "false",
+                "prowlarr_enabled": ("true" if provider_key == "prowlarr" else "false"),
+                "direct_indexers_enabled": (
+                    "true" if provider_key == "direct_indexers" else "false"
+                ),
+            }.get(key, default)
+
+        return getter
+
+    provider_cases = [
+        (
+            "hydra",
+            "resources.lib.hydra.search_hydra",
+            "https://hydra/getnzb/1",
+        ),
+        (
+            "prowlarr",
+            "resources.lib.prowlarr.search_prowlarr",
+            "https://prowlarr/getnzb/1",
+        ),
+        (
+            "direct_indexers",
+            "resources.lib.direct_indexers.search_direct_indexers",
+            "https://direct/getnzb/1",
+        ),
+    ]
+
+    for provider_key, patch_path, link in provider_cases:
+        mock_log_timing.reset_mock()
+        search_mock = MagicMock(
+            return_value=(
+                [
+                    {
+                        "title": "The.Matrix.1999.1080p-GRP",
+                        "link": link,
+                        "size": "123",
+                        "indexer": provider_key,
+                        "pubdate": "",
+                        "age": "",
+                    }
+                ],
+                None,
+            )
+        )
+
+        with patch(patch_path, search_mock):
+            results, error = _search_all_providers(
+                "movie", "The Matrix", settings_getter=setting(provider_key)
+            )
+
+        assert error is None
+        assert len(results) == 1
+        assert mock_log_timing.call_count == 1
+        label, elapsed_ms = mock_log_timing.call_args.args
+        assert label == "provider_search"
+        assert elapsed_ms >= 0
+        assert mock_log_timing.call_args.kwargs == {
+            "provider": provider_key,
+            "count": 1,
+            "error": False,
+        }
+
+
+@patch("resources.lib.router.telemetry.log_timing")
+def test_search_all_providers_logs_provider_timing_for_errors(mock_log_timing):
+    from resources.lib.router import _search_all_providers
+
+    def setting(key, default=""):
+        return {
+            "nzbhydra_enabled": "true",
+            "prowlarr_enabled": "false",
+            "direct_indexers_enabled": "false",
+        }.get(key, default)
+
+    hydra_search = MagicMock(return_value=([], "hydra unavailable"))
+
+    with patch("resources.lib.hydra.search_hydra", hydra_search):
+        results, error = _search_all_providers(
+            "movie", "The Matrix", settings_getter=setting
+        )
+
+    assert not results
+    assert error == "hydra unavailable"
+    assert mock_log_timing.call_count == 1
+    label, elapsed_ms = mock_log_timing.call_args.args
+    assert label == "provider_search"
+    assert elapsed_ms >= 0
+    assert mock_log_timing.call_args.kwargs == {
+        "provider": "hydra",
+        "count": 0,
+        "error": True,
+    }
+
+
+@patch("resources.lib.router.telemetry.log_timing")
+def test_search_all_providers_logs_provider_timing_for_exceptions(mock_log_timing):
+    from resources.lib.router import _search_all_providers
+
+    def setting(key, default=""):
+        return {
+            "nzbhydra_enabled": "true",
+            "prowlarr_enabled": "false",
+            "direct_indexers_enabled": "false",
+        }.get(key, default)
+
+    hydra_search = MagicMock(side_effect=RuntimeError("boom"))
+
+    try:
+        with patch("resources.lib.hydra.search_hydra", hydra_search):
+            _search_all_providers("movie", "The Matrix", settings_getter=setting)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected provider exception")
+
+    assert mock_log_timing.call_count == 1
+    label, elapsed_ms = mock_log_timing.call_args.args
+    assert label == "provider_search"
+    assert elapsed_ms >= 0
+    assert mock_log_timing.call_args.kwargs == {
+        "provider": "hydra",
+        "count": 0,
+        "error": True,
+    }
+
+
 def test_get_script_setting_reads_translated_profile_settings(tmp_path):
     from resources.lib import router
 

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -505,6 +505,32 @@ def test_prepare_stream_proxies_mkv():
     assert ctx["content_length"] == 100000
 
 
+def test_prepare_stream_logs_timing_for_successful_prepare():
+    from resources.lib.stream_proxy import StreamProxy
+
+    sp = StreamProxy.__new__(StreamProxy)
+    sp._server = MagicMock()
+    sp._context_lock = __import__("threading").Lock()
+    sp.port = 9999
+
+    with patch.object(sp, "_get_content_length", return_value=100000), patch(
+        "resources.lib.stream_proxy.telemetry.log_timing"
+    ) as mock_log_timing:
+        url, info = sp.prepare_stream("http://host/film.mkv")
+
+    assert url.startswith("http://127.0.0.1:9999/stream/")
+    assert info["remux"] is False
+    assert mock_log_timing.call_count == 1
+    label, elapsed_ms = mock_log_timing.call_args.args
+    assert label == "prepare_stream"
+    assert elapsed_ms >= 0
+    assert mock_log_timing.call_args.kwargs == {
+        "content_type": "video/x-matroska",
+        "faststart": False,
+        "remux": False,
+    }
+
+
 def test_prepare_stream_uses_content_length_hint_for_passthrough_start():
     """A PROPFIND size hint should skip the duplicate prepare-time HEAD."""
     from resources.lib.stream_proxy import StreamProxy

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock
+
+from resources.lib import telemetry
+
+
+def test_timed_block_logs_elapsed_milliseconds(monkeypatch):
+    clock_values = iter([10.0, 10.125])
+    log = MagicMock()
+
+    monkeypatch.setattr(telemetry.time, "monotonic", lambda: next(clock_values))
+    monkeypatch.setattr(telemetry.xbmc, "log", log)
+
+    with telemetry.timed_block("search hydra", count=3, error=False):
+        pass
+
+    log.assert_called_once_with(
+        "NZB-DAV: timing search hydra elapsed_ms=125.0 count=3 error=False",
+        telemetry.xbmc.LOGDEBUG,
+    )
+
+
+def test_log_timing_tolerates_logger_failure(monkeypatch):
+    monkeypatch.setattr(
+        telemetry.xbmc,
+        "log",
+        MagicMock(side_effect=RuntimeError("Kodi shutting down")),
+    )
+
+    telemetry.log_timing("filter", 1.25, results=10)


### PR DESCRIPTION
## Summary
- Add lightweight timing telemetry helpers for key search, filtering, fallback, and stream-proxy paths.
- Log elapsed milliseconds around provider search, result filtering, fallback manifest attachment, and content-length lookups without changing user-facing behavior.
- Keep instrumentation failure-tolerant so telemetry logging cannot interrupt playback or search flows.

## Performance Benefit
- Makes slow startup, search, fallback, and proxy phases measurable in Kodi logs so follow-up optimization can target the real bottleneck.
- Low direct runtime overhead: monotonic timestamp capture plus one log line per measured block.

## Risk
- Low. This is observational instrumentation only, with tests covering normal logging and logger failure tolerance.

## Review Notes
- Runtime code remains Python 3.8-compatible and pure Python.
- Existing playback, resolver, fallback, and HTTP Range behavior is unchanged.
- Automated subagent review completed during implementation with no unresolved findings.

## Test Plan
- [x] `just lint`
- [x] `just test` (1503 passed, 5 skipped, 13 deselected)
