### PR TITLE
Add agent PR review helper workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,17 @@ just clean         # Remove __pycache__, .pytest_cache, zip
 just dist-clean    # clean + remove pages-dist/
 ```
 
+## PR Review Helper Scripts
+
+For agent PR review workflows:
+
+- `python3 scripts/pr_agent_context.py --json` -- preferred unified agent context packet.
+- `python3 scripts/pr_review_context.py --json` -- local branch, PR, check, and file context.
+- `python3 scripts/fetch_comments.py --json` -- unresolved GitHub review threads and PR comments.
+
+Use `fetch_comments.py` directly when a skill or workflow expects that helper by name.
+Use `pr_agent_context.py` when starting a PR review or addressing comments from scratch.
+
 ## Repository Map
 
 - `repo/plugin.video.nzbdav/` -- Kodi addon installed via zip

--- a/scripts/fetch_comments.py
+++ b/scripts/fetch_comments.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Print GitHub PR review threads in a Codex-friendly format."""
+
+import argparse
+import json
+import subprocess
+import sys
+import textwrap
+
+PR_JSON_FIELDS = "number,title,url,comments"
+
+REVIEW_THREADS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          startLine
+          comments(first: 100) {
+            nodes {
+              id
+              author {
+                login
+              }
+              body
+              createdAt
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def run_command(args, cwd=None, check=True):
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def load_json(stdout, description):
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit("Failed to parse {} JSON: {}".format(description, exc))
+
+
+def split_repo(name_with_owner):
+    parts = (name_with_owner or "").split("/")
+    if len(parts) != 2 or not all(parts):
+        raise SystemExit("GitHub repository must be in OWNER/REPO form")
+    return parts[0], parts[1]
+
+
+def current_pr(pr_number=None, runner=run_command):
+    args = ["gh", "pr", "view"]
+    if pr_number is not None:
+        args.append(str(pr_number))
+    args.extend(["--json", PR_JSON_FIELDS])
+    return load_json(runner(args).stdout, "PR")
+
+
+def current_repo(runner=run_command):
+    result = runner(["gh", "repo", "view", "--json", "nameWithOwner"])
+    payload = load_json(result.stdout, "repository")
+    return split_repo(payload.get("nameWithOwner"))
+
+
+def review_threads(owner, name, number, runner=run_command):
+    result = runner(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            "owner={}".format(owner),
+            "-f",
+            "name={}".format(name),
+            "-F",
+            "number={}".format(number),
+            "-f",
+            "query={}".format(REVIEW_THREADS_QUERY),
+        ]
+    )
+    return load_json(result.stdout, "review thread")
+
+
+def _thread_line(thread):
+    return thread.get("line") or thread.get("startLine") or "?"
+
+
+def _comment_author(comment):
+    author = comment.get("author") or {}
+    return author.get("login") or "unknown"
+
+
+def _comment_payload(comment, fallback_id):
+    return {
+        "id": comment.get("id") or fallback_id,
+        "author": _comment_author(comment),
+        "body": (comment.get("body") or "").strip(),
+        "created_at": comment.get("createdAt", ""),
+        "url": comment.get("url", ""),
+    }
+
+
+def _thread_payload(thread, index):
+    comments = []
+    for comment_index, comment in enumerate(
+        thread.get("comments", {}).get("nodes") or [], 1
+    ):
+        comments.append(
+            _comment_payload(
+                comment, "thread-{}-comment-{}".format(index, comment_index)
+            )
+        )
+
+    return {
+        "id": thread.get("id") or "thread-{}".format(index),
+        "is_resolved": bool(thread.get("isResolved")),
+        "path": thread.get("path") or "(unknown path)",
+        "line": _thread_line(thread),
+        "comments": comments,
+    }
+
+
+def build_agent_payload(pr, thread_data, include_resolved=False):
+    pull_request = (
+        thread_data.get("data", {}).get("repository", {}).get("pullRequest", {})
+    )
+    raw_threads = pull_request.get("reviewThreads", {}).get("nodes") or []
+    if not include_resolved:
+        raw_threads = [thread for thread in raw_threads if not thread.get("isResolved")]
+
+    issue_comments = []
+    for index, comment in enumerate(pr.get("comments") or [], 1):
+        issue_comments.append(
+            _comment_payload(comment, "issue-comment-{}".format(index))
+        )
+
+    thread_payloads = []
+    for index, thread in enumerate(raw_threads, 1):
+        thread_payloads.append(_thread_payload(thread, index))
+
+    return {
+        "pr": {
+            "number": pr.get("number"),
+            "title": pr.get("title", ""),
+            "url": pr.get("url", ""),
+        },
+        "summary": {
+            "issue_comment_count": len(issue_comments),
+            "review_thread_count": len(thread_payloads),
+            "include_resolved": include_resolved,
+        },
+        "issue_comments": issue_comments,
+        "review_threads": thread_payloads,
+    }
+
+
+def render_comments(pr, thread_data, include_resolved=False):
+    payload = build_agent_payload(pr, thread_data, include_resolved=include_resolved)
+
+    lines = [
+        "PR #{}: {}".format(pr.get("number"), pr.get("title", "")),
+        pr.get("url", ""),
+        "",
+    ]
+
+    comments = payload["issue_comments"]
+    if comments:
+        lines.append("Issue comments:")
+        for index, comment in enumerate(comments, 1):
+            lines.append(
+                "[I{}] {} {} at {}".format(
+                    index,
+                    comment["id"],
+                    comment["author"],
+                    comment["created_at"],
+                )
+            )
+            if comment["url"]:
+                lines.append(comment["url"])
+            lines.append(textwrap.indent(comment["body"], "  "))
+            lines.append("")
+
+    threads = payload["review_threads"]
+    if not threads:
+        lines.append("No review threads found.")
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.append("Review threads:")
+    for index, thread in enumerate(threads, 1):
+        resolved = "resolved" if thread["is_resolved"] else "unresolved"
+        lines.append(
+            "[{}] {} {}:{} ({})".format(
+                index, thread["id"], thread["path"], thread["line"], resolved
+            )
+        )
+        for comment in thread["comments"]:
+            lines.append(
+                "{} {} at {}".format(
+                    comment["id"], comment["author"], comment["created_at"]
+                )
+            )
+            if comment["url"]:
+                lines.append(comment["url"])
+            lines.append(textwrap.indent(comment["body"], "  "))
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Print PR review comments and review threads."
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="PR number. Defaults to the PR for the current branch.",
+    )
+    parser.add_argument(
+        "--include-resolved",
+        action="store_true",
+        help="Include resolved review threads.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit structured JSON instead of Markdown.",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    pr = current_pr(args.pr)
+    owner, name = current_repo()
+    threads = review_threads(owner, name, pr["number"])
+    if args.json:
+        payload = build_agent_payload(pr, threads, args.include_resolved)
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True))
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(render_comments(pr, threads, args.include_resolved))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_comments.py
+++ b/scripts/fetch_comments.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import textwrap
 
-PR_JSON_FIELDS = "number,title,url,comments"
+PR_JSON_FIELDS = "number,title,url,comments,reviews"
 
 REVIEW_THREADS_QUERY = """
 query(
@@ -235,6 +235,20 @@ def _comment_payload(comment, fallback_id):
     }
 
 
+def _review_comment_payload(review, fallback_id):
+    body = (review.get("body") or "").strip()
+    state = review.get("state")
+    if state:
+        body = "[{}] {}".format(state, body).strip()
+    return {
+        "id": review.get("id") or fallback_id,
+        "author": _comment_author(review),
+        "body": body,
+        "created_at": review.get("submittedAt", ""),
+        "url": review.get("url", ""),
+    }
+
+
 def _thread_payload(thread, index):
     comments = []
     for comment_index, comment in enumerate(
@@ -268,6 +282,11 @@ def build_agent_payload(pr, thread_data, include_resolved=False):
         issue_comments.append(
             _comment_payload(comment, "issue-comment-{}".format(index))
         )
+    for index, review in enumerate(pr.get("reviews") or [], 1):
+        if (review.get("body") or "").strip():
+            issue_comments.append(
+                _review_comment_payload(review, "review-comment-{}".format(index))
+            )
 
     thread_payloads = []
     for index, thread in enumerate(raw_threads, 1):

--- a/scripts/fetch_comments.py
+++ b/scripts/fetch_comments.py
@@ -13,10 +13,15 @@ import textwrap
 PR_JSON_FIELDS = "number,title,url,comments"
 
 REVIEW_THREADS_QUERY = """
-query($owner: String!, $name: String!, $number: Int!) {
+query(
+  $owner: String!,
+  $name: String!,
+  $number: Int!,
+  $review_threads_after: String
+) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $review_threads_after) {
         nodes {
           id
           isResolved
@@ -33,7 +38,39 @@ query($owner: String!, $name: String!, $number: Int!) {
               createdAt
               url
             }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
           }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+"""
+
+REVIEW_THREAD_COMMENTS_QUERY = """
+query($thread_id: ID!, $comments_after: String) {
+  node(id: $thread_id) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $comments_after) {
+        nodes {
+          id
+          author {
+            login
+          }
+          body
+          createdAt
+          url
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
     }
@@ -81,23 +118,102 @@ def current_repo(runner=run_command):
     return split_repo(payload.get("nameWithOwner"))
 
 
+def _graphql(query, variables, runner=run_command):
+    args = ["gh", "api", "graphql"]
+    for name, value in variables:
+        if value is None:
+            continue
+        flag = "-F" if isinstance(value, int) else "-f"
+        args.extend([flag, "{}={}".format(name, value)])
+    args.extend(["-f", "query={}".format(query)])
+    return load_json(runner(args).stdout, "review thread")
+
+
+def _page_info(connection):
+    return connection.get("pageInfo") or {}
+
+
+def _has_next_page(connection):
+    return bool(_page_info(connection).get("hasNextPage"))
+
+
+def _end_cursor(connection):
+    return _page_info(connection).get("endCursor")
+
+
+def _fetch_remaining_comments(thread, runner=run_command):
+    comments = thread.get("comments") or {}
+    if not thread.get("id") or not _has_next_page(comments):
+        return thread
+
+    nodes = list(comments.get("nodes") or [])
+    comments_after = _end_cursor(comments)
+    while comments_after:
+        data = _graphql(
+            REVIEW_THREAD_COMMENTS_QUERY,
+            [
+                ("thread_id", thread["id"]),
+                ("comments_after", comments_after),
+            ],
+            runner=runner,
+        )
+        next_comments = (
+            data.get("data", {}).get("node", {}).get("comments", {})
+        )
+        nodes.extend(next_comments.get("nodes") or [])
+        if not _has_next_page(next_comments):
+            break
+        comments_after = _end_cursor(next_comments)
+
+    comments["nodes"] = nodes
+    comments["pageInfo"] = {"hasNextPage": False, "endCursor": None}
+    thread["comments"] = comments
+    return thread
+
+
 def review_threads(owner, name, number, runner=run_command):
-    result = runner(
-        [
-            "gh",
-            "api",
-            "graphql",
-            "-f",
-            "owner={}".format(owner),
-            "-f",
-            "name={}".format(name),
-            "-F",
-            "number={}".format(number),
-            "-f",
-            "query={}".format(REVIEW_THREADS_QUERY),
-        ]
+    all_threads = []
+    review_threads_after = None
+    last_payload = None
+
+    while True:
+        last_payload = _graphql(
+            REVIEW_THREADS_QUERY,
+            [
+                ("owner", owner),
+                ("name", name),
+                ("number", number),
+                ("review_threads_after", review_threads_after),
+            ],
+            runner=runner,
+        )
+        pull_request = (
+            last_payload.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+        )
+        connection = pull_request.get("reviewThreads") or {}
+        for thread in connection.get("nodes") or []:
+            all_threads.append(_fetch_remaining_comments(thread, runner=runner))
+
+        if not _has_next_page(connection):
+            break
+        review_threads_after = _end_cursor(connection)
+        if not review_threads_after:
+            break
+
+    if last_payload is None:
+        last_payload = {"data": {"repository": {"pullRequest": {}}}}
+    pull_request = (
+        last_payload.setdefault("data", {})
+        .setdefault("repository", {})
+        .setdefault("pullRequest", {})
     )
-    return load_json(result.stdout, "review thread")
+    pull_request["reviewThreads"] = {
+        "nodes": all_threads,
+        "pageInfo": {"hasNextPage": False, "endCursor": None},
+    }
+    return last_payload
 
 
 def _thread_line(thread):

--- a/scripts/pr_agent_context.py
+++ b/scripts/pr_agent_context.py
@@ -6,6 +6,7 @@
 
 import argparse
 import json
+import shlex
 import subprocess
 import sys
 
@@ -19,7 +20,7 @@ SCHEMA_VERSION = 1
 
 
 def _command_text(args):
-    return " ".join(str(arg) for arg in args)
+    return " ".join(shlex.quote(str(arg)) for arg in args)
 
 
 def _error_payload(stage, exc):
@@ -48,6 +49,10 @@ def _empty_comments(include_resolved=False):
         "issue_comments": [],
         "review_threads": [],
     }
+
+
+def _empty_thread_data():
+    return {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
 
 
 def _file_payloads(changed_files):
@@ -110,19 +115,48 @@ def _commands(base_ref):
         "preferred_markdown": "python3 scripts/pr_agent_context.py",
         "local_context_json": "python3 scripts/pr_review_context.py --json",
         "comments_json": "python3 scripts/fetch_comments.py --json",
-        "diff_stat": "git diff {} --stat".format(diff_range),
-        "diff": "git diff {}".format(diff_range),
+        "diff_stat": "git diff {} --stat".format(shlex.quote(diff_range)),
+        "diff": "git diff {}".format(shlex.quote(diff_range)),
         "lint": "just lint",
         "test": "just test",
     }
 
 
-def _collect_comments(pr_number, include_resolved, runner):
-    pr = fetch_comments.current_pr(pr_number, runner=runner)
-    owner, name = fetch_comments.current_repo(runner=runner)
-    threads = fetch_comments.review_threads(owner, name, pr["number"], runner=runner)
-    return fetch_comments.build_agent_payload(
-        pr, threads, include_resolved=include_resolved
+def _pr_has_comments(pr):
+    return pr is not None and "comments" in pr
+
+
+def _context_pr_for_comments(context_pr, pr_number):
+    if not _pr_has_comments(context_pr):
+        return None
+    if pr_number is not None and context_pr.get("number") != pr_number:
+        return None
+    return context_pr
+
+
+def _collect_comments(pr_number, include_resolved, runner, context_pr=None):
+    errors = []
+    try:
+        pr = _context_pr_for_comments(context_pr, pr_number)
+        if pr is None:
+            pr = fetch_comments.current_pr(pr_number, runner=runner)
+    except (OSError, subprocess.CalledProcessError, SystemExit) as exc:
+        return _empty_comments(include_resolved=include_resolved), [
+            _error_payload("comments", exc)
+        ]
+
+    try:
+        owner, name = fetch_comments.current_repo(runner=runner)
+        threads = fetch_comments.review_threads(owner, name, pr["number"], runner=runner)
+    except (OSError, subprocess.CalledProcessError, SystemExit) as exc:
+        threads = _empty_thread_data()
+        errors.append(_error_payload("review_threads", exc))
+
+    return (
+        fetch_comments.build_agent_payload(
+            pr, threads, include_resolved=include_resolved
+        ),
+        errors,
     )
 
 
@@ -140,12 +174,12 @@ def collect_agent_context(
         max_diff_lines=max_diff_lines,
         runner=runner,
     )
-    errors = []
-    try:
-        comments = _collect_comments(pr_number, include_resolved, runner)
-    except (OSError, subprocess.CalledProcessError, SystemExit) as exc:
-        comments = _empty_comments(include_resolved=include_resolved)
-        errors.append(_error_payload("comments", exc))
+    comments, errors = _collect_comments(
+        pr_number,
+        include_resolved,
+        runner,
+        context_pr=context.get("pr"),
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,

--- a/scripts/pr_agent_context.py
+++ b/scripts/pr_agent_context.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Print a unified PR context packet for AI agent review workflows."""
+
+import argparse
+import json
+import subprocess
+import sys
+
+try:
+    from scripts import fetch_comments, pr_review_context
+except ImportError:  # pragma: no cover - supports direct script execution.
+    import fetch_comments
+    import pr_review_context
+
+SCHEMA_VERSION = 1
+
+
+def _command_text(args):
+    return " ".join(str(arg) for arg in args)
+
+
+def _error_payload(stage, exc):
+    command = ""
+    message = str(exc).strip()
+    if isinstance(exc, subprocess.CalledProcessError):
+        command = _command_text(exc.cmd)
+        message = (exc.stderr or exc.stdout or str(exc)).strip()
+    if isinstance(exc, SystemExit):
+        message = str(exc).strip()
+    return {
+        "stage": stage,
+        "command": command,
+        "message": message,
+    }
+
+
+def _empty_comments(include_resolved=False):
+    return {
+        "pr": {"number": None, "title": "", "url": ""},
+        "summary": {
+            "issue_comment_count": 0,
+            "review_thread_count": 0,
+            "include_resolved": include_resolved,
+        },
+        "issue_comments": [],
+        "review_threads": [],
+    }
+
+
+def _file_payloads(changed_files):
+    files = []
+    for line in changed_files:
+        parts = line.split("\t")
+        if len(parts) >= 3:
+            files.append(
+                {
+                    "status": parts[0],
+                    "path": parts[-1],
+                    "previous_path": parts[-2],
+                }
+            )
+        elif len(parts) >= 2:
+            files.append({"status": parts[0], "path": parts[1]})
+    return files
+
+
+def _pr_payload(context):
+    pr = context.get("pr") or {}
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title", ""),
+        "url": pr.get("url", ""),
+        "base_ref": pr.get("baseRefName", ""),
+        "head_ref": pr.get("headRefName", ""),
+        "review_decision": pr.get("reviewDecision"),
+    }
+
+
+def _git_payload(context):
+    payload = {
+        "branch": context.get("branch", ""),
+        "base_ref": context.get("base_ref", ""),
+        "head_sha": context.get("head_sha", ""),
+        "merge_base": context.get("merge_base", ""),
+        "commits": context.get("commits") or [],
+        "diff_stat": context.get("diff_stat", ""),
+    }
+    if context.get("diff") is not None:
+        payload["diff"] = context.get("diff")
+        payload["diff_truncated"] = bool(context.get("diff_truncated"))
+    return payload
+
+
+def _checks_payload(context):
+    pr = context.get("pr") or {}
+    return {
+        "status": context.get("status", "UNKNOWN"),
+        "review_decision": pr.get("reviewDecision"),
+        "rollup": pr.get("statusCheckRollup") or [],
+    }
+
+
+def _commands(base_ref):
+    diff_range = "{}...HEAD".format(base_ref or "origin/main")
+    return {
+        "preferred_json": "python3 scripts/pr_agent_context.py --json",
+        "preferred_markdown": "python3 scripts/pr_agent_context.py",
+        "local_context_json": "python3 scripts/pr_review_context.py --json",
+        "comments_json": "python3 scripts/fetch_comments.py --json",
+        "diff_stat": "git diff {} --stat".format(diff_range),
+        "diff": "git diff {}".format(diff_range),
+        "lint": "just lint",
+        "test": "just test",
+    }
+
+
+def _collect_comments(pr_number, include_resolved, runner):
+    pr = fetch_comments.current_pr(pr_number, runner=runner)
+    owner, name = fetch_comments.current_repo(runner=runner)
+    threads = fetch_comments.review_threads(owner, name, pr["number"], runner=runner)
+    return fetch_comments.build_agent_payload(
+        pr, threads, include_resolved=include_resolved
+    )
+
+
+def collect_agent_context(
+    base_ref=None,
+    pr_number=None,
+    include_resolved=False,
+    include_diff=False,
+    max_diff_lines=400,
+    runner=pr_review_context.run_command,
+):
+    context = pr_review_context.collect_context(
+        base_ref=base_ref,
+        include_diff=include_diff,
+        max_diff_lines=max_diff_lines,
+        runner=runner,
+    )
+    errors = []
+    try:
+        comments = _collect_comments(pr_number, include_resolved, runner)
+    except (OSError, subprocess.CalledProcessError, SystemExit) as exc:
+        comments = _empty_comments(include_resolved=include_resolved)
+        errors.append(_error_payload("comments", exc))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "pr": _pr_payload(context),
+        "git": _git_payload(context),
+        "checks": _checks_payload(context),
+        "files": _file_payloads(context.get("changed_files") or []),
+        "comments": comments,
+        "commands": _commands(context.get("base_ref")),
+        "errors": errors,
+    }
+
+
+def render_markdown(payload):
+    pr = payload.get("pr") or {}
+    git = payload.get("git") or {}
+    checks = payload.get("checks") or {}
+    comments = payload.get("comments") or _empty_comments()
+    summary = comments.get("summary") or {}
+    lines = ["# Agent PR Context", ""]
+
+    if pr.get("number"):
+        lines.append(
+            "- PR #{} {} ({})".format(
+                pr.get("number"), pr.get("title", ""), pr.get("url", "")
+            )
+        )
+    else:
+        lines.append("- PR: not detected for current branch")
+    if pr.get("base_ref") or pr.get("head_ref"):
+        lines.append(
+            "- PR base/head: `{}` <- `{}`".format(
+                pr.get("base_ref", "?"), pr.get("head_ref", "?")
+            )
+        )
+
+    lines.extend(
+        [
+            "- Branch: `{}`".format(git.get("branch", "")),
+            "- Base ref: `{}`".format(git.get("base_ref", "")),
+            "- Merge base: `{}`".format(git.get("merge_base", "")),
+            "- Head SHA: `{}`".format(git.get("head_sha", "")),
+            "- Check status: `{}`".format(checks.get("status", "UNKNOWN")),
+        ]
+    )
+    if checks.get("review_decision"):
+        lines.append("- Review decision: `{}`".format(checks["review_decision"]))
+
+    lines.extend(["", "## Files", ""])
+    files = payload.get("files") or []
+    if files:
+        file_lines = []
+        for item in files:
+            if item.get("previous_path"):
+                file_lines.append(
+                    "{}\t{}\t{}".format(
+                        item.get("status", ""),
+                        item["previous_path"],
+                        item.get("path", ""),
+                    )
+                )
+            else:
+                file_lines.append("{}\t{}".format(item.get("status", ""), item["path"]))
+        lines.extend("```text\n{}\n```".format("\n".join(file_lines)).splitlines())
+    else:
+        lines.append("No changed files.")
+
+    lines.extend(["", "## Comments", ""])
+    lines.append("- Issue comments: {}".format(summary.get("issue_comment_count", 0)))
+    lines.append("- Review threads: {}".format(summary.get("review_thread_count", 0)))
+    for thread in comments.get("review_threads") or []:
+        resolved = "resolved" if thread.get("is_resolved") else "unresolved"
+        lines.append(
+            "- {} {}:{} ({})".format(
+                thread.get("id", ""),
+                thread.get("path", ""),
+                thread.get("line", "?"),
+                resolved,
+            )
+        )
+
+    errors = payload.get("errors") or []
+    if errors:
+        lines.extend(["", "## Errors", ""])
+        for error in errors:
+            lines.append(
+                "- {}: {}".format(error.get("stage", ""), error.get("message", ""))
+            )
+
+    lines.extend(["", "## Commands", ""])
+    command_lines = []
+    commands = payload.get("commands") or {}
+    for key in sorted(commands):
+        command_lines.append("{}: {}".format(key, commands[key]))
+    lines.extend("```text\n{}\n```".format("\n".join(command_lines)).splitlines())
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Print unified PR context for AI agent review workflows."
+    )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Base ref for diff context. Defaults to the PR base or origin/main.",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="PR number for GitHub comments. Defaults to the current branch PR.",
+    )
+    parser.add_argument(
+        "--include-resolved",
+        action="store_true",
+        help="Include resolved review threads.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit structured JSON instead of Markdown.",
+    )
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Include a bounded git diff in the output.",
+    )
+    parser.add_argument(
+        "--max-diff-lines",
+        type=int,
+        default=400,
+        help="Maximum diff lines to emit with --diff. Defaults to 400.",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    payload = collect_agent_context(
+        base_ref=args.base,
+        pr_number=args.pr,
+        include_resolved=args.include_resolved,
+        include_diff=args.diff,
+        max_diff_lines=args.max_diff_lines,
+    )
+    if args.json:
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True))
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(render_markdown(payload))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pr_agent_context.py
+++ b/scripts/pr_agent_context.py
@@ -311,7 +311,7 @@ def build_parser():
     )
     parser.add_argument(
         "--max-diff-lines",
-        type=int,
+        type=pr_review_context.non_negative_int,
         default=400,
         help="Maximum diff lines to emit with --diff. Defaults to 400.",
     )

--- a/scripts/pr_review_context.py
+++ b/scripts/pr_review_context.py
@@ -14,8 +14,22 @@ PR_JSON_FIELDS = (
     "number,title,url,baseRefName,headRefName,statusCheckRollup,reviewDecision,comments"
 )
 PR_FALLBACK_JSON_FIELDS = "number,title,url,baseRefName,headRefName,reviewDecision,comments"
-FAILING_CHECK_STATES = ("FAILURE", "ERROR", "CANCELLED", "TIMED_OUT")
-PENDING_CHECK_STATES = ("PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED", "WAITING")
+FAILING_CHECK_STATES = (
+    "FAILURE",
+    "ERROR",
+    "CANCELLED",
+    "TIMED_OUT",
+    "ACTION_REQUIRED",
+    "STARTUP_FAILURE",
+)
+PENDING_CHECK_STATES = (
+    "PENDING",
+    "QUEUED",
+    "IN_PROGRESS",
+    "REQUESTED",
+    "WAITING",
+    "EXPECTED",
+)
 PASSING_CHECK_STATES = ("SUCCESS", "COMPLETED", "NEUTRAL", "SKIPPED")
 
 

--- a/scripts/pr_review_context.py
+++ b/scripts/pr_review_context.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Print a compact context packet for local or GitHub PR review."""
+
+import argparse
+import json
+import subprocess
+import sys
+
+PR_JSON_FIELDS = (
+    "number,title,url,baseRefName,headRefName,statusCheckRollup,reviewDecision"
+)
+FAILING_CHECK_STATES = ("FAILURE", "ERROR", "CANCELLED", "TIMED_OUT")
+PENDING_CHECK_STATES = ("PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED")
+PASSING_CHECK_STATES = ("SUCCESS", "COMPLETED", "NEUTRAL", "SKIPPED")
+
+
+def run_command(args, cwd=None, check=True):
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _stdout(result):
+    return result.stdout.strip()
+
+
+def _run_optional(args, runner=run_command, cwd=None):
+    try:
+        return runner(args, cwd=cwd)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _json_optional(args, runner=run_command, cwd=None):
+    result = _run_optional(args, runner=runner, cwd=cwd)
+    if result is None or result.returncode not in (0, None):
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _git_stdout(args, runner=run_command, cwd=None):
+    return _stdout(runner(args, cwd=cwd))
+
+
+def _split_lines(text):
+    if not text:
+        return []
+    return [line for line in text.splitlines() if line.strip()]
+
+
+def _summarize_checks(pr):
+    if not pr:
+        return "UNKNOWN"
+    checks = pr.get("statusCheckRollup") or []
+    if not checks:
+        return "UNKNOWN"
+
+    states = []
+    for check in checks:
+        state = check.get("state") or check.get("conclusion") or check.get("status")
+        if state:
+            states.append(state.upper())
+
+    if not states:
+        return "UNKNOWN"
+    if any(state in FAILING_CHECK_STATES for state in states):
+        return "FAILING"
+    if any(state in PENDING_CHECK_STATES for state in states):
+        return "PENDING"
+    if all(state in PASSING_CHECK_STATES for state in states):
+        return "PASSING"
+    return "UNKNOWN"
+
+
+def _bounded_text(text, max_lines):
+    lines = text.splitlines()
+    if max_lines is None or len(lines) <= max_lines:
+        return text.strip(), False
+    return "\n".join(lines[:max_lines]).rstrip(), True
+
+
+def collect_context(
+    base_ref=None, include_diff=False, max_diff_lines=400, runner=run_command
+):
+    root = _git_stdout(["git", "rev-parse", "--show-toplevel"], runner=runner)
+    branch = _git_stdout(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], runner=runner, cwd=root
+    )
+    head_sha = _git_stdout(["git", "rev-parse", "HEAD"], runner=runner, cwd=root)
+    pr = _json_optional(["gh", "pr", "view", "--json", PR_JSON_FIELDS], runner=runner)
+
+    if base_ref is None:
+        if pr and pr.get("baseRefName"):
+            base_ref = "origin/{}".format(pr["baseRefName"])
+        else:
+            base_ref = "origin/main"
+
+    merge_base = _git_stdout(["git", "merge-base", base_ref, "HEAD"], runner=runner)
+    diff_range = "{}...HEAD".format(base_ref)
+    changed_files = _split_lines(
+        _git_stdout(
+            ["git", "diff", "--name-status", diff_range], runner=runner, cwd=root
+        )
+    )
+    diff_stat = _git_stdout(
+        ["git", "diff", "--stat", diff_range], runner=runner, cwd=root
+    )
+    commits = _split_lines(
+        _git_stdout(
+            ["git", "log", "--oneline", "{}..HEAD".format(base_ref)],
+            runner=runner,
+            cwd=root,
+        )
+    )
+    diff = None
+    diff_truncated = False
+    if include_diff:
+        diff_output = _git_stdout(["git", "diff", diff_range], runner=runner, cwd=root)
+        diff, diff_truncated = _bounded_text(diff_output, max_diff_lines)
+
+    return {
+        "branch": branch,
+        "base_ref": base_ref,
+        "head_sha": head_sha,
+        "merge_base": merge_base,
+        "pr": pr,
+        "status": _summarize_checks(pr),
+        "changed_files": changed_files,
+        "diff_stat": diff_stat,
+        "commits": commits,
+        "diff": diff,
+        "diff_truncated": diff_truncated,
+    }
+
+
+def _changed_file_paths(changed_files):
+    paths = []
+    for line in changed_files:
+        parts = line.split("\t")
+        if len(parts) >= 3:
+            paths.append(parts[-1])
+        elif len(parts) >= 2:
+            paths.append(parts[1])
+    return paths
+
+
+def render_markdown(data):
+    pr = data.get("pr")
+    lines = ["# PR Review Context", ""]
+    if pr:
+        lines.append(
+            "- PR: #{} {} ({})".format(
+                pr.get("number"), pr.get("title", ""), pr.get("url", "")
+            )
+        )
+        lines.append(
+            "- PR base/head: `{}` <- `{}`".format(
+                pr.get("baseRefName", "?"), pr.get("headRefName", "?")
+            )
+        )
+        if pr.get("reviewDecision"):
+            lines.append("- Review decision: `{}`".format(pr["reviewDecision"]))
+    else:
+        lines.append("- PR: not detected for current branch")
+
+    lines.extend(
+        [
+            "- Branch: `{}`".format(data.get("branch", "")),
+            "- Base ref: `{}`".format(data.get("base_ref", "")),
+            "- Merge base: `{}`".format(data.get("merge_base", "")),
+            "- Head SHA: `{}`".format(data.get("head_sha", "")),
+            "- Check status: `{}`".format(data.get("status", "UNKNOWN")),
+            "",
+            "## Changed Files",
+            "",
+        ]
+    )
+
+    changed_files = data.get("changed_files") or []
+    if changed_files:
+        lines.extend("```text\n{}\n```".format("\n".join(changed_files)).splitlines())
+    else:
+        lines.append("No changed files.")
+
+    lines.extend(["", "## Diff Stat", ""])
+    diff_stat = data.get("diff_stat") or "No diff stat."
+    lines.extend("```text\n{}\n```".format(diff_stat).splitlines())
+
+    lines.extend(["", "## Commits", ""])
+    commits = data.get("commits") or []
+    if commits:
+        lines.extend("```text\n{}\n```".format("\n".join(commits)).splitlines())
+    else:
+        lines.append("No commits ahead of base.")
+
+    lines.extend(["", "## Review Commands", ""])
+    lines.extend(
+        "```bash\n{}\n```".format(
+            "\n".join(
+                [
+                    "git diff {}...HEAD --stat".format(data.get("base_ref", "")),
+                    "git diff {}...HEAD -- <path>".format(data.get("base_ref", "")),
+                    "python3 scripts/fetch_comments.py --json",
+                    "just lint",
+                    "just test",
+                ]
+            )
+        ).splitlines()
+    )
+
+    file_paths = _changed_file_paths(changed_files)
+    if file_paths:
+        lines.extend(["", "## Per-File Diff Commands", ""])
+        lines.extend(
+            "```bash\n{}\n```".format(
+                "\n".join(
+                    "git diff {}...HEAD -- {}".format(data.get("base_ref", ""), path)
+                    for path in file_paths
+                )
+            ).splitlines()
+        )
+
+    if data.get("diff"):
+        lines.extend(["", "## Bounded Diff", ""])
+        if data.get("diff_truncated"):
+            lines.append(
+                "Diff output was truncated. Re-run with a larger "
+                "`--max-diff-lines` if needed."
+            )
+            lines.append("")
+        lines.extend("```diff\n{}\n```".format(data["diff"]).splitlines())
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Print branch and PR context for code review."
+    )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Base ref for diff context. Defaults to the PR base or origin/main.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of Markdown.",
+    )
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Include a bounded git diff in the output.",
+    )
+    parser.add_argument(
+        "--max-diff-lines",
+        type=int,
+        default=400,
+        help="Maximum diff lines to emit with --diff. Defaults to 400.",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    data = collect_context(
+        base_ref=args.base,
+        include_diff=args.diff,
+        max_diff_lines=args.max_diff_lines,
+    )
+    if args.json:
+        sys.stdout.write(json.dumps(data, indent=2, sort_keys=True))
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(render_markdown(data))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pr_review_context.py
+++ b/scripts/pr_review_context.py
@@ -13,8 +13,9 @@ import sys
 PR_JSON_FIELDS = (
     "number,title,url,baseRefName,headRefName,statusCheckRollup,reviewDecision,comments"
 )
+PR_FALLBACK_JSON_FIELDS = "number,title,url,baseRefName,headRefName,reviewDecision,comments"
 FAILING_CHECK_STATES = ("FAILURE", "ERROR", "CANCELLED", "TIMED_OUT")
-PENDING_CHECK_STATES = ("PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED")
+PENDING_CHECK_STATES = ("PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED", "WAITING")
 PASSING_CHECK_STATES = ("SUCCESS", "COMPLETED", "NEUTRAL", "SKIPPED")
 
 
@@ -48,6 +49,15 @@ def _json_optional(args, runner=run_command, cwd=None):
         return json.loads(result.stdout)
     except json.JSONDecodeError:
         return None
+
+
+def _current_pr(runner=run_command):
+    pr = _json_optional(["gh", "pr", "view", "--json", PR_JSON_FIELDS], runner=runner)
+    if pr is not None:
+        return pr
+    return _json_optional(
+        ["gh", "pr", "view", "--json", PR_FALLBACK_JSON_FIELDS], runner=runner
+    )
 
 
 def _git_stdout(args, runner=run_command, cwd=None):
@@ -85,10 +95,19 @@ def _summarize_checks(pr):
 
 
 def _bounded_text(text, max_lines):
+    if max_lines is not None and max_lines < 0:
+        raise ValueError("max_diff_lines must be >= 0")
     lines = text.splitlines()
     if max_lines is None or len(lines) <= max_lines:
         return text.strip(), False
     return "\n".join(lines[:max_lines]).rstrip(), True
+
+
+def non_negative_int(value):
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
 
 
 def collect_context(
@@ -99,7 +118,7 @@ def collect_context(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"], runner=runner, cwd=root
     )
     head_sha = _git_stdout(["git", "rev-parse", "HEAD"], runner=runner, cwd=root)
-    pr = _json_optional(["gh", "pr", "view", "--json", PR_JSON_FIELDS], runner=runner)
+    pr = _current_pr(runner=runner)
 
     if base_ref is None:
         if pr and pr.get("baseRefName"):
@@ -214,8 +233,12 @@ def render_markdown(data):
         "```bash\n{}\n```".format(
             "\n".join(
                 [
-                    "git diff {}...HEAD --stat".format(data.get("base_ref", "")),
-                    "git diff {}...HEAD -- <path>".format(data.get("base_ref", "")),
+                    "git diff {} --stat".format(
+                        _quote("{}...HEAD".format(data.get("base_ref", "")))
+                    ),
+                    "git diff {} -- <path>".format(
+                        _quote("{}...HEAD".format(data.get("base_ref", "")))
+                    ),
                     "python3 scripts/fetch_comments.py --json",
                     "just lint",
                     "just test",
@@ -273,7 +296,7 @@ def build_parser():
     )
     parser.add_argument(
         "--max-diff-lines",
-        type=int,
+        type=non_negative_int,
         default=400,
         help="Maximum diff lines to emit with --diff. Defaults to 400.",
     )

--- a/scripts/pr_review_context.py
+++ b/scripts/pr_review_context.py
@@ -6,11 +6,12 @@
 
 import argparse
 import json
+import shlex
 import subprocess
 import sys
 
 PR_JSON_FIELDS = (
-    "number,title,url,baseRefName,headRefName,statusCheckRollup,reviewDecision"
+    "number,title,url,baseRefName,headRefName,statusCheckRollup,reviewDecision,comments"
 )
 FAILING_CHECK_STATES = ("FAILURE", "ERROR", "CANCELLED", "TIMED_OUT")
 PENDING_CHECK_STATES = ("PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED")
@@ -155,6 +156,10 @@ def _changed_file_paths(changed_files):
     return paths
 
 
+def _quote(value):
+    return shlex.quote(str(value))
+
+
 def render_markdown(data):
     pr = data.get("pr")
     lines = ["# PR Review Context", ""]
@@ -225,7 +230,10 @@ def render_markdown(data):
         lines.extend(
             "```bash\n{}\n```".format(
                 "\n".join(
-                    "git diff {}...HEAD -- {}".format(data.get("base_ref", ""), path)
+                    "git diff {} -- {}".format(
+                        _quote("{}...HEAD".format(data.get("base_ref", ""))),
+                        _quote(path),
+                    )
                     for path in file_paths
                 )
             ).splitlines()

--- a/tests/test_pr_review_tools.py
+++ b/tests/test_pr_review_tools.py
@@ -143,6 +143,45 @@ def test_fetch_comments_emits_agent_json_with_stable_ids():
     assert payload["review_threads"][0]["line"] == 42
 
 
+def test_fetch_comments_includes_top_level_review_bodies():
+    pr = {
+        "number": 7,
+        "title": "Tighten proxy fallback",
+        "url": "https://pr",
+        "comments": [],
+        "reviews": [
+            {
+                "id": "REVIEW_changes",
+                "author": {"login": "reviewer"},
+                "body": "Please address the deployment note.",
+                "submittedAt": "2026-05-26T13:00:00Z",
+                "state": "CHANGES_REQUESTED",
+            },
+            {
+                "id": "REVIEW_empty",
+                "author": {"login": "reviewer"},
+                "body": "",
+                "submittedAt": "2026-05-26T14:00:00Z",
+                "state": "COMMENTED",
+            },
+        ],
+    }
+    thread_data = {
+        "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}
+    }
+
+    payload = fetch_comments.build_agent_payload(
+        pr, thread_data, include_resolved=False
+    )
+
+    assert payload["summary"]["issue_comment_count"] == 1
+    assert payload["issue_comments"][0]["id"] == "REVIEW_changes"
+    assert payload["issue_comments"][0]["author"] == "reviewer"
+    assert payload["issue_comments"][0]["created_at"] == "2026-05-26T13:00:00Z"
+    assert "[CHANGES_REQUESTED]" in payload["issue_comments"][0]["body"]
+    assert "Please address the deployment note." in payload["issue_comments"][0]["body"]
+
+
 def test_fetch_comments_rejects_malformed_repo_name():
     with pytest.raises(SystemExit, match="OWNER/REPO"):
         fetch_comments.split_repo("not-a-slash-repo")
@@ -537,6 +576,18 @@ def test_pr_review_context_treats_waiting_checks_as_pending():
     assert status == "PENDING"
 
 
+@pytest.mark.parametrize("state", ["EXPECTED", "ACTION_REQUIRED", "STARTUP_FAILURE"])
+def test_pr_review_context_classifies_additional_check_states(state):
+    status = pr_review_context._summarize_checks(
+        {"statusCheckRollup": [{"state": state}]}
+    )
+
+    if state == "EXPECTED":
+        assert status == "PENDING"
+    else:
+        assert status == "FAILING"
+
+
 def test_pr_agent_context_emits_unified_agent_json(tmp_path):
     def runner(args, cwd=None, check=True):
         if args[:3] == ["git", "rev-parse", "--show-toplevel"]:
@@ -762,7 +813,7 @@ def test_pr_agent_context_keeps_local_context_when_comments_fail(tmp_path):
     assert payload["errors"] == [
         {
             "stage": "comments",
-            "command": "gh pr view --json number,title,url,comments",
+            "command": "gh pr view --json number,title,url,comments,reviews",
             "message": "gh auth token is unavailable",
         }
     ]

--- a/tests/test_pr_review_tools.py
+++ b/tests/test_pr_review_tools.py
@@ -148,6 +148,143 @@ def test_fetch_comments_rejects_malformed_repo_name():
         fetch_comments.split_repo("not-a-slash-repo")
 
 
+def test_fetch_comments_paginates_review_threads_and_comments():
+    calls = []
+
+    def runner(args, cwd=None, check=True):
+        calls.append(args)
+        if "thread_id=THREAD_two" in args:
+            assert "comments_after=COMMENT_CURSOR" in args
+            return completed(
+                json.dumps(
+                    {
+                        "data": {
+                            "node": {
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "COMMENT_two_b",
+                                            "author": {"login": "reviewer"},
+                                            "body": "Second page comment.",
+                                            "createdAt": "2026-05-26T12:02:00Z",
+                                            "url": "https://comment-two-b",
+                                        }
+                                    ],
+                                    "pageInfo": {
+                                        "hasNextPage": False,
+                                        "endCursor": None,
+                                    },
+                                }
+                            }
+                        }
+                    }
+                )
+            )
+        if "review_threads_after=THREAD_CURSOR" in args:
+            return completed(
+                json.dumps(
+                    {
+                        "data": {
+                            "repository": {
+                                "pullRequest": {
+                                    "reviewThreads": {
+                                        "nodes": [
+                                            {
+                                                "id": "THREAD_two",
+                                                "isResolved": False,
+                                                "path": "scripts/two.py",
+                                                "line": 20,
+                                                "comments": {
+                                                    "nodes": [
+                                                        {
+                                                            "id": "COMMENT_two_a",
+                                                            "author": {
+                                                                "login": "reviewer"
+                                                            },
+                                                            "body": (
+                                                                "First page comment."
+                                                            ),
+                                                            "createdAt": (
+                                                                "2026-05-26T12:01:00Z"
+                                                            ),
+                                                            "url": (
+                                                                "https://comment-two-a"
+                                                            ),
+                                                        }
+                                                    ],
+                                                    "pageInfo": {
+                                                        "hasNextPage": True,
+                                                        "endCursor": "COMMENT_CURSOR",
+                                                    },
+                                                },
+                                            }
+                                        ],
+                                        "pageInfo": {
+                                            "hasNextPage": False,
+                                            "endCursor": None,
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
+            )
+        return completed(
+            json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "nodes": [
+                                        {
+                                            "id": "THREAD_one",
+                                            "isResolved": False,
+                                            "path": "scripts/one.py",
+                                            "line": 10,
+                                            "comments": {
+                                                "nodes": [
+                                                    {
+                                                        "id": "COMMENT_one",
+                                                        "author": {"login": "reviewer"},
+                                                        "body": "Only comment.",
+                                                        "createdAt": (
+                                                            "2026-05-26T12:00:00Z"
+                                                        ),
+                                                        "url": "https://comment-one",
+                                                    }
+                                                ],
+                                                "pageInfo": {
+                                                    "hasNextPage": False,
+                                                    "endCursor": None,
+                                                },
+                                            },
+                                        }
+                                    ],
+                                    "pageInfo": {
+                                        "hasNextPage": True,
+                                        "endCursor": "THREAD_CURSOR",
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        )
+
+    data = fetch_comments.review_threads("owner", "repo", 7, runner=runner)
+    threads = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+
+    assert [thread["id"] for thread in threads] == ["THREAD_one", "THREAD_two"]
+    assert [comment["id"] for comment in threads[1]["comments"]["nodes"]] == [
+        "COMMENT_two_a",
+        "COMMENT_two_b",
+    ]
+    assert len(calls) == 3
+
+
 def test_pr_review_context_renders_markdown_packet():
     data = {
         "branch": "feature/pr-tools",
@@ -206,6 +343,25 @@ def test_pr_review_context_quotes_diff_command_paths():
     assert (
         "git diff origin/main...HEAD -- 'path with spaces/review helper.py'" in output
     )
+
+
+def test_pr_review_context_quotes_base_ref_in_review_commands():
+    data = {
+        "branch": "feature/pr-tools",
+        "base_ref": "origin/base&branch",
+        "head_sha": "abc123",
+        "merge_base": "def456",
+        "pr": None,
+        "status": "UNKNOWN",
+        "changed_files": [],
+        "diff_stat": " 1 file changed",
+        "commits": [],
+    }
+
+    output = pr_review_context.render_markdown(data)
+
+    assert "git diff 'origin/base&branch...HEAD' --stat" in output
+    assert "git diff 'origin/base&branch...HEAD' -- <path>" in output
 
 
 def test_pr_review_context_omits_diff_by_default():
@@ -271,6 +427,65 @@ def test_pr_review_context_collects_data_with_injected_runner(tmp_path):
     assert ["gh", "pr", "view", "--json", pr_review_context.PR_JSON_FIELDS] in calls
 
 
+def test_pr_review_context_falls_back_when_status_rollup_is_unavailable(tmp_path):
+    calls = []
+
+    def runner(args, cwd=None, check=True):
+        calls.append(args)
+        if args[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return completed(str(tmp_path))
+        if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return completed("feature/pr-tools")
+        if args[:3] == ["git", "rev-parse", "HEAD"]:
+            return completed("abc123")
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and pr_review_context.PR_JSON_FIELDS in args
+        ):
+            raise subprocess.CalledProcessError(
+                1, args, stderr="Field 'statusCheckRollup' doesn't exist\n"
+            )
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and pr_review_context.PR_FALLBACK_JSON_FIELDS in args
+        ):
+            return completed(
+                json.dumps(
+                    {
+                        "number": 7,
+                        "title": "Add PR helpers",
+                        "url": "https://pr",
+                        "baseRefName": "main",
+                        "headRefName": "feature/pr-tools",
+                        "reviewDecision": "REVIEW_REQUIRED",
+                    }
+                )
+            )
+        if args[:4] == ["git", "merge-base", "origin/main", "HEAD"]:
+            return completed("def456")
+        if args[:3] == ["git", "diff", "--name-status"]:
+            return completed("A\tscripts/fetch_comments.py")
+        if args[:3] == ["git", "diff", "--stat"]:
+            return completed(" 1 file changed, 100 insertions(+)")
+        if args[:3] == ["git", "log", "--oneline"]:
+            return completed("abc123 Add PR helpers")
+        raise AssertionError("unexpected command: {}".format(args))
+
+    data = pr_review_context.collect_context(runner=runner)
+
+    assert data["pr"]["number"] == 7
+    assert data["pr"]["baseRefName"] == "main"
+    assert data["status"] == "UNKNOWN"
+    assert ["gh", "pr", "view", "--json", pr_review_context.PR_JSON_FIELDS] in calls
+    assert [
+        "gh",
+        "pr",
+        "view",
+        "--json",
+        pr_review_context.PR_FALLBACK_JSON_FIELDS,
+    ] in calls
+
+
 def test_pr_review_context_collects_bounded_diff_when_requested(tmp_path):
     def runner(args, cwd=None, check=True):
         if args[:3] == ["git", "rev-parse", "--show-toplevel"]:
@@ -299,6 +514,27 @@ def test_pr_review_context_collects_bounded_diff_when_requested(tmp_path):
 
     assert data["diff"] == "line0\nline1\nline2"
     assert data["diff_truncated"] is True
+
+
+def test_pr_review_context_rejects_negative_max_diff_lines():
+    with pytest.raises(ValueError, match="max_diff_lines"):
+        pr_review_context._bounded_text("line0\nline1", -1)
+
+    with pytest.raises(SystemExit):
+        pr_review_context.build_parser().parse_args(["--max-diff-lines", "-1"])
+
+
+def test_pr_agent_context_rejects_negative_max_diff_lines():
+    with pytest.raises(SystemExit):
+        pr_agent_context.build_parser().parse_args(["--max-diff-lines", "-1"])
+
+
+def test_pr_review_context_treats_waiting_checks_as_pending():
+    status = pr_review_context._summarize_checks(
+        {"statusCheckRollup": [{"state": "WAITING"}]}
+    )
+
+    assert status == "PENDING"
 
 
 def test_pr_agent_context_emits_unified_agent_json(tmp_path):

--- a/tests/test_pr_review_tools.py
+++ b/tests/test_pr_review_tools.py
@@ -188,6 +188,26 @@ def test_pr_review_context_renders_markdown_packet():
     assert "+print('hello')" in output
 
 
+def test_pr_review_context_quotes_diff_command_paths():
+    data = {
+        "branch": "feature/pr-tools",
+        "base_ref": "origin/main",
+        "head_sha": "abc123",
+        "merge_base": "def456",
+        "pr": None,
+        "status": "UNKNOWN",
+        "changed_files": ["A\tpath with spaces/review helper.py"],
+        "diff_stat": " 1 file changed",
+        "commits": [],
+    }
+
+    output = pr_review_context.render_markdown(data)
+
+    assert (
+        "git diff origin/main...HEAD -- 'path with spaces/review helper.py'" in output
+    )
+
+
 def test_pr_review_context_omits_diff_by_default():
     data = {
         "branch": "feature/pr-tools",
@@ -318,16 +338,6 @@ def test_pr_agent_context_emits_unified_agent_json(tmp_path):
                         "headRefName": "feature/pr-tools",
                         "reviewDecision": "REVIEW_REQUIRED",
                         "statusCheckRollup": [{"state": "SUCCESS"}],
-                    }
-                )
-            )
-        if args[:3] == ["gh", "pr", "view"] and fetch_comments.PR_JSON_FIELDS in args:
-            return completed(
-                json.dumps(
-                    {
-                        "number": 7,
-                        "title": "Add PR helpers",
-                        "url": "https://pr",
                         "comments": [
                             {
                                 "id": "ISSUE_comment",
@@ -340,6 +350,8 @@ def test_pr_agent_context_emits_unified_agent_json(tmp_path):
                     }
                 )
             )
+        if args[:3] == ["gh", "pr", "view"] and fetch_comments.PR_JSON_FIELDS in args:
+            raise AssertionError("wrapper should reuse PR data from local context")
         if args[:3] == ["gh", "repo", "view"]:
             return completed(json.dumps({"nameWithOwner": "owner/repo"}))
         if args[:4] == ["gh", "api", "graphql", "-f"]:
@@ -398,6 +410,74 @@ def test_pr_agent_context_emits_unified_agent_json(tmp_path):
         "python3 scripts/pr_agent_context.py --json"
     )
     assert not payload["errors"]
+
+
+def test_pr_agent_context_preserves_issue_comments_when_threads_fail(tmp_path):
+    def runner(args, cwd=None, check=True):
+        if args[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return completed(str(tmp_path))
+        if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return completed("feature/pr-tools")
+        if args[:3] == ["git", "rev-parse", "HEAD"]:
+            return completed("abc123")
+        if args[:4] == ["git", "merge-base", "origin/main", "HEAD"]:
+            return completed("def456")
+        if args[:3] == ["git", "diff", "--name-status"]:
+            return completed("M\tscripts/pr_agent_context.py")
+        if args[:3] == ["git", "diff", "--stat"]:
+            return completed(" 1 file changed, 20 insertions(+)")
+        if args[:3] == ["git", "log", "--oneline"]:
+            return completed("abc123 Add agent PR wrapper")
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and pr_review_context.PR_JSON_FIELDS in args
+        ):
+            return completed(
+                json.dumps(
+                    {
+                        "number": 7,
+                        "title": "Add PR helpers",
+                        "url": "https://pr",
+                        "baseRefName": "main",
+                        "headRefName": "feature/pr-tools",
+                        "statusCheckRollup": [],
+                        "comments": [
+                            {
+                                "id": "ISSUE_comment",
+                                "author": {"login": "maintainer"},
+                                "body": "Please check CI.",
+                                "createdAt": "2026-05-26T11:00:00Z",
+                                "url": "https://issue-comment",
+                            }
+                        ],
+                    }
+                )
+            )
+        if args[:3] == ["gh", "repo", "view"]:
+            return completed(json.dumps({"nameWithOwner": "owner/repo"}))
+        if args[:4] == ["gh", "api", "graphql", "-f"]:
+            raise subprocess.CalledProcessError(
+                1, args, stderr="GraphQL rate limit exceeded\n"
+            )
+        raise AssertionError("unexpected command: {}".format(args))
+
+    payload = pr_agent_context.collect_agent_context(runner=runner)
+
+    assert payload["comments"]["summary"]["issue_comment_count"] == 1
+    assert payload["comments"]["issue_comments"][0]["id"] == "ISSUE_comment"
+    assert payload["comments"]["summary"]["review_thread_count"] == 0
+    assert payload["errors"][0]["stage"] == "review_threads"
+    assert payload["errors"][0]["command"].startswith(
+        "gh api graphql -f owner=owner -f name=repo -F number=7 -f "
+    )
+    assert payload["errors"][0]["message"] == "GraphQL rate limit exceeded"
+
+
+def test_pr_agent_context_quotes_displayed_commands():
+    commands = pr_agent_context._commands("origin/base branch")
+
+    assert commands["diff_stat"] == "git diff 'origin/base branch...HEAD' --stat"
+    assert commands["diff"] == "git diff 'origin/base branch...HEAD'"
 
 
 def test_pr_agent_context_keeps_local_context_when_comments_fail(tmp_path):

--- a/tests/test_pr_review_tools.py
+++ b/tests/test_pr_review_tools.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+import json
+import subprocess
+
+import pytest
+
+from scripts import fetch_comments, pr_review_context
+
+
+def test_fetch_comments_formats_unresolved_review_threads():
+    pr = {"number": 7, "title": "Tighten proxy fallback", "url": "https://pr"}
+    thread_data = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "isResolved": False,
+                                "path": (
+                                    "repo/plugin.video.nzbdav/resources/lib/resolver.py"
+                                ),
+                                "line": 42,
+                                "id": "THREAD_unresolved",
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "COMMENT_timeout",
+                                            "author": {"login": "reviewer"},
+                                            "body": "This misses the timeout path.",
+                                            "createdAt": "2026-05-26T12:00:00Z",
+                                            "url": "https://comment",
+                                        }
+                                    ]
+                                },
+                            },
+                            {
+                                "isResolved": True,
+                                "path": "tests/test_resolver.py",
+                                "line": 9,
+                                "comments": {"nodes": []},
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    output = fetch_comments.render_comments(pr, thread_data, include_resolved=False)
+
+    assert "PR #7: Tighten proxy fallback" in output
+    assert (
+        "[1] THREAD_unresolved repo/plugin.video.nzbdav/resources/lib/resolver.py:42"
+        in output
+    )
+    assert "COMMENT_timeout reviewer at 2026-05-26T12:00:00Z" in output
+    assert "reviewer at 2026-05-26T12:00:00Z" in output
+    assert "This misses the timeout path." in output
+    assert "tests/test_resolver.py" not in output
+
+
+def test_fetch_comments_reports_no_comments():
+    pr = {"number": 7, "title": "Tighten proxy fallback", "url": "https://pr"}
+    thread_data = {
+        "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}
+    }
+
+    output = fetch_comments.render_comments(pr, thread_data)
+
+    assert "No review threads found." in output
+
+
+def test_fetch_comments_emits_agent_json_with_stable_ids():
+    pr = {
+        "number": 7,
+        "title": "Tighten proxy fallback",
+        "url": "https://pr",
+        "comments": [
+            {
+                "id": "ISSUE_comment",
+                "author": {"login": "maintainer"},
+                "body": "Please check CI.",
+                "createdAt": "2026-05-26T11:00:00Z",
+                "url": "https://issue-comment",
+            }
+        ],
+    }
+    thread_data = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": "THREAD_unresolved",
+                                "isResolved": False,
+                                "path": (
+                                    "repo/plugin.video.nzbdav/resources/lib/resolver.py"
+                                ),
+                                "line": 42,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "COMMENT_timeout",
+                                            "author": {"login": "reviewer"},
+                                            "body": "This misses the timeout path.",
+                                            "createdAt": "2026-05-26T12:00:00Z",
+                                            "url": "https://comment",
+                                        }
+                                    ]
+                                },
+                            },
+                            {
+                                "id": "THREAD_resolved",
+                                "isResolved": True,
+                                "path": "tests/test_resolver.py",
+                                "line": 9,
+                                "comments": {"nodes": []},
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    payload = fetch_comments.build_agent_payload(
+        pr, thread_data, include_resolved=False
+    )
+
+    assert payload["pr"]["number"] == 7
+    assert payload["summary"]["issue_comment_count"] == 1
+    assert payload["summary"]["review_thread_count"] == 1
+    assert payload["issue_comments"][0]["id"] == "ISSUE_comment"
+    assert payload["review_threads"][0]["id"] == "THREAD_unresolved"
+    assert payload["review_threads"][0]["comments"][0]["id"] == "COMMENT_timeout"
+    assert payload["review_threads"][0]["path"] == (
+        "repo/plugin.video.nzbdav/resources/lib/resolver.py"
+    )
+    assert payload["review_threads"][0]["line"] == 42
+
+
+def test_fetch_comments_rejects_malformed_repo_name():
+    with pytest.raises(SystemExit, match="OWNER/REPO"):
+        fetch_comments.split_repo("not-a-slash-repo")
+
+
+def test_pr_review_context_renders_markdown_packet():
+    data = {
+        "branch": "feature/pr-tools",
+        "base_ref": "origin/main",
+        "head_sha": "abc123",
+        "merge_base": "def456",
+        "pr": {
+            "number": 7,
+            "title": "Add PR helpers",
+            "url": "https://pr",
+            "baseRefName": "main",
+            "headRefName": "feature/pr-tools",
+            "reviewDecision": "CHANGES_REQUESTED",
+        },
+        "status": "PASSING",
+        "changed_files": [
+            "A\tscripts/fetch_comments.py",
+            "A\tscripts/pr_review_context.py",
+        ],
+        "diff_stat": " 2 files changed, 200 insertions(+)",
+        "commits": ["abc123 Add PR helpers"],
+        "diff": "diff --git a/scripts/a.py b/scripts/a.py\n+print('hello')",
+        "diff_truncated": False,
+    }
+
+    output = pr_review_context.render_markdown(data)
+
+    assert "# PR Review Context" in output
+    assert "- PR: #7 Add PR helpers (https://pr)" in output
+    assert "- Review decision: `CHANGES_REQUESTED`" in output
+    assert "- Branch: `feature/pr-tools`" in output
+    assert "A\tscripts/fetch_comments.py" in output
+    assert "2 files changed" in output
+    assert "abc123 Add PR helpers" in output
+    assert "## Review Commands" in output
+    assert "git diff origin/main...HEAD -- scripts/fetch_comments.py" in output
+    assert "## Bounded Diff" in output
+    assert "+print('hello')" in output
+
+
+def test_pr_review_context_omits_diff_by_default():
+    data = {
+        "branch": "feature/pr-tools",
+        "base_ref": "origin/main",
+        "head_sha": "abc123",
+        "merge_base": "def456",
+        "pr": None,
+        "status": "UNKNOWN",
+        "changed_files": [],
+        "diff_stat": "",
+        "commits": [],
+    }
+
+    output = pr_review_context.render_markdown(data)
+
+    assert "## Bounded Diff" not in output
+
+
+def test_pr_review_context_collects_data_with_injected_runner(tmp_path):
+    calls = []
+
+    def runner(args, cwd=None, check=True):
+        calls.append(args)
+        if args[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return completed(str(tmp_path))
+        if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return completed("feature/pr-tools")
+        if args[:3] == ["git", "rev-parse", "HEAD"]:
+            return completed("abc123")
+        if args[:4] == ["git", "merge-base", "origin/main", "HEAD"]:
+            return completed("def456")
+        if args[:3] == ["git", "diff", "--name-status"]:
+            return completed("A\tscripts/fetch_comments.py")
+        if args[:3] == ["git", "diff", "--stat"]:
+            return completed(" 1 file changed, 100 insertions(+)")
+        if args[:3] == ["git", "log", "--oneline"]:
+            return completed("abc123 Add PR helpers")
+        if args[:3] == ["gh", "pr", "view"] and "--json" in args:
+            return completed(
+                json.dumps(
+                    {
+                        "number": 7,
+                        "title": "Add PR helpers",
+                        "url": "https://pr",
+                        "baseRefName": "main",
+                        "headRefName": "feature/pr-tools",
+                        "statusCheckRollup": [],
+                    }
+                )
+            )
+        raise AssertionError("unexpected command: {}".format(args))
+
+    data = pr_review_context.collect_context(runner=runner)
+
+    assert data["branch"] == "feature/pr-tools"
+    assert data["base_ref"] == "origin/main"
+    assert data["head_sha"] == "abc123"
+    assert data["merge_base"] == "def456"
+    assert data["status"] == "UNKNOWN"
+    assert data["changed_files"] == ["A\tscripts/fetch_comments.py"]
+    assert ["gh", "pr", "view", "--json", pr_review_context.PR_JSON_FIELDS] in calls
+
+
+def test_pr_review_context_collects_bounded_diff_when_requested(tmp_path):
+    def runner(args, cwd=None, check=True):
+        if args[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return completed(str(tmp_path))
+        if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return completed("feature/pr-tools")
+        if args[:3] == ["git", "rev-parse", "HEAD"]:
+            return completed("abc123")
+        if args[:3] == ["gh", "pr", "view"]:
+            raise subprocess.CalledProcessError(1, args)
+        if args[:4] == ["git", "merge-base", "origin/main", "HEAD"]:
+            return completed("def456")
+        if args[:3] == ["git", "diff", "--name-status"]:
+            return completed("M\tscripts/pr_review_context.py")
+        if args[:3] == ["git", "diff", "--stat"]:
+            return completed(" 1 file changed, 100 insertions(+)")
+        if args[:3] == ["git", "log", "--oneline"]:
+            return completed("abc123 Add PR helpers")
+        if args[:2] == ["git", "diff"] and "--" not in args:
+            return completed("\n".join(["line{}".format(index) for index in range(5)]))
+        raise AssertionError("unexpected command: {}".format(args))
+
+    data = pr_review_context.collect_context(
+        include_diff=True, max_diff_lines=3, runner=runner
+    )
+
+    assert data["diff"] == "line0\nline1\nline2"
+    assert data["diff_truncated"] is True
+
+
+def completed(stdout):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout + "\n")

--- a/tests/test_pr_review_tools.py
+++ b/tests/test_pr_review_tools.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 
-from scripts import fetch_comments, pr_review_context
+from scripts import fetch_comments, pr_agent_context, pr_review_context
 
 
 def test_fetch_comments_formats_unresolved_review_threads():
@@ -281,5 +281,235 @@ def test_pr_review_context_collects_bounded_diff_when_requested(tmp_path):
     assert data["diff_truncated"] is True
 
 
+def test_pr_agent_context_emits_unified_agent_json(tmp_path):
+    def runner(args, cwd=None, check=True):
+        if args[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return completed(str(tmp_path))
+        if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return completed("feature/pr-tools")
+        if args[:3] == ["git", "rev-parse", "HEAD"]:
+            return completed("abc123")
+        if args[:4] == ["git", "merge-base", "origin/main", "HEAD"]:
+            return completed("def456")
+        if args[:3] == ["git", "diff", "--name-status"]:
+            return completed(
+                "\n".join(
+                    [
+                        "A\tscripts/pr_agent_context.py",
+                        "R100\tscripts/old.py\tscripts/new.py",
+                    ]
+                )
+            )
+        if args[:3] == ["git", "diff", "--stat"]:
+            return completed(" 2 files changed, 100 insertions(+)")
+        if args[:3] == ["git", "log", "--oneline"]:
+            return completed("abc123 Add agent PR wrapper")
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and pr_review_context.PR_JSON_FIELDS in args
+        ):
+            return completed(
+                json.dumps(
+                    {
+                        "number": 7,
+                        "title": "Add PR helpers",
+                        "url": "https://pr",
+                        "baseRefName": "main",
+                        "headRefName": "feature/pr-tools",
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "statusCheckRollup": [{"state": "SUCCESS"}],
+                    }
+                )
+            )
+        if args[:3] == ["gh", "pr", "view"] and fetch_comments.PR_JSON_FIELDS in args:
+            return completed(
+                json.dumps(
+                    {
+                        "number": 7,
+                        "title": "Add PR helpers",
+                        "url": "https://pr",
+                        "comments": [
+                            {
+                                "id": "ISSUE_comment",
+                                "author": {"login": "maintainer"},
+                                "body": "Please check CI.",
+                                "createdAt": "2026-05-26T11:00:00Z",
+                                "url": "https://issue-comment",
+                            }
+                        ],
+                    }
+                )
+            )
+        if args[:3] == ["gh", "repo", "view"]:
+            return completed(json.dumps({"nameWithOwner": "owner/repo"}))
+        if args[:4] == ["gh", "api", "graphql", "-f"]:
+            return completed(
+                json.dumps(
+                    {
+                        "data": {
+                            "repository": {
+                                "pullRequest": {
+                                    "reviewThreads": {
+                                        "nodes": [
+                                            {
+                                                "id": "THREAD_one",
+                                                "isResolved": False,
+                                                "path": "scripts/pr_agent_context.py",
+                                                "line": 12,
+                                                "comments": {
+                                                    "nodes": [
+                                                        {
+                                                            "id": "COMMENT_one",
+                                                            "author": {
+                                                                "login": "reviewer"
+                                                            },
+                                                            "body": "Add tests.",
+                                                            "createdAt": (
+                                                                "2026-05-26T12:00:00Z"
+                                                            ),
+                                                            "url": "https://comment",
+                                                        }
+                                                    ]
+                                                },
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
+            )
+        raise AssertionError("unexpected command: {}".format(args))
+
+    payload = pr_agent_context.collect_agent_context(runner=runner)
+
+    assert payload["schema_version"] == 1
+    assert payload["pr"]["number"] == 7
+    assert payload["git"]["branch"] == "feature/pr-tools"
+    assert payload["checks"]["status"] == "PASSING"
+    assert payload["files"] == [
+        {"status": "A", "path": "scripts/pr_agent_context.py"},
+        {"status": "R100", "path": "scripts/new.py", "previous_path": "scripts/old.py"},
+    ]
+    assert payload["comments"]["summary"]["issue_comment_count"] == 1
+    assert payload["comments"]["review_threads"][0]["id"] == "THREAD_one"
+    assert payload["commands"]["preferred_json"] == (
+        "python3 scripts/pr_agent_context.py --json"
+    )
+    assert not payload["errors"]
+
+
+def test_pr_agent_context_keeps_local_context_when_comments_fail(tmp_path):
+    def runner(args, cwd=None, check=True):
+        if args[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return completed(str(tmp_path))
+        if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return completed("feature/pr-tools")
+        if args[:3] == ["git", "rev-parse", "HEAD"]:
+            return completed("abc123")
+        if args[:4] == ["git", "merge-base", "origin/main", "HEAD"]:
+            return completed("def456")
+        if args[:3] == ["git", "diff", "--name-status"]:
+            return completed("M\tscripts/pr_review_context.py")
+        if args[:3] == ["git", "diff", "--stat"]:
+            return completed(" 1 file changed, 20 insertions(+)")
+        if args[:3] == ["git", "log", "--oneline"]:
+            return completed("abc123 Add agent PR wrapper")
+        if (
+            args[:3] == ["gh", "pr", "view"]
+            and pr_review_context.PR_JSON_FIELDS in args
+        ):
+            return completed(
+                json.dumps(
+                    {
+                        "number": 7,
+                        "title": "Add PR helpers",
+                        "url": "https://pr",
+                        "baseRefName": "main",
+                        "headRefName": "feature/pr-tools",
+                        "statusCheckRollup": [],
+                    }
+                )
+            )
+        if args[:3] == ["gh", "pr", "view"] and fetch_comments.PR_JSON_FIELDS in args:
+            raise subprocess.CalledProcessError(
+                1, args, stderr="gh auth token is unavailable\n"
+            )
+        raise AssertionError("unexpected command: {}".format(args))
+
+    payload = pr_agent_context.collect_agent_context(runner=runner)
+
+    assert payload["git"]["head_sha"] == "abc123"
+    assert payload["comments"]["summary"]["issue_comment_count"] == 0
+    assert payload["comments"]["summary"]["review_thread_count"] == 0
+    assert payload["errors"] == [
+        {
+            "stage": "comments",
+            "command": "gh pr view --json number,title,url,comments",
+            "message": "gh auth token is unavailable",
+        }
+    ]
+
+
+def test_pr_agent_context_renders_markdown_packet():
+    payload = {
+        "schema_version": 1,
+        "pr": {"number": 7, "title": "Add PR helpers", "url": "https://pr"},
+        "git": {
+            "branch": "feature/pr-tools",
+            "base_ref": "origin/main",
+            "head_sha": "abc123",
+            "merge_base": "def456",
+            "commits": ["abc123 Add agent PR wrapper"],
+            "diff_stat": " 1 file changed, 20 insertions(+)",
+        },
+        "checks": {"status": "PASSING", "review_decision": "REVIEW_REQUIRED"},
+        "files": [{"status": "A", "path": "scripts/pr_agent_context.py"}],
+        "comments": {
+            "summary": {"issue_comment_count": 1, "review_thread_count": 1},
+            "issue_comments": [{"id": "ISSUE_comment", "body": "Check CI."}],
+            "review_threads": [
+                {
+                    "id": "THREAD_one",
+                    "path": "scripts/pr_agent_context.py",
+                    "line": 12,
+                    "is_resolved": False,
+                    "comments": [{"id": "COMMENT_one", "body": "Add tests."}],
+                }
+            ],
+        },
+        "commands": {
+            "preferred_json": "python3 scripts/pr_agent_context.py --json",
+            "comments_json": "python3 scripts/fetch_comments.py --json",
+        },
+        "errors": [],
+    }
+
+    output = pr_agent_context.render_markdown(payload)
+
+    assert "# Agent PR Context" in output
+    assert "PR #7 Add PR helpers" in output
+    assert "## Files" in output
+    assert "A\tscripts/pr_agent_context.py" in output
+    assert "## Comments" in output
+    assert "Issue comments: 1" in output
+    assert "Review threads: 1" in output
+    assert "THREAD_one scripts/pr_agent_context.py:12" in output
+    assert "python3 scripts/pr_agent_context.py --json" in output
+
+
+def test_agents_mentions_preferred_pr_agent_context_wrapper():
+    agents = (PROJECT_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+    assert "python3 scripts/pr_agent_context.py --json" in agents
+    assert "preferred unified agent context packet" in agents
+    assert "fetch_comments.py" in agents
+    assert "skill or workflow expects that helper by name" in agents
+
+
 def completed(stdout):
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout + "\n")
+
+
+PROJECT_ROOT = __import__("pathlib").Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

This PR adds and refines helper scripts for AI-agent PR review workflows. The goal is to give Codex, Claude, Copilot, and similar agents a reliable, low-friction way to collect the local branch context, GitHub PR metadata, review comments, check status, changed files, and suggested follow-up commands without every agent re-discovering the same `git` and `gh` incantations.

The preferred entry point is:

```bash
python3 scripts/pr_agent_context.py --json
```

That produces a unified structured packet intended for agent consumption. The existing compatibility entry points remain available:

```bash
python3 scripts/pr_review_context.py --json
python3 scripts/fetch_comments.py --json
```

`fetch_comments.py` is kept because review-comment workflows, including the `gh-address-comments` skill, expect that helper name directly.

## What Changed

- Added `scripts/fetch_comments.py` to fetch unresolved GitHub review threads and PR issue comments in a stable JSON/Markdown format.
- Added `scripts/pr_review_context.py` to collect local branch context: branch, base ref, head SHA, merge base, changed files, diff stat, commits, PR metadata, and check status.
- Added `scripts/pr_agent_context.py` as the preferred wrapper that combines local context and GitHub comments into a single agent-oriented payload.
- Documented the helper workflow in `AGENTS.md` so future agents know which script to start with and when to use the compatibility helper.
- Hardened the helper ergonomics for AI agents:
  - generated shell commands now quote arguments where paths or refs may need shell escaping;
  - the unified wrapper preserves PR issue comments if review-thread fetching fails;
  - the unified wrapper reuses PR data from local context instead of calling `gh pr view` twice when possible.

## Why This Exists

AI review agents work best when they receive compact, structured, reproducible context. Without helper scripts, each agent has to independently decide how to inspect the branch, find the PR, fetch comments, summarize checks, and build follow-up commands. That creates several problems:

- context can be incomplete or inconsistent between agents;
- agents may miss review comments or changed-file details;
- GitHub auth or rate-limit failures can cause the whole workflow to fail instead of returning useful partial context;
- generated commands can be unsafe to copy when paths contain spaces or shell-sensitive characters;
- downstream skills that expect a specific helper, such as `scripts/fetch_comments.py`, need a stable compatibility path.

This PR gives agents a single preferred packet while still preserving smaller scripts for direct use and compatibility.

## Behavior Notes

- `pr_agent_context.py` is best-effort for GitHub comment collection. If comment or review-thread fetching fails, it still emits local branch, file, check, and PR context and records structured errors in the `errors` array.
- `fetch_comments.py` remains fail-fast when used directly, which is useful for workflows that specifically need comment fetching to succeed.
- The scripts are stdlib-only and Python 3.8-compatible in style, matching the repo's runtime portability expectations even though these are development helpers.

## Test Plan

- `python3 -m pytest tests/test_pr_review_tools.py -q`
- `just lint`
- `just test`
- `just chroma-index --reset`
