### PR TITLE
perf: reuse WebDAV content length hints

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -59,6 +59,10 @@ _POLL_NEAR_COMPLETE_FAST_REPOLL_SECONDS = 0.1
 _POLL_NEAR_COMPLETE_FAST_REPOLL_COUNT = 5
 _PLAYBACK_CLEANUP_HANDOFF_GRACE_SECONDS = 0.25
 _PLAYBACK_PREPARE_HANDOFF_GRACE_SECONDS = 8.0
+_STREAM_CONTENT_LENGTH_HINT_TTL_SECONDS = 30.0
+_STREAM_CONTENT_LENGTH_HINTS_MAX = 128
+_STREAM_CONTENT_LENGTH_HINTS = {}
+_STREAM_CONTENT_LENGTH_HINTS_LOCK = threading.Lock()
 # HTTP status codes the submit retry loop treats as transient and worth
 # retrying. RFC 9110 explicitly calls 408 retry-friendly ("client may
 # assume the server closed the connection due to inactivity and retry").
@@ -513,6 +517,59 @@ def _stream_auth_header(stream_headers):
     return None
 
 
+def _stream_content_length_hint_key(stream_url, auth_header):
+    return stream_url, auth_header or ""
+
+
+def _remember_stream_content_length_hint(stream_url, auth_header, size):
+    try:
+        size = int(size or 0)
+    except (TypeError, ValueError):
+        return
+    if not stream_url or size <= 0:
+        return
+    key = _stream_content_length_hint_key(stream_url, auth_header)
+    expires_at = time.monotonic() + _STREAM_CONTENT_LENGTH_HINT_TTL_SECONDS
+    with _STREAM_CONTENT_LENGTH_HINTS_LOCK:
+        _STREAM_CONTENT_LENGTH_HINTS[key] = (expires_at, size)
+        while len(_STREAM_CONTENT_LENGTH_HINTS) > _STREAM_CONTENT_LENGTH_HINTS_MAX:
+            _STREAM_CONTENT_LENGTH_HINTS.pop(
+                min(
+                    _STREAM_CONTENT_LENGTH_HINTS,
+                    key=lambda key: _STREAM_CONTENT_LENGTH_HINTS[key][0],
+                ),
+                None,
+            )
+
+
+def _remember_resolved_stream_content_length_hint(
+    video_path, stream_url, stream_headers
+):
+    try:
+        from resources.lib import webdav as _webdav
+
+        size = _webdav.get_video_file_size_hint(video_path)
+    except Exception:  # pylint: disable=broad-except
+        return
+    _remember_stream_content_length_hint(
+        stream_url, _stream_auth_header(stream_headers), size
+    )
+
+
+def _get_stream_content_length_hint(stream_url, auth_header):
+    now = time.monotonic()
+    key = _stream_content_length_hint_key(stream_url, auth_header)
+    with _STREAM_CONTENT_LENGTH_HINTS_LOCK:
+        cached = _STREAM_CONTENT_LENGTH_HINTS.get(key)
+        if cached is None:
+            return 0
+        expires_at, size = cached
+        if expires_at <= now:
+            _STREAM_CONTENT_LENGTH_HINTS.pop(key, None)
+            return 0
+        return size
+
+
 def _prepare_direct_playback(
     stream_url,
     stream_headers,
@@ -543,6 +600,9 @@ def _prepare_direct_playback(
 
     auth_header = _stream_auth_header(stream_headers)
     prepare_kwargs = {"fallback_sources": fallback_sources}
+    content_length_hint = _get_stream_content_length_hint(stream_url, auth_header)
+    if content_length_hint > 0:
+        prepare_kwargs["content_length_hint"] = content_length_hint
     settings_snapshot = build_settings_snapshot(settings_getter=settings_getter)
     if any(settings_snapshot.values()):
         prepare_kwargs["settings_snapshot"] = settings_snapshot
@@ -1392,9 +1452,14 @@ def _find_video_stream_for_folder(webdav_folder, settings_getter=None):
             and get_webdav_stream_url_for_path is _webdav.get_webdav_stream_url_for_path
         ):
             _resolve_stage("find_video_stream_for_folder_delegated")
-            return find_video_stream_for_folder(
+            video_path, stream_url, stream_headers = find_video_stream_for_folder(
                 webdav_folder, **_settings_getter_kwargs(settings_getter)
             )
+            if video_path:
+                _remember_resolved_stream_content_length_hint(
+                    video_path, stream_url, stream_headers
+                )
+            return video_path, stream_url, stream_headers
     except (AttributeError, ImportError):
         pass
 
@@ -1407,6 +1472,9 @@ def _find_video_stream_for_folder(webdav_folder, settings_getter=None):
     _resolve_stage("get_webdav_stream_url_start")
     stream_url, stream_headers = get_webdav_stream_url_for_path(video_path, **kwargs)
     _resolve_stage("get_webdav_stream_url_done")
+    _remember_resolved_stream_content_length_hint(
+        video_path, stream_url, stream_headers
+    )
     return video_path, stream_url, stream_headers
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -6295,8 +6295,8 @@ class StreamProxy:
         is_mp4 = lower_url.endswith((".mp4", ".m4v"))
 
         if fallback_sources:
-            content_length = content_length_hint or self._get_content_length(
-                remote_url, auth_header
+            content_length = self._get_content_length(
+                remote_url, auth_header, content_length_hint=content_length_hint
             )
             if content_length <= 0:
                 raise OSError(
@@ -6317,8 +6317,8 @@ class StreamProxy:
                 xbmc.LOGINFO,
             )
         elif is_mp4:
-            content_length = content_length_hint or self._get_content_length(
-                remote_url, auth_header
+            content_length = self._get_content_length(
+                remote_url, auth_header, content_length_hint=content_length_hint
             )
             content_length_unknown = content_length <= 0
             faststart = self._try_faststart_layout(
@@ -6439,8 +6439,8 @@ class StreamProxy:
                         "faststart": False,
                     }
         else:
-            content_length = content_length_hint or self._get_content_length(
-                remote_url, auth_header
+            content_length = self._get_content_length(
+                remote_url, auth_header, content_length_hint=content_length_hint
             )
             content_length_unknown = content_length <= 0
             if settings_snapshot:
@@ -7019,8 +7019,29 @@ class StreamProxy:
         return None
 
     @staticmethod
-    def _get_content_length(url, auth_header):
+    def _get_content_length(url, auth_header, content_length_hint=None):
         """Get file size via HEAD or range probe."""
+        content_length_hint = _normalize_content_length_hint(content_length_hint)
+        if content_length_hint > 0:
+            try:
+                req = Request(url)
+                _add_request_headers(req, auth_header)
+                req.add_header("Range", "bytes=0-0")
+                # nosemgrep
+                with urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
+                    req, timeout=10
+                ) as resp:
+                    cr = resp.headers.get("Content-Range", "")
+                    status = getattr(resp, "status", None)
+                    if status is None:
+                        status = resp.getcode()
+                    match = re.match(r"^bytes\s+0-0/(\d+)$", cr.strip())
+                    stream_length = int(match.group(1)) if match else 0
+                    if status == 206 and stream_length == content_length_hint:
+                        return content_length_hint
+            except (OSError, ValueError):
+                pass
+
         req = Request(url, method="HEAD")
         _add_request_headers(req, auth_header)
         try:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2569,18 +2569,21 @@ def test_script_history_failure_uses_notification_not_modal(
     mock_xbmc.log.assert_called()
 
 
+@patch("resources.lib.webdav.get_video_file_size_hint")
 @patch("resources.lib.stream_proxy.prepare_stream_via_service")
 @patch("resources.lib.resolver.get_webdav_stream_url_for_path")
 @patch("resources.lib.resolver.find_video_file")
-def test_completed_history_propfind_length_hint_does_not_override_stream_head(
+def test_completed_history_propfind_length_hint_is_passed_to_proxy_prepare(
     mock_find_video,
     mock_stream_url,
     mock_prepare_via_service,
+    mock_size_hint,
 ):
-    """PROPFIND sizes can be stale; proxy prepare must use the HTTP stream HEAD."""
+    """Reuse the PROPFIND getcontentlength so proxy prepare can skip stream HEAD."""
     from resources.lib.resolver import _handle_history_result, _prepare_direct_playback
 
     mock_find_video.return_value = "/content/uncategorized/movie/movie.mkv"
+    mock_size_hint.return_value = 4294967296
     mock_stream_url.return_value = (
         "http://webdav/content/uncategorized/movie/movie.mkv",
         {"Authorization": "Basic primary"},
@@ -2613,7 +2616,65 @@ def test_completed_history_propfind_length_hint_does_not_override_stream_head(
         "http://webdav/content/uncategorized/movie/movie.mkv",
         "Basic primary",
         fallback_sources=None,
+        content_length_hint=4294967296,
         prepare_token="token",
+    )
+
+
+@patch("resources.lib.stream_proxy.prepare_stream_via_service")
+def test_content_length_hint_is_scoped_to_stream_auth(mock_prepare_via_service):
+    from resources.lib import resolver
+    from resources.lib.resolver import _prepare_direct_playback
+
+    with resolver._STREAM_CONTENT_LENGTH_HINTS_LOCK:
+        resolver._STREAM_CONTENT_LENGTH_HINTS.clear()
+    resolver._remember_stream_content_length_hint(
+        "http://webdav/content/movie.mkv", "Basic primary", 4294967296
+    )
+    mock_prepare_via_service.return_value = (
+        "http://127.0.0.1:57800/stream/abc",
+        {"remux": False},
+    )
+
+    _prepare_direct_playback(
+        "http://webdav/content/movie.mkv",
+        {"Authorization": "Basic other"},
+        service_port=57800,
+        prepare_token="token",
+    )
+
+    assert "content_length_hint" not in mock_prepare_via_service.call_args.kwargs
+
+
+@patch("resources.lib.webdav.get_video_file_size_hint", return_value=4294967296)
+def test_delegated_find_video_stream_remembers_content_length_hint(mock_size_hint):
+    from resources.lib import resolver
+    from resources.lib.resolver import _find_video_stream_for_folder
+
+    with resolver._STREAM_CONTENT_LENGTH_HINTS_LOCK:
+        resolver._STREAM_CONTENT_LENGTH_HINTS.clear()
+
+    delegated = MagicMock(
+        return_value=(
+            "/content/uncategorized/movie/movie.mkv",
+            "http://webdav/content/uncategorized/movie/movie.mkv",
+            {"Authorization": "Basic delegated"},
+        )
+    )
+
+    with patch("resources.lib.webdav.find_video_stream_for_folder", delegated):
+        with patch.object(resolver, "find_video_stream_for_folder", delegated):
+            video_path, stream_url, stream_headers = _find_video_stream_for_folder(
+                "/content/uncategorized/movie"
+            )
+
+    assert video_path == "/content/uncategorized/movie/movie.mkv"
+    assert stream_url == "http://webdav/content/uncategorized/movie/movie.mkv"
+    assert stream_headers == {"Authorization": "Basic delegated"}
+    mock_size_hint.assert_called_once_with("/content/uncategorized/movie/movie.mkv")
+    assert (
+        resolver._get_stream_content_length_hint(stream_url, "Basic delegated")
+        == 4294967296
     )
 
 

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -447,6 +447,89 @@ def test_get_content_length_returns_zero_on_failure():
         assert sp._get_content_length("http://host/file.mp4", None) == 0
 
 
+def test_get_content_length_uses_matching_range_validated_hint_before_head():
+    from resources.lib.stream_proxy import StreamProxy
+
+    sp = StreamProxy.__new__(StreamProxy)
+    range_resp = _mock_urlopen_response(
+        [b"x"], headers={"Content-Range": "bytes 0-0/131072"}
+    )
+
+    with patch("resources.lib.stream_proxy.urlopen", return_value=range_resp) as mocked:
+        assert (
+            sp._get_content_length(
+                "http://host/file.mkv", None, content_length_hint=131072
+            )
+            == 131072
+        )
+
+    req = mocked.call_args[0][0]
+    assert req.get_method() == "GET"
+    assert _request_header(req, "Range") == "bytes=0-0"
+
+
+def test_get_content_length_ignores_stale_hint_and_uses_head_total():
+    from resources.lib.stream_proxy import StreamProxy
+
+    sp = StreamProxy.__new__(StreamProxy)
+    stale_range_resp = _mock_urlopen_response(
+        [b"x"], headers={"Content-Range": "bytes 0-0/65536"}
+    )
+    head_resp = MagicMock()
+    head_resp.__enter__ = MagicMock(return_value=head_resp)
+    head_resp.__exit__ = MagicMock(return_value=False)
+    head_resp.headers.get.return_value = "65536"
+
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        side_effect=[stale_range_resp, head_resp],
+    ) as mocked:
+        assert (
+            sp._get_content_length(
+                "http://host/file.mkv", None, content_length_hint=131072
+            )
+            == 65536
+        )
+
+    assert mocked.call_args_list[1].args[0].get_method() == "HEAD"
+
+
+@pytest.mark.parametrize(
+    ("status", "content_range"),
+    [
+        (200, "bytes 0-0/131072"),
+        (206, "bytes 1-1/131072"),
+        (206, "items 0-0/131072"),
+    ],
+)
+def test_get_content_length_ignores_malformed_matching_hint_validation(
+    status, content_range
+):
+    from resources.lib.stream_proxy import StreamProxy
+
+    sp = StreamProxy.__new__(StreamProxy)
+    malformed_range_resp = _mock_urlopen_response(
+        [b"x"], status=status, headers={"Content-Range": content_range}
+    )
+    head_resp = MagicMock()
+    head_resp.__enter__ = MagicMock(return_value=head_resp)
+    head_resp.__exit__ = MagicMock(return_value=False)
+    head_resp.headers.get.return_value = "65536"
+
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        side_effect=[malformed_range_resp, head_resp],
+    ) as mocked:
+        assert (
+            sp._get_content_length(
+                "http://host/file.mkv", None, content_length_hint=131072
+            )
+            == 65536
+        )
+
+    assert mocked.call_args_list[1].args[0].get_method() == "HEAD"
+
+
 # ---------------------------------------------------------------------------
 # StreamProxy.prepare_stream — remux vs proxy
 # ---------------------------------------------------------------------------
@@ -506,7 +589,7 @@ def test_prepare_stream_proxies_mkv():
 
 
 def test_prepare_stream_uses_content_length_hint_for_passthrough_start():
-    """A PROPFIND size hint should skip the duplicate prepare-time HEAD."""
+    """A PROPFIND size hint is passed through for stream-side validation."""
     from resources.lib.stream_proxy import StreamProxy
 
     sp = StreamProxy.__new__(StreamProxy)
@@ -517,22 +600,17 @@ def test_prepare_stream_uses_content_length_hint_for_passthrough_start():
     sp._context_lock = threading.RLock()
     sp.port = 9999
 
-    def slow_head(*_args, **_kwargs):
-        time.sleep(0.12)
-        return 131072
-
-    with patch.object(sp, "_get_content_length", side_effect=slow_head) as mock_head:
-        started = time.perf_counter()
+    with patch.object(sp, "_get_content_length", return_value=131072) as mock_head:
         url, info = sp.prepare_stream(
             "http://host/movie.mkv", content_length_hint=131072
         )
-        elapsed = time.perf_counter() - started
 
     assert url.startswith("http://127.0.0.1:9999/stream/")
     assert info["total_bytes"] == 131072
     assert sp._server.stream_context["content_length"] == 131072
-    assert elapsed < 0.2, "content-length hint path stalled: {:.3f}s".format(elapsed)
-    mock_head.assert_not_called()
+    mock_head.assert_called_once_with(
+        "http://host/movie.mkv", None, content_length_hint=131072
+    )
 
 
 def test_prepare_stream_matroska_mode_forces_remux_for_large_mkv():


### PR DESCRIPTION
## Summary
- Carry WebDAV PROPFIND content-length hints from resolver discovery into stream proxy preparation.
- Scope resolver length hints by stream URL and auth header so protected streams do not share hints across credentials.
- Validate a hinted length with `Range: bytes=0-0` before trusting it, requiring `206` and an exact `Content-Range: bytes 0-0/<hint>` response.

## Performance Benefit
- Avoids an extra full content-length discovery path for streams whose size was already found during WebDAV discovery.
- Reduces playback startup work while preserving strict upstream validation before the proxy uses the hint.

## Risk
- Medium-low. This touches resolver-to-proxy handoff and content-length validation, but malformed/mismatched hints are rejected and HTTP Range behavior remains covered.

## Review Notes
- Runtime code remains Python 3.8-compatible and pure Python.
- Preserves proxy seeking and Range semantics; the hint only short-circuits after strict validation.
- Automated review found one validation gap during implementation; it was fixed by requiring exact `206`/`Content-Range` validation, and final automated re-review was clean.

## Test Plan
- [x] `just lint`
- [x] `just test` (1503 passed, 5 skipped, 13 deselected)
