### PR TITLE
🎨 Palette: Add explicit keyboard navigation between list and scrollbar

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,7 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +234,7 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onleft>50</onleft>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
*   **💡 What:** Added explicit `<onleft>` and `<onright>` tags in `results-dialog.xml` to link the main list (`id="50"`) and its scrollbar (`id="60"`).
*   **🎯 Why:** Kodi requires explicit directional mapping between UI controls in XML skins. Without this, users navigating via keyboard or a TV remote cannot easily shift focus from the list to the scrollbar, degrading the UX.
*   **♿ Accessibility:** Enables full keyboard and directional remote accessibility for scrolling through long result lists.

---
*PR created automatically by Jules for task [7006458267466561940](https://jules.google.com/task/7006458267466561940) started by @xbmc4lyfe*