### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -1505,7 +1505,11 @@ class _StreamHandler(BaseHTTPRequestHandler):
         )
         try:
             proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
             )
         except OSError as error:
             xbmc.log("NZB-DAV: Failed to start ffmpeg: {}".format(error), xbmc.LOGERROR)
@@ -5872,6 +5876,7 @@ class StreamProxy:
         try:
             proc = subprocess.Popen(
                 cmd,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 shell=False,
@@ -6773,6 +6778,7 @@ class StreamProxy:
             )
             proc = subprocess.Popen(
                 cmd,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=False,
@@ -6845,6 +6851,7 @@ class StreamProxy:
         try:
             proc = subprocess.Popen(
                 cmd,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 shell=False,
@@ -6968,7 +6975,11 @@ class StreamProxy:
         try:
             xbmc.log("NZB-DAV: Temp-file faststart remux starting", xbmc.LOGINFO)
             proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
             )
             _, stderr = proc.communicate(timeout=600)  # 10 min timeout
             if proc.returncode != 0:

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -1103,6 +1103,8 @@ def _validate_url(url):
         raise ValueError("Invalid URL scheme: {}".format(repr(url)[:30]))
     if any(ord(c) < 0x20 for c in url):
         raise ValueError("URL contains control characters: {}".format(repr(url)[:60]))
+    if url.startswith("-"):
+        raise ValueError("URL cannot start with a dash")
 
 
 def _validate_auth_header(auth_header):


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When creating child processes using subprocess.Popen, they inherit the standard input of the parent unless explicitly overridden. For certain tools (like ffmpeg, which waits for stdin), this can cause the process to hang indefinitely.
🎯 Impact: This could result in unbounded resource consumption or service unavailability due to stalled/hanging background tasks.
🔧 Fix: Added stdin=subprocess.DEVNULL to all subprocess.Popen calls inside stream_proxy.py to ensure the child process does not wait on input.
✅ Verification: Ran just lint-fix and passed pytest successfully. Also recorded this as a critical learning in .jules/sentinel.md.

---
*PR created automatically by Jules for task [7347568470637681908](https://jules.google.com/task/7347568470637681908) started by @xbmc4lyfe*