### PR TITLE
fix(stream_proxy): drive live fallback when upstream stalls instead of wedging as client_disconnected

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -121,6 +121,17 @@ _FFPROBE_PATHS = [
 
 # Pass-through proxy recovery constants
 _UPSTREAM_OPEN_TIMEOUT = 60
+# Dedicated recv() deadline for the streaming body, armed explicitly on the
+# upstream socket AFTER the response headers arrive (see
+# _set_upstream_read_timeout). _UPSTREAM_OPEN_TIMEOUT above is inherited by
+# recv() too, but we want a tighter, explicit bound so a stalled backend (all
+# Usenet providers returning article-not-found) surfaces as a RECOVERABLE read
+# result that drives live fallback — and wins the race against the equal 60 s
+# proxy->Kodi write timeout (_REMUX_WRITE_TIMEOUT) instead of unwinding as
+# terminal_reason="client_disconnected" with recoveries=0. Kept well above a
+# realistic single-article fetch so a slow-but-progressing source is not
+# falsely rotated. See https://github.com/Appz4Fun/nzbdavkodi/issues/214
+_UPSTREAM_READ_TIMEOUT = 45
 _SKIP_PROBE_TIMEOUT = 60
 # Geometric skip sizes for probing past a bad article region. 1 MB covers a
 # single missing article (~700 KB). 16 MB covers a cluster of ~20 articles.
@@ -167,6 +178,31 @@ def _passthrough_watchdog_applies(ctx):
     """
     content_type = (ctx.get("content_type") or "").lower()
     return content_type.startswith("video/")
+
+
+def _set_upstream_read_timeout(resp, timeout):
+    """Best-effort: arm a recv() deadline on an urlopen response's socket.
+
+    urllib inherits the urlopen connect timeout for reads, but we set a
+    tighter, explicit deadline on the body socket so a stalled upstream
+    surfaces as a recoverable read error promptly (which drives live
+    fallback) rather than blocking until the equal proxy->Kodi write
+    timeout fires first and the stall is misattributed to a client
+    disconnect. Tolerant of the CPython-internal attribute path
+    (BufferedReader -> SocketIO -> socket) being absent on other
+    implementations; on failure the inherited urlopen timeout still
+    applies. See https://github.com/Appz4Fun/nzbdavkodi/issues/214
+    """
+    try:
+        sock = resp.fp.raw._sock
+    except AttributeError:
+        return
+    if sock is None:
+        return
+    try:
+        sock.settimeout(timeout)
+    except OSError:
+        pass
 
 
 # Chunk size for reading from the upstream HTTP response in _serve_proxy.
@@ -4361,6 +4397,14 @@ class _StreamHandler(BaseHTTPRequestHandler):
             getattr(self, "server", None), ctx, observed_at=observed_at
         )
 
+        # Arm a dedicated, shorter recv() deadline on the body socket now that
+        # headers are in. A stalled backend (e.g. looping on article-not-found)
+        # then surfaces as a recoverable read error within _UPSTREAM_READ_TIMEOUT
+        # — driving the live fallback cutover below — instead of blocking on the
+        # inherited 60 s timeout until Kodi gives up and the stall is logged as
+        # client_disconnected. See issue #214.
+        _set_upstream_read_timeout(resp, _UPSTREAM_READ_TIMEOUT)
+
         try:
             status = getattr(resp, "status", None) or resp.getcode()
             content_range = _get_header(resp, "Content-Range")
@@ -4491,6 +4535,28 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     if window_elapsed >= _PASSTHROUGH_THROUGHPUT_WINDOW_SECONDS:
                         bps = ctx["passthrough_window_bytes"] / window_elapsed
                         if bps < _PASSTHROUGH_MIN_THROUGHPUT_BPS:
+                            # When a live fallback upload is attached, a
+                            # sustained sub-floor trickle should switch sources
+                            # rather than blindly close for a reconnect to the
+                            # SAME stalled upload (which just wedges again on a
+                            # dead/missing-article release). Returning a
+                            # recoverable result hands control to _serve_proxy's
+                            # cutover (which calls _select_live_fallback_source);
+                            # the no-fallback path below is unchanged so the
+                            # existing passthrough_stall reconnect + audio-skip
+                            # behavior and its tests still hold. See issue #214.
+                            if ctx.get("fallback_sources"):
+                                xbmc.log(
+                                    "NZB-DAV: Pass-through trickle below floor "
+                                    "at byte {} ({:.0f} B/s over {:.1f}s) with "
+                                    "fallback attached; returning recoverable to "
+                                    "trigger cutover "
+                                    "(reason=passthrough_stall_fallback)".format(
+                                        start + written, bps, window_elapsed
+                                    ),
+                                    xbmc.LOGWARNING,
+                                )
+                                return _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE, written
                             # Mark before raising so the _serve_proxy handler
                             # can distinguish stall-induced unwind from a
                             # real Kodi disconnect. socket.timeout is an

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -10643,6 +10643,86 @@ def test_passthrough_watchdog_applies_returns_true_only_for_video():
     assert not _passthrough_watchdog_applies({})
 
 
+def test_serve_proxy_arms_explicit_upstream_read_deadline():
+    """The body socket gets a dedicated _UPSTREAM_READ_TIMEOUT recv deadline.
+
+    Guarantees a stalled backend surfaces as a recoverable read (which drives
+    the live fallback cutover) within the deadline, instead of riding the
+    inherited 60 s urlopen timeout and losing the race to the equal 60 s
+    proxy->Kodi write timeout — the wedge that logged as client_disconnected
+    with recoveries=0. See issue #214.
+    """
+    from resources.lib.stream_proxy import _UPSTREAM_READ_TIMEOUT
+
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 2048,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-2047")
+
+    payload = b"A" * 2048
+    resp = _mock_urlopen_response([payload])
+    fake_sock = MagicMock()
+    resp.fp.raw._sock = fake_sock
+    with patch("resources.lib.stream_proxy.urlopen", return_value=resp):
+        handler._serve_proxy(ctx)
+
+    fake_sock.settimeout.assert_called_once_with(_UPSTREAM_READ_TIMEOUT)
+    assert _collect_written(handler) == payload
+
+
+@patch("resources.lib.stream_proxy.xbmc")
+def test_serve_proxy_trickle_triggers_cutover_when_fallback_attached(mock_xbmc):
+    """A sub-floor trickle with a fallback attached drives live cutover.
+
+    Instead of the blind close/reconnect to the SAME stalled upload
+    (terminal_reason=passthrough_stall), the watchdog returns a recoverable
+    result so _serve_proxy runs the fallback cutover. Here the fallback can't
+    be validated (patched to None), so it surfaces as fallback_exhausted —
+    proving the cutover path ran rather than a blind reconnect. The
+    no-fallback case is covered by
+    test_serve_proxy_stall_watchdog_aborts_on_low_throughput. See issue #214.
+    """
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 1048576,
+        "fallback_sources": [
+            {"nzo_id": "alt", "stream_url": "http://host/alt.mkv"},
+        ],
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-1048575")
+
+    # Same trickle as the abort test: two 1 KB chunks, ~82 B/s over a 25 s
+    # window. Monotonic padded so post-return bookkeeping can't exhaust it.
+    chunks = [b"A" * 1024, b"B" * 1024]
+    monotonic_returns = iter([100.0, 105.0, 125.0] + [125.0] * 30)
+
+    with patch(
+        "resources.lib.stream_proxy.time.monotonic",
+        side_effect=lambda: next(monotonic_returns),
+    ), patch(
+        "resources.lib.stream_proxy.urlopen",
+        return_value=_mock_urlopen_response(chunks),
+    ), patch.object(
+        handler, "_select_live_fallback_source", return_value=None
+    ) as mock_select:
+        handler._serve_proxy(ctx)
+
+    # Cutover was attempted (recoverable return -> _select_live_fallback_source)
+    # rather than the blind passthrough_stall reconnect.
+    mock_select.assert_called()
+    assert ctx.get("passthrough_stall_detected", False) is False
+    logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
+    assert "passthrough_stall_fallback" in logged
+    assert "reason=fallback_exhausted" in logged
+    # The blind-reconnect path (outer handler) must NOT have run.
+    assert "Pass-through stall at byte" not in logged
+
+
 @patch("resources.lib.stream_proxy.xbmc")
 def test_serve_proxy_logs_terminal_summary_on_success(mock_xbmc):
     ctx = {


### PR DESCRIPTION
## Problem

When a Usenet upload's article body becomes unavailable (DMCA/retention) or the nzbdav backend stops delivering bytes, pass-through playback **wedges and is torn down as `client_disconnected` without ever triggering the live fallback cutover** — even though fallback uploads are attached (`recoveries=0`, `zero_fill=0`, no `Switched pass-through source`).

Root cause (full analysis in #214):
- Recovery/cutover only runs when `_stream_upstream_range` **returns** `SHORT_READ_RECOVERABLE`/`UPSTREAM_ERROR`.
- The inherited 60 s `urlopen` read timeout **loses the race** to the equal 60 s proxy→Kodi write timeout (`_REMUX_WRITE_TIMEOUT`), so a stall unwinds at the outer handler as `client_disconnected` before the read side can return a recoverable result.
- The throughput watchdog, when it does trip, **raises → blind reconnect** to the same dead source rather than switching uploads.

(Supersedes #213, whose proposed "add a `resp.read()` timeout" was redundant — the `urlopen` timeout already applies to `resp.read()`.)

## Fix

Two additive changes in `_stream_upstream_range`, neither altering the existing watchdog's tested raise/`passthrough_stall`/audio-skip semantics:

1. **Arm an explicit, shorter recv() deadline** (`_UPSTREAM_READ_TIMEOUT = 45 s`) on the body socket once headers arrive, via a best-effort `_set_upstream_read_timeout(resp, ...)` helper. A stalled backend now surfaces as a recoverable read within ~45 s — driving the existing fallback cutover and **winning the race** against the 60 s write timeout — instead of wedging until Kodi gives up. 45 s sits above a realistic single-article fetch, so slow-but-progressing sources aren't falsely rotated. Falls back to the inherited timeout if the socket isn't reachable.

2. **On a throughput-watchdog trip, prefer live cutover when fallbacks exist.** When `bps` is below the floor **and** `ctx["fallback_sources"]` is non-empty, return `SHORT_READ_RECOVERABLE` so `_serve_proxy` switches uploads, instead of a blind reconnect to the same dead source. With no fallback sources, behavior is unchanged (still raises `passthrough_stall`), preserving the existing watchdog tests and the deliberate audio-skip exemption.

## Tests

- `test_serve_proxy_arms_explicit_upstream_read_deadline` — asserts the dedicated read deadline is armed on the body socket.
- `test_serve_proxy_trickle_triggers_cutover_when_fallback_attached` — a sub-floor trickle with a fallback attached drives the cutover path (no `passthrough_stall_detected`; `_select_live_fallback_source` invoked) instead of a blind reconnect.
- Existing watchdog tests (incl. audio-skip and the no-fallback `passthrough_stall` abort) still pass unchanged.

Full default suite: **1565 passed, 5 skipped**; `ruff` clean.

## Out of scope / follow-ups
- Making the throughput watchdog content-type-agnostic (audio is intentionally exempt today).
- A session-level stall accumulator so repeated reconnects to a dead source escalate to fallback (each reconnect resets per-call state today).

Fixes #214.
