### PR TITLE
perf: cache fallback manifests briefly

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -4,6 +4,7 @@
 
 """Conservative grouping for duplicate releases usable as fallback streams."""
 
+import copy
 import hashlib
 import os
 import re
@@ -78,6 +79,8 @@ _FINGERPRINT_BYTES = 4096
 _MAX_FALLBACKS = 5
 _FALLBACK_MANIFEST_STALL_SPECULATION_SECONDS = 0.05
 _FALLBACK_MANIFEST_OPTIONAL_TAIL_WAIT_SECONDS = 0.1
+_FALLBACK_MANIFEST_CACHE_TTL_SECONDS = 10.0
+_FALLBACK_MANIFEST_CACHE_MAX_ENTRIES = 128
 _ALLOWED_STREAM_SCHEMES = frozenset(("http", "https"))
 _METADATA_ONLY_MANIFEST_REASONS = frozenset(("too_large",))
 _ADDON_SETTINGS_SCHEMA = (
@@ -86,6 +89,81 @@ _ADDON_SETTINGS_SCHEMA = (
 _INDEXER_SIZE_SYNTHETIC_MANIFEST_REASONS = frozenset(("invalid_xml", "no_video_file"))
 _INDEXER_SIZE_SYNTHETIC_MIN_BYTES = 100 * 1024 * 1024
 _PrecomputedProbeBase = namedtuple("_PrecomputedProbeBase", "parts origin path")
+_FALLBACK_MANIFEST_CACHE = {}
+_FALLBACK_MANIFEST_CACHE_LOCK = threading.Lock()
+
+
+def _fallback_manifest_cache_now():
+    return time.monotonic()
+
+
+def clear_fallback_manifest_cache():
+    """Clear the short-lived fallback manifest cache."""
+    with _FALLBACK_MANIFEST_CACHE_LOCK:
+        _FALLBACK_MANIFEST_CACHE.clear()
+
+
+def _fallback_manifest_cache_key(link):
+    return fetch_nzb_video_manifest, link
+
+
+def _copy_manifest(manifest):
+    return copy.deepcopy(manifest) if isinstance(manifest, dict) else manifest
+
+
+def _cached_fallback_manifest(link, now):
+    key = _fallback_manifest_cache_key(link)
+    with _FALLBACK_MANIFEST_CACHE_LOCK:
+        cached = _FALLBACK_MANIFEST_CACHE.get(key)
+        if cached is None:
+            return None
+        expires_at, manifest = cached
+        if expires_at <= now:
+            _FALLBACK_MANIFEST_CACHE.pop(key, None)
+            return None
+        return _copy_manifest(manifest)
+
+
+def _store_fallback_manifest(link, manifest, now):
+    if not isinstance(manifest, dict):
+        return
+    key = _fallback_manifest_cache_key(link)
+    expires_at = now + _FALLBACK_MANIFEST_CACHE_TTL_SECONDS
+    with _FALLBACK_MANIFEST_CACHE_LOCK:
+        if len(_FALLBACK_MANIFEST_CACHE) >= _FALLBACK_MANIFEST_CACHE_MAX_ENTRIES:
+            expired = [
+                cache_key
+                for cache_key, (cached_expires_at, _manifest) in (
+                    _FALLBACK_MANIFEST_CACHE.items()
+                )
+                if cached_expires_at <= now
+            ]
+            for cache_key in expired:
+                _FALLBACK_MANIFEST_CACHE.pop(cache_key, None)
+            if len(_FALLBACK_MANIFEST_CACHE) >= _FALLBACK_MANIFEST_CACHE_MAX_ENTRIES:
+                oldest_key = min(
+                    _FALLBACK_MANIFEST_CACHE,
+                    key=lambda cache_key: _FALLBACK_MANIFEST_CACHE[cache_key][0],
+                )
+                _FALLBACK_MANIFEST_CACHE.pop(oldest_key, None)
+        _FALLBACK_MANIFEST_CACHE[key] = (expires_at, _copy_manifest(manifest))
+
+
+def _fetch_fallback_manifest(link):
+    now = _fallback_manifest_cache_now()
+    manifest = _cached_fallback_manifest(link, now)
+    if isinstance(manifest, dict):
+        return manifest
+    try:
+        manifest = fetch_nzb_video_manifest(
+            link, health_check=_manifest_candidate_message_ids_are_healthy
+        )
+    except Exception:  # pylint: disable=broad-except
+        manifest = _manifest_error("fetch_error")
+    if not isinstance(manifest, dict):
+        manifest = _manifest_error("fetch_error")
+    _store_fallback_manifest(link, manifest, _fallback_manifest_cache_now())
+    return _copy_manifest(manifest)
 
 
 def _setting_bool(addon, key, default=False):
@@ -1101,12 +1179,7 @@ def _ensure_fallback_manifest(result, manifest_cache):
         result["_fallback_manifest_error"] = "missing_link"
         return None
     if link not in manifest_cache:
-        try:
-            manifest_cache[link] = fetch_nzb_video_manifest(
-                link, health_check=_manifest_candidate_message_ids_are_healthy
-            )
-        except Exception:  # pylint: disable=broad-except
-            manifest_cache[link] = _manifest_error("fetch_error")
+        manifest_cache[link] = _fetch_fallback_manifest(link)
     manifest = manifest_cache[link]
     if not isinstance(manifest, dict):
         manifest = _manifest_error("fetch_error")

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -25,6 +25,15 @@ from resources.lib.fallback_streams import (
 from resources.lib.nzb_manifest import make_empty_manifest
 
 
+@pytest.fixture(autouse=True)
+def _clear_fallback_manifest_cache():
+    from resources.lib import fallback_streams
+
+    fallback_streams.clear_fallback_manifest_cache()
+    yield
+    fallback_streams.clear_fallback_manifest_cache()
+
+
 def _mock_range_response(body, status=206, headers=None):
     resp = MagicMock()
     resp.__enter__ = MagicMock(return_value=resp)
@@ -2503,6 +2512,194 @@ def test_manifest_fetches_are_cached_per_attach_call(mock_settings, mock_fetch):
     assert first["_fallback_manifest_error"] == ""
     assert second["_fallback_manifest_error"] == ""
     assert duplicate["_fallback_manifest_error"] == ""
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_manifest_fetches_are_cached_across_short_lived_selection_calls(
+    mock_settings, mock_fetch
+):
+    from resources.lib import fallback_streams
+
+    fallback_streams.clear_fallback_manifest_cache()
+    mock_settings.return_value = (True, 1)
+    now = [100.0]
+    manifests = {
+        "https://idx/selected-cache.nzb": _manifest(
+            "video", "the matrix 1999 remux.mkv", 60000000000, "selected"
+        ),
+        "https://idx/related-cache.nzb": _manifest(
+            "video", "the matrix 1999 remux.mkv", 60000000000, "related"
+        ),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    def result_pair():
+        selected = _result(
+            "The.Matrix.1999.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+            "https://idx/selected-cache.nzb",
+            60000000000,
+            meta={
+                "resolution": "2160p",
+                "quality": "REMUX",
+                "codec": "x265/HEVC",
+                "hdr": ["Dolby Vision"],
+                "audio": ["TrueHD", "Atmos"],
+                "container": "mkv",
+            },
+        )
+        related = _result(
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALT",
+            "https://idx/related-cache.nzb",
+            60000000000,
+            meta=selected["_meta"],
+        )
+        return selected, related
+
+    with patch(
+        "resources.lib.fallback_streams._fallback_manifest_cache_now",
+        side_effect=lambda: now[0],
+    ):
+        first_selected, first_related = result_pair()
+        attach_fallback_candidates_for_selection(
+            first_selected, [first_selected, first_related]
+        )
+        second_selected, second_related = result_pair()
+        attach_fallback_candidates_for_selection(
+            second_selected, [second_selected, second_related]
+        )
+
+    assert first_selected["_fallback_candidates"] == [first_related]
+    assert second_selected["_fallback_candidates"] == [second_related]
+    first_manifest = first_selected["_fallback_manifest"]
+    second_manifest = second_selected["_fallback_manifest"]
+    first_related_manifest = first_related["_fallback_manifest"]
+    second_related_manifest = second_related["_fallback_manifest"]
+    assert first_manifest == second_manifest
+    assert first_manifest is not second_manifest
+    assert first_related_manifest == second_related_manifest
+    assert first_related_manifest is not second_related_manifest
+    first_manifest["skipped_candidates"].append({"subject": "mutated"})
+    first_related_manifest["skipped_candidates"].append({"subject": "mutated"})
+    assert second_manifest["skipped_candidates"] == []
+    assert second_related_manifest["skipped_candidates"] == []
+    assert sorted(call.args[0] for call in mock_fetch.call_args_list) == [
+        "https://idx/related-cache.nzb",
+        "https://idx/selected-cache.nzb",
+    ]
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_short_lived_manifest_cache_expires_between_selection_calls(
+    mock_settings, mock_fetch
+):
+    from resources.lib import fallback_streams
+
+    fallback_streams.clear_fallback_manifest_cache()
+    mock_settings.return_value = (True, 1)
+    now = [100.0]
+    manifests = {
+        "https://idx/selected-expire.nzb": _manifest(
+            "video", "the matrix 1999 remux.mkv", 60000000000, "selected"
+        ),
+        "https://idx/related-expire.nzb": _manifest(
+            "video", "the matrix 1999 remux.mkv", 60000000000, "related"
+        ),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    def result_pair():
+        selected = _result(
+            "The.Matrix.1999.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+            "https://idx/selected-expire.nzb",
+            60000000000,
+            meta={
+                "resolution": "2160p",
+                "quality": "REMUX",
+                "codec": "x265/HEVC",
+                "hdr": ["Dolby Vision"],
+                "audio": ["TrueHD", "Atmos"],
+                "container": "mkv",
+            },
+        )
+        related = _result(
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALT",
+            "https://idx/related-expire.nzb",
+            60000000000,
+            meta=selected["_meta"],
+        )
+        return selected, related
+
+    with patch(
+        "resources.lib.fallback_streams._fallback_manifest_cache_now",
+        side_effect=lambda: now[0],
+    ):
+        first_selected, first_related = result_pair()
+        attach_fallback_candidates_for_selection(
+            first_selected, [first_selected, first_related]
+        )
+        now[0] += fallback_streams._FALLBACK_MANIFEST_CACHE_TTL_SECONDS + 0.01
+        second_selected, second_related = result_pair()
+        attach_fallback_candidates_for_selection(
+            second_selected, [second_selected, second_related]
+        )
+
+    assert first_selected["_fallback_candidates"] == [first_related]
+    assert second_selected["_fallback_candidates"] == [second_related]
+    assert len(mock_fetch.call_args_list) == 4
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+def test_manifest_cache_ttl_starts_after_fetch_completes(mock_fetch):
+    from resources.lib import fallback_streams
+
+    fallback_streams.clear_fallback_manifest_cache()
+    now = [100.0]
+    manifest = _manifest("video", "movie.mkv", 1000, "articles")
+
+    def fetch_manifest(_url, **_kwargs):
+        now[0] += fallback_streams._FALLBACK_MANIFEST_CACHE_TTL_SECONDS - 1
+        return manifest
+
+    mock_fetch.side_effect = fetch_manifest
+
+    with patch(
+        "resources.lib.fallback_streams._fallback_manifest_cache_now",
+        side_effect=lambda: now[0],
+    ):
+        first = fallback_streams._fetch_fallback_manifest("https://idx/slow.nzb")
+        now[0] += fallback_streams._FALLBACK_MANIFEST_CACHE_TTL_SECONDS - 0.5
+        second = fallback_streams._fetch_fallback_manifest("https://idx/slow.nzb")
+
+    assert first == second
+    assert mock_fetch.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "fetch_result",
+    [
+        RuntimeError("fetch failed"),
+        None,
+    ],
+)
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+def test_manifest_cache_reuses_normalized_fetch_errors(mock_fetch, fetch_result):
+    from resources.lib import fallback_streams
+
+    fallback_streams.clear_fallback_manifest_cache()
+    if isinstance(fetch_result, Exception):
+        mock_fetch.side_effect = fetch_result
+    else:
+        mock_fetch.return_value = fetch_result
+
+    first = fallback_streams._fetch_fallback_manifest("https://idx/error.nzb")
+    second = fallback_streams._fetch_fallback_manifest("https://idx/error.nzb")
+
+    assert first == make_empty_manifest("fetch_error")
+    assert second == first
+    assert second is not first
+    assert mock_fetch.call_count == 1
 
 
 @patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")


### PR DESCRIPTION
## Summary
- Add a short-lived fallback manifest cache so repeated candidate scans can reuse manifest fetch results.
- Key cache entries by fetch function and request inputs, return deep copies, and clear cache state in tests to avoid cross-test leakage.
- Start TTL after fetch completion so slow manifest fetches still receive the intended usable cache window.

## Performance Benefit
- Reduces duplicate NZB manifest downloads/parsing when fallback attachment and selection paths inspect overlapping candidates.
- Helps picker-to-playback fallback preparation avoid repeated network work on the same candidate set.

## Risk
- Medium-low. This adds in-memory caching, but it is short-lived, function-scoped, deep-copy protected, and covered by cache isolation/TTL tests.

## Review Notes
- Runtime code remains Python 3.8-compatible and pure Python.
- Fallback validation behavior remains strict; the cache only avoids repeated manifest fetch work.
- Automated review found cache leakage/copy and TTL issues during implementation; both were fixed, and final automated review was clean.

## Test Plan
- [x] `just lint`
- [x] `just test` (1499 passed, 5 skipped, 13 deselected)
