### PR TITLE
Show cleaned playback titles

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -511,6 +511,19 @@ def _apply_proxy_mime(li, stream_url, stream_info):
             li.setMimeType("video/x-matroska")
 
 
+def _apply_display_title(li, display_title):
+    if not display_title:
+        return
+    try:
+        li.setLabel(display_title)
+    except (AttributeError, RuntimeError, TypeError):
+        pass
+    try:
+        li.getVideoInfoTag().setTitle(display_title)
+    except (AttributeError, RuntimeError, TypeError):
+        pass
+
+
 def _stream_auth_header(stream_headers):
     if stream_headers and "Authorization" in stream_headers:
         return stream_headers["Authorization"]
@@ -927,6 +940,7 @@ def _finish_direct_playback(handle, prepared):
     stream_url = prepared["stream_url"]
     stream_headers = prepared["stream_headers"]
     service_port = prepared.get("service_port")
+    display_title = prepared.get("display_title") or stream_url.rsplit("/", 1)[-1]
     _resolve_stage(
         "finish_direct_playback_got_params service_port={}".format(service_port)
     )
@@ -949,9 +963,10 @@ def _finish_direct_playback(handle, prepared):
             )
             bust_url = _cache_bust_url(stream_url)
             li = _make_playable_listitem(bust_url, stream_headers)
+            _apply_display_title(li, display_title)
             play_url = _build_play_url(bust_url, stream_headers)
             home.setProperty("nzbdav.stream_url", play_url)
-            home.setProperty("nzbdav.stream_title", stream_url.rsplit("/", 1)[-1])
+            home.setProperty("nzbdav.stream_title", display_title)
             home.setProperty("nzbdav.active", "true")
             xbmcplugin.setResolvedUrl(handle, True, li)
             return
@@ -959,9 +974,10 @@ def _finish_direct_playback(handle, prepared):
         li = xbmcgui.ListItem(path=proxy_url)
         li.setContentLookup(False)
         _apply_proxy_mime(li, stream_url, stream_info)
+        _apply_display_title(li, display_title)
 
         home.setProperty("nzbdav.stream_url", proxy_url)
-        home.setProperty("nzbdav.stream_title", stream_url.rsplit("/", 1)[-1])
+        home.setProperty("nzbdav.stream_title", display_title)
         home.setProperty("nzbdav.active", "true")
         xbmcplugin.setResolvedUrl(handle, True, li)
         return
@@ -974,9 +990,10 @@ def _finish_direct_playback(handle, prepared):
     )
 
     li = _make_playable_listitem(bust_url, stream_headers)
+    _apply_display_title(li, display_title)
     home = xbmcgui.Window(10000)
     home.setProperty("nzbdav.stream_url", play_url)
-    home.setProperty("nzbdav.stream_title", stream_url.rsplit("/", 1)[-1])
+    home.setProperty("nzbdav.stream_title", display_title)
     home.setProperty("nzbdav.active", "true")
     xbmcplugin.setResolvedUrl(handle, True, li)
 
@@ -987,7 +1004,7 @@ def _finish_player_playback(prepared):
     stream_headers = prepared["stream_headers"]
     service_port = prepared.get("service_port")
     home = xbmcgui.Window(10000)
-    title = stream_url.rsplit("/", 1)[-1]
+    title = prepared.get("display_title") or stream_url.rsplit("/", 1)[-1]
 
     if service_port:
         proxy_url = prepared["proxy_url"]
@@ -1000,6 +1017,7 @@ def _finish_player_playback(prepared):
             )
             bust_url = _cache_bust_url(stream_url)
             li = _make_playable_listitem(bust_url, stream_headers)
+            _apply_display_title(li, title)
             play_url = _build_play_url(bust_url, stream_headers)
             home.setProperty("nzbdav.stream_url", play_url)
             home.setProperty("nzbdav.stream_title", title)
@@ -1010,6 +1028,7 @@ def _finish_player_playback(prepared):
         li = xbmcgui.ListItem(path=proxy_url)
         li.setContentLookup(False)
         _apply_proxy_mime(li, stream_url, stream_info)
+        _apply_display_title(li, title)
         home.setProperty("nzbdav.stream_url", proxy_url)
         home.setProperty("nzbdav.stream_title", title)
         home.setProperty("nzbdav.active", "true")
@@ -1019,6 +1038,7 @@ def _finish_player_playback(prepared):
 
     bust_url = _cache_bust_url(stream_url)
     li = _make_playable_listitem(bust_url, stream_headers)
+    _apply_display_title(li, title)
     play_url = _build_play_url(bust_url, stream_headers)
     xbmc.log("NZB-DAV: Playing direct (no proxy): {}".format(stream_url), xbmc.LOGINFO)
     home.setProperty("nzbdav.stream_url", play_url)
@@ -2969,6 +2989,7 @@ def resolve(handle, params):
     """
     nzb_url = unquote(params.get("nzburl", ""))
     title = unquote(params.get("title", ""))
+    display_title = unquote(params.get("_display_title", ""))
     fallback_state = None
     playback_cleanup_state = None
 
@@ -3053,6 +3074,8 @@ def resolve(handle, params):
             )
             _wait_playback_state_cleanup(playback_cleanup_state)
             prepared = _wait_direct_playback_prepare(playback_prepare_state)
+            if prepared and display_title:
+                prepared["display_title"] = display_title
             _finish_direct_playback(handle, prepared)
         else:
             _stop_fallback_submit_worker(fallback_state, cancel_submitted=True)
@@ -3091,6 +3114,7 @@ def resolve_and_play(nzb_url, title, params=None):
     try:
         _resolve_stage("enter resolve_and_play")
         resolve_params = params or {}
+        display_title = resolve_params.get("_display_title", "")
         settings_getter = resolve_params.get("_settings_getter")
         selected_indexer = resolve_params.get("_selected_indexer", "")
         fallback_candidates = resolve_params.get("_fallback_candidates", [])
@@ -3191,6 +3215,8 @@ def resolve_and_play(nzb_url, title, params=None):
             _resolve_stage("finish playback start")
             _resolve_stage("prepare wait start")
             prepared = _wait_direct_playback_prepare(playback_prepare_state)
+            if prepared and display_title:
+                prepared["display_title"] = display_title
             _resolve_stage(
                 "prepare wait done service_port={}".format(
                     prepared.get("service_port") if prepared else ""

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -232,6 +232,9 @@ def route(argv):
             # TMDBHelper bookmark row (keyed by tmdb_id+title) when
             # playback starts. Without it, replays resume from a stale
             # offset. TODO.md §H.3.
+            clean["_display_title"] = _build_display_title(
+                clean, clean.get("title", "")
+            )
             resolve_and_play(
                 clean.get("nzburl", ""),
                 clean.get("title", ""),
@@ -326,6 +329,81 @@ def _clean_params(params):
     https://github.com/jurialmunkey/plugin.video.themoviedb.helper/wiki/PlayerConfig
     """
     return {k: ("" if v == "_" else v) for k, v in params.items()}
+
+
+def _format_episode_display_title(title, season, episode):
+    def _pad(value):
+        try:
+            return "{:02d}".format(int(value))
+        except (TypeError, ValueError):
+            return str(value or "")
+
+    if title and season not in ("", None) and episode not in ("", None):
+        return "{} S{}E{}".format(title, _pad(season), _pad(episode))
+    return title or ""
+
+
+def _build_display_title(params, fallback_title=""):
+    title = params.get("title", "")
+    search_type = params.get("type", "movie")
+    if search_type == "episode":
+        season = params.get("season", "") or params.get("ep_season", "")
+        episode = params.get("episode", "") or params.get("ep_episode", "")
+        return _format_episode_display_title(title, season, episode) or fallback_title
+    year = params.get("year", "")
+    if title and year:
+        return "{} ({})".format(title, year)
+    return title or fallback_title
+
+
+def _build_resolved_display_title(
+    params, fallback_title="", title=None, year=None, season=None, episode=None
+):
+    display_params = dict(params)
+    if title:
+        display_params["title"] = title
+    if year:
+        display_params["year"] = year
+    if season not in ("", None):
+        display_params["season"] = season
+    if episode not in ("", None):
+        display_params["episode"] = episode
+    return _build_display_title(display_params, fallback_title)
+
+
+def _resolver_params_for_selection(
+    params,
+    selected,
+    results,
+    title=None,
+    year=None,
+    season=None,
+    episode=None,
+    settings_getter=None,
+    preserve_params=False,
+):
+    if preserve_params:
+        resolver_params = dict(params)
+    else:
+        resolver_params = {
+            "nzburl": selected["link"],
+            "title": selected["title"],
+        }
+    resolver_params["_display_title"] = _build_resolved_display_title(
+        params,
+        selected["title"],
+        title=title,
+        year=year,
+        season=season,
+        episode=episode,
+    )
+    resolver_params["_fallback_candidates"] = []
+    resolver_params["_fallback_candidate_loader"] = (
+        _fallback_candidate_loader_for_selection(
+            selected, results, settings_getter=settings_getter
+        )
+    )
+    return resolver_params
 
 
 def _fallback_candidate_loader_for_selection(selected, results, settings_getter=None):
@@ -1134,6 +1212,8 @@ def _handle_play(handle, params):
         looked_up = _lookup_episode_info(imdb, params.get("tmdb_id", ""))
         if looked_up:
             title = looked_up.get("title", title)
+            season = season or looked_up.get("season", "")
+            episode = episode or looked_up.get("episode", "")
 
     xbmc.log(
         "NZB-DAV: Search stage: checking cache for '{}' ({})".format(
@@ -1233,14 +1313,15 @@ def _handle_play(handle, params):
         best = filtered[0]
         from resources.lib.resolver import resolve
 
-        resolver_params = {
-            "nzburl": best["link"],
-            "title": best["title"],
-            "_fallback_candidates": [],
-            "_fallback_candidate_loader": _fallback_candidate_loader_for_selection(
-                best, filtered
-            ),
-        }
+        resolver_params = _resolver_params_for_selection(
+            params,
+            best,
+            filtered,
+            title=title,
+            year=year,
+            season=season,
+            episode=episode,
+        )
         _attach_selected_indexer(resolver_params, best)
         resolve(
             handle,
@@ -1261,14 +1342,15 @@ def _handle_play(handle, params):
     if selected:
         from resources.lib.resolver import resolve
 
-        resolver_params = {
-            "nzburl": selected["link"],
-            "title": selected["title"],
-            "_fallback_candidates": [],
-            "_fallback_candidate_loader": _fallback_candidate_loader_for_selection(
-                selected, filtered
-            ),
-        }
+        resolver_params = _resolver_params_for_selection(
+            params,
+            selected,
+            filtered,
+            title=title,
+            year=year,
+            season=season,
+            episode=episode,
+        )
         completed_job = selected.get("_completed_job")
         if completed_job:
             resolver_params["_completed_job"] = completed_job
@@ -1420,10 +1502,16 @@ def _handle_search(handle, params):
         best = filtered[0]
         from resources.lib.resolver import resolve_and_play
 
-        resolver_params = dict(params)
-        resolver_params["_fallback_candidates"] = []
-        fallback_loader = _fallback_candidate_loader_for_selection(best, filtered)
-        resolver_params["_fallback_candidate_loader"] = fallback_loader
+        resolver_params = _resolver_params_for_selection(
+            params,
+            best,
+            filtered,
+            title=title,
+            year=year,
+            season=season,
+            episode=episode,
+            preserve_params=True,
+        )
         _attach_selected_indexer(resolver_params, best)
         resolve_and_play(best["link"], best["title"], params=resolver_params)
         # Same hang class as C1 (router.py): /search is a directory
@@ -1448,10 +1536,15 @@ def _handle_search(handle, params):
     if selected:
         from resources.lib.resolver import resolve_and_play
 
-        resolver_params = dict(params)
-        resolver_params["_fallback_candidates"] = []
-        resolver_params["_fallback_candidate_loader"] = (
-            _fallback_candidate_loader_for_selection(selected, filtered)
+        resolver_params = _resolver_params_for_selection(
+            params,
+            selected,
+            filtered,
+            title=title,
+            year=year,
+            season=season,
+            episode=episode,
+            preserve_params=True,
         )
         completed_job = selected.get("_completed_job")
         if completed_job:
@@ -1567,12 +1660,17 @@ def _handle_script_play(params):
         best = filtered[0]
         from resources.lib.resolver import resolve_and_play
 
-        resolver_params = dict(params)
-        resolver_params["_fallback_candidates"] = []
-        fallback_loader = _fallback_candidate_loader_for_selection(
-            best, filtered, settings_getter=_get_script_setting
+        resolver_params = _resolver_params_for_selection(
+            params,
+            best,
+            filtered,
+            title=title,
+            year=year,
+            season=season,
+            episode=episode,
+            settings_getter=_get_script_setting,
+            preserve_params=True,
         )
-        resolver_params["_fallback_candidate_loader"] = fallback_loader
         completed_job = _script_completed_job_for_selection(best)
         if completed_job:
             resolver_params["_completed_job"] = completed_job
@@ -1609,12 +1707,17 @@ def _handle_script_play(params):
 
     from resources.lib.resolver import resolve_and_play
 
-    resolver_params = dict(params)
-    resolver_params["_fallback_candidates"] = []
-    fallback_loader = _fallback_candidate_loader_for_selection(
-        selected, filtered, settings_getter=_get_script_setting
+    resolver_params = _resolver_params_for_selection(
+        params,
+        selected,
+        filtered,
+        title=title,
+        year=year,
+        season=season,
+        episode=episode,
+        settings_getter=_get_script_setting,
+        preserve_params=True,
     )
-    resolver_params["_fallback_candidate_loader"] = fallback_loader
     resolver_params["_settings_getter"] = _get_script_setting
     completed_job = selected.get("_completed_job")
     if not completed_job and not _completed_lookup_was_done(completed_jobs):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -18,6 +18,7 @@ from resources.lib.resolver import (
     _direct_playback_service_config,
     _existing_completed_stream,
     _fallback_submit_jobs_snapshot,
+    _finish_direct_playback,
     _get_poll_settings,
     _get_submit_timeout_seconds,
     _handle_history_result,
@@ -452,6 +453,37 @@ def test_play_direct_mkv_sets_matroska_mime_on_passthrough(
     _play_direct(1, "http://webdav:8080/content/movie/movie.mkv", None)
 
     listitem.setMimeType.assert_called_with("video/x-matroska")
+
+
+@patch("resources.lib.resolver.xbmcplugin")
+@patch("resources.lib.resolver.xbmcgui")
+@patch("resources.lib.resolver.xbmc")
+def test_finish_direct_playback_uses_display_title_for_kodi_metadata(
+    _mock_xbmc, mock_gui, mock_plugin
+):
+    listitem = MagicMock()
+    info_tag = MagicMock()
+    listitem.getVideoInfoTag.return_value = info_tag
+    mock_gui.ListItem.return_value = listitem
+    home = MagicMock()
+    mock_gui.Window.return_value = home
+
+    _finish_direct_playback(
+        1,
+        {
+            "stream_url": "http://webdav/content/abc123/hash-name.mkv",
+            "stream_headers": {},
+            "service_port": 57800,
+            "proxy_url": "http://127.0.0.1:57800/stream/session",
+            "stream_info": {},
+            "display_title": "Slow Horses S03E02",
+        },
+    )
+
+    listitem.setLabel.assert_called_once_with("Slow Horses S03E02")
+    info_tag.setTitle.assert_called_once_with("Slow Horses S03E02")
+    home.setProperty.assert_any_call("nzbdav.stream_title", "Slow Horses S03E02")
+    mock_plugin.setResolvedUrl.assert_called_once()
 
 
 @patch("resources.lib.stream_proxy.prepare_stream_via_service")
@@ -1085,6 +1117,57 @@ def test_resolve_routes_plain_mkv_through_proxy_without_fallbacks(
     )
     mock_wait_prepare.assert_called_once_with({"state": "prepare"})
     mock_finish_playback.assert_called_once_with(1, {"state": "prepared"})
+
+
+@patch("resources.lib.resolver._fallback_submit_jobs_snapshot", return_value=[])
+@patch("resources.lib.resolver._finish_direct_playback")
+@patch("resources.lib.resolver._wait_direct_playback_prepare")
+@patch("resources.lib.resolver._start_direct_playback_prepare")
+@patch("resources.lib.resolver._start_fallback_submit_worker")
+@patch("resources.lib.resolver._poll_until_ready")
+@patch("resources.lib.resolver._clear_kodi_playback_state")
+@patch("resources.lib.resolver.xbmc")
+@patch("resources.lib.resolver.xbmcgui")
+@patch("resources.lib.resolver.xbmcplugin")
+@patch("resources.lib.resolver._get_poll_settings")
+def test_resolve_passes_display_title_to_direct_playback_handoff(
+    mock_poll_settings,
+    _mock_plugin,
+    mock_gui,
+    mock_xbmc,
+    _mock_clear_state,
+    mock_poll_until_ready,
+    mock_start_fallback,
+    mock_start_prepare,
+    mock_wait_prepare,
+    mock_finish_playback,
+    _mock_snapshot,
+):
+    mock_poll_settings.return_value = (2, 60)
+    mock_start_fallback.return_value = {"state": "fallback"}
+    mock_start_prepare.return_value = {"state": "prepare"}
+    prepared = {"state": "prepared"}
+    mock_wait_prepare.return_value = prepared
+    mock_xbmc.Monitor.return_value = _make_monitor()
+    mock_gui.DialogProgress.return_value = MagicMock()
+    mock_poll_until_ready.return_value = (
+        "http://webdav/content/primary/slow-horses.mkv",
+        {"Authorization": "Basic primary"},
+    )
+
+    resolve(
+        1,
+        {
+            "nzburl": "http://hydra/getnzb/primary",
+            "title": "Slow.Horses.S03E02.2160p.WEB-DL.Atmos.mkv",
+            "_display_title": "Slow Horses S03E02",
+            "_fallback_candidates": [],
+        },
+    )
+
+    mock_finish_playback.assert_called_once_with(
+        1, {"state": "prepared", "display_title": "Slow Horses S03E02"}
+    )
 
 
 @patch("resources.lib.resolver._fallback_submit_jobs_snapshot", return_value=[])
@@ -1756,6 +1839,53 @@ def test_resolve_and_play_routes_plain_mkv_through_proxy_without_fallbacks(
     )
     mock_wait_prepare.assert_called_once_with({"state": "prepare"})
     mock_finish_playback.assert_called_once_with({"state": "prepared"})
+
+
+@patch("resources.lib.resolver._fallback_submit_jobs_snapshot", return_value=[])
+@patch("resources.lib.resolver._finish_player_playback")
+@patch("resources.lib.resolver._wait_direct_playback_prepare")
+@patch("resources.lib.resolver._start_direct_playback_prepare")
+@patch("resources.lib.resolver._start_fallback_submit_worker")
+@patch("resources.lib.resolver._poll_until_ready")
+@patch("resources.lib.resolver._clear_kodi_playback_state")
+@patch("resources.lib.resolver.xbmc")
+@patch("resources.lib.resolver.xbmcgui")
+@patch("resources.lib.resolver._get_poll_settings")
+def test_resolve_and_play_passes_display_title_to_player_handoff(
+    mock_poll_settings,
+    mock_gui,
+    mock_xbmc,
+    _mock_clear_state,
+    mock_poll_until_ready,
+    mock_start_fallback,
+    mock_start_prepare,
+    mock_wait_prepare,
+    mock_finish_playback,
+    _mock_snapshot,
+):
+    mock_poll_settings.return_value = (2, 60)
+    mock_start_fallback.return_value = {"state": "fallback"}
+    mock_start_prepare.return_value = {"state": "prepare"}
+    mock_wait_prepare.return_value = {"state": "prepared"}
+    mock_xbmc.Monitor.return_value = _make_monitor()
+    mock_gui.DialogProgress.return_value = MagicMock()
+    mock_poll_until_ready.return_value = (
+        "http://webdav/content/primary/slow-horses.mkv",
+        {"Authorization": "Basic primary"},
+    )
+
+    resolve_and_play(
+        "http://hydra/getnzb/primary",
+        "Slow.Horses.S03E02.2160p.WEB-DL.Atmos.mkv",
+        params={
+            "_display_title": "Slow Horses S03E02",
+            "_fallback_candidates": [],
+        },
+    )
+
+    mock_finish_playback.assert_called_once_with(
+        {"state": "prepared", "display_title": "Slow Horses S03E02"}
+    )
 
 
 @patch("resources.lib.resolver._fallback_submit_jobs_snapshot")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -17,6 +17,7 @@ from resources.lib.router import (
     _handle_play,
     _handle_search,
     _prowlarr_indexers_response_ok,
+    _resolver_params_for_selection,
     _safe_resolve_handle,
     _tag_available,
     _test_connection,
@@ -52,6 +53,31 @@ def test_parse_route_install_player_other():
         parse_route("plugin://plugin.video.nzbdav/install_player_other")
         == "/install_player_other"
     )
+
+
+def test_resolver_params_for_selection_builds_clean_episode_display_title():
+    selected = {
+        "title": "Slow.Horses.S03E02.2160p.WEB-DL.Atmos.mkv",
+        "link": "http://hydra/nzb/slow-horses",
+    }
+    params = _resolver_params_for_selection(
+        {"type": "episode", "title": "", "season": "", "episode": ""},
+        selected,
+        [selected],
+        title="Slow Horses",
+        year="",
+        season="3",
+        episode="2",
+    )
+
+    loader = params.pop("_fallback_candidate_loader")
+    assert loader is None
+    assert params == {
+        "nzburl": selected["link"],
+        "title": selected["title"],
+        "_display_title": "Slow Horses S03E02",
+        "_fallback_candidates": [],
+    }
 
 
 def test_parse_params_movie():
@@ -1721,6 +1747,92 @@ def test_handle_play_happy_path_invokes_resolve(
 @patch("resources.lib.results_dialog.show_results_dialog")
 @patch("resources.lib.filter.filter_results")
 @patch("resources.lib.router._search_all_providers")
+@patch("resources.lib.router._tag_available")
+@patch("resources.lib.cache.get_cached", return_value=None)
+def test_handle_play_passes_clean_episode_display_title_to_resolver(
+    mock_cache,
+    mock_tag,
+    mock_search,
+    mock_filter,
+    mock_dialog,
+    mock_resolve,
+    mock_listitem,
+    mock_resolved,
+    mock_addon,
+):
+    _install_progress_dialog_that_wont_cancel()
+    mock_addon.return_value.getSetting.side_effect = _stub_setting("false")
+    mock_listitem.return_value = "li"
+    chosen = {
+        "title": "Slow.Horses.S03E02.2160p.WEB-DL.Atmos.mkv",
+        "link": "http://hydra/nzb/slow-horses",
+    }
+    mock_search.return_value = ([chosen], None)
+    mock_filter.return_value = ([chosen], [chosen])
+    mock_dialog.return_value = chosen
+
+    _handle_play(
+        5,
+        {"type": "episode", "title": "Slow Horses", "season": "3", "episode": "2"},
+    )
+
+    args, _kwargs = mock_resolve.call_args
+    assert args[1]["title"] == chosen["title"]
+    assert args[1]["_display_title"] == "Slow Horses S03E02"
+
+
+@patch("xbmcaddon.Addon")
+@patch("xbmcplugin.setResolvedUrl")
+@patch("xbmcgui.ListItem")
+@patch("resources.lib.resolver.resolve")
+@patch("resources.lib.results_dialog.show_results_dialog")
+@patch("resources.lib.filter.filter_results")
+@patch("resources.lib.router._search_all_providers")
+@patch("resources.lib.router._tag_available")
+@patch("resources.lib.cache.get_cached", return_value=None)
+def test_handle_play_uses_infolabel_episode_metadata_for_display_title(
+    mock_cache,
+    mock_tag,
+    mock_search,
+    mock_filter,
+    mock_dialog,
+    mock_resolve,
+    mock_listitem,
+    mock_resolved,
+    mock_addon,
+):
+    _install_progress_dialog_that_wont_cancel()
+    mock_addon.return_value.getSetting.side_effect = _stub_setting("false")
+    mock_listitem.return_value = "li"
+    chosen = {
+        "title": "Slow.Horses.S03E02.2160p.WEB-DL.Atmos.mkv",
+        "link": "http://hydra/nzb/slow-horses",
+    }
+    mock_search.return_value = ([chosen], None)
+    mock_filter.return_value = ([chosen], [chosen])
+    mock_dialog.return_value = chosen
+
+    info_labels = {
+        "ListItem.TVShowTitle": "Slow Horses",
+        "ListItem.Season": "3",
+        "ListItem.Episode": "2",
+    }
+    with patch("resources.lib.router.xbmc") as mock_xbmc:
+        mock_xbmc.getInfoLabel.side_effect = lambda label: info_labels.get(label, "")
+        _handle_play(5, {"type": "episode"})
+
+    args, _kwargs = mock_resolve.call_args
+    assert args[1]["title"] == chosen["title"]
+    assert args[1]["_display_title"] == "Slow Horses S03E02"
+
+
+@patch("xbmcaddon.Addon")
+@patch("xbmcplugin.setResolvedUrl")
+@patch("xbmcgui.ListItem")
+@patch("resources.lib.resolver.resolve")
+@patch("resources.lib.results_dialog.show_results_dialog")
+@patch("resources.lib.filter.filter_results")
+@patch("resources.lib.router._search_all_providers")
 @patch("resources.lib.router.get_completed_jobs")
 @patch("resources.lib.cache.get_cached", return_value=None)
 def test_handle_play_marks_completed_history_miss_from_picker_snapshot(
@@ -1983,6 +2095,7 @@ def test_handle_search_auto_select_passes_clean_params_to_resolver(
         "title": "The Matrix",
         "year": "",
         "tmdb_id": "603",
+        "_display_title": "The Matrix",
         "_fallback_candidates": [],
     }
     mock_end.assert_called_once_with(7, succeeded=False)
@@ -2037,6 +2150,7 @@ def test_handle_search_picker_passes_clean_params_to_resolver(
         "title": "The Matrix",
         "year": "",
         "tmdb_id": "603",
+        "_display_title": "The Matrix",
         "_fallback_candidates": [],
     }
     mock_end.assert_called_once_with(8, succeeded=False)
@@ -2105,6 +2219,7 @@ def test_handle_script_play_uses_picker_without_plugin_handle_resolution(
         "title": "The Odyssey",
         "year": "2026",
         "tmdb_id": "1368337",
+        "_display_title": "The Odyssey (2026)",
         "_fallback_candidates": [],
         "_selected_indexer": "NZBFinder",
     }
@@ -2427,6 +2542,7 @@ def test_handle_script_play_auto_select_marks_completed_lookup_done(
         "type": "movie",
         "title": "The Odyssey",
         "year": "2026",
+        "_display_title": "The Odyssey (2026)",
         "_fallback_candidates": [],
         "_completed_job_lookup_done": True,
     }
@@ -2540,6 +2656,7 @@ def test_handle_search_picker_fetches_fallbacks_after_selection(
         "title": "The Matrix",
         "year": "",
         "tmdb_id": "603",
+        "_display_title": "The Matrix",
         "_fallback_candidates": [],
     }
 


### PR DESCRIPTION
## Summary
- Show cleaned movie and episode names in Kodi playback metadata instead of WebDAV/hash-style stream basenames.
- Format movies as `Title (Year)` when a year is available and episodes as `Show Title SxxExx`.
- Keep the selected NZB/release title unchanged for nzbdav submit, completed-history lookup, fallback handling, and search result identity.

## Details
- Adds display-title construction in the router for `/play`, `/search`, `/resolve`, and TMDBHelper RunScript playback paths.
- Centralizes selected-result resolver parameter assembly through `_resolver_params_for_selection()` so display-title, fallback-loader, and fallback-candidate fields stay aligned across auto-select and picker paths.
- Builds display titles from resolved local metadata, including InfoLabel and `_lookup_episode_info()` fallback values, so sparse TMDBHelper params still produce clean episode titles.
- Propagates `_display_title` through `resolve()` and `resolve_and_play()` into the prepared playback payload.
- Applies the display title to Kodi `ListItem` label, video title metadata, and `nzbdav.stream_title`, while falling back to the stream basename if no display title is available.

## Test Plan
- [x] `just lint`
- [x] `python3 -m pytest tests/test_router.py::test_resolver_params_for_selection_builds_clean_episode_display_title tests/test_router.py::test_handle_play_passes_clean_episode_display_title_to_resolver tests/test_router.py::test_handle_play_uses_infolabel_episode_metadata_for_display_title tests/test_resolver.py::test_finish_direct_playback_uses_display_title_for_kodi_metadata tests/test_resolver.py::test_resolve_passes_display_title_to_direct_playback_handoff tests/test_resolver.py::test_resolve_and_play_passes_display_title_to_player_handoff -q`
- [ ] `just test` currently fails locally with unrelated timing-budget failures across resolver, stream proxy, fallback streams, and WebDAV tests. The display-title tests pass inside that run.

## Notes
- No README or changelog update is included because this is not a release-prep branch. Release notes should be added when cutting the next addon version.