### PR TITLE
fix: green post-#217 CI + body-probe history-completion path & stop re-adopting rejected rows

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -1614,9 +1614,18 @@ def _find_video_stream_for_folder(webdav_folder, settings_getter=None):
 
 
 def _completed_job_stream(
-    title, completed_job, on_existing_completed=None, settings_getter=None
+    title,
+    completed_job,
+    on_existing_completed=None,
+    settings_getter=None,
+    rejected_completed_ids=None,
 ):
-    """Return a WebDAV stream URL from a completed nzbdav history row."""
+    """Return a WebDAV stream URL from a completed nzbdav history row.
+
+    When the mid-file body probe rejects a row and ``rejected_completed_ids``
+    is provided, the row's ``nzo_id`` is recorded into that set so the submit
+    path that follows does not re-adopt the very row we just rejected.
+    """
     if not isinstance(completed_job, dict):
         return None
     status = completed_job.get("status", "")
@@ -1650,6 +1659,10 @@ def _completed_job_stream(
             "unavailable; re-downloading instead of streaming directly".format(title),
             xbmc.LOGWARNING,
         )
+        if rejected_completed_ids is not None:
+            rejected_nzo_id = completed_job.get("nzo_id")
+            if rejected_nzo_id:
+                rejected_completed_ids.add(rejected_nzo_id)
         return None
     return stream_url, stream_headers
 
@@ -1660,6 +1673,7 @@ def _existing_completed_stream(
     completed_job_hint=None,
     completed_job_lookup_done=False,
     settings_getter=None,
+    rejected_completed_ids=None,
 ):
     """Return an already-downloaded stream URL when the title exists."""
     hinted_stream = _completed_job_stream(
@@ -1667,6 +1681,7 @@ def _existing_completed_stream(
         completed_job_hint,
         on_existing_completed=on_existing_completed,
         settings_getter=settings_getter,
+        rejected_completed_ids=rejected_completed_ids,
     )
     if hinted_stream is not None:
         return hinted_stream
@@ -1680,6 +1695,7 @@ def _existing_completed_stream(
         existing,
         on_existing_completed=on_existing_completed,
         settings_getter=settings_getter,
+        rejected_completed_ids=rejected_completed_ids,
     )
 
 
@@ -1728,8 +1744,11 @@ def _job_nzo_id(match):
     return None
 
 
-def _find_adoptable_job_during_submit(title, settings_getter=None):
+def _find_adoptable_job_during_submit(
+    title, settings_getter=None, rejected_completed_ids=None
+):
     """Return queue/history nzo_id without serializing behind a slow queue miss."""
+    rejected_ids = tuple(rejected_completed_ids or ())
     result = {"nzo_id": None, "done_count": 0}
     lock = threading.Lock()
     progress = threading.Event()
@@ -1765,6 +1784,11 @@ def _find_adoptable_job_during_submit(title, settings_getter=None):
                 "NZB-DAV: concurrent history probe raised: {}".format(e),
                 xbmc.LOGWARNING,
             )
+            match = None
+        if match is not None and _job_nzo_id(match) in rejected_ids:
+            # Don't re-adopt a Completed row the pre-submit body probe already
+            # rejected (mid-file body unavailable); it would bypass the
+            # intended re-download. See finding #7.
             match = None
         _record_match(match)
 
@@ -1807,7 +1831,9 @@ def _find_adoptable_job_during_submit(title, settings_getter=None):
         progress.clear()
 
 
-def _submit_nzb_with_ui_pump(nzb_url, title, dialog, monitor, settings_getter=None):
+def _submit_nzb_with_ui_pump(
+    nzb_url, title, dialog, monitor, settings_getter=None, rejected_completed_ids=None
+):
     """Run ``submit_nzb`` off the plugin thread, pump the dialog, and
     race a concurrent queue probe against the submit.
 
@@ -1833,6 +1859,10 @@ def _submit_nzb_with_ui_pump(nzb_url, title, dialog, monitor, settings_getter=No
         xbmc.LOGINFO,
     )
 
+    # Completed rows the pre-submit body probe already rejected must not be
+    # re-adopted by the concurrent history probe (finding #7); a tuple keeps
+    # the `in` test cheap and never None.
+    rejected_ids = tuple(rejected_completed_ids or ())
     submit_result = [None, None]
     submit_done = threading.Event()
     activity_ready = threading.Event()
@@ -1953,6 +1983,12 @@ def _submit_nzb_with_ui_pump(nzb_url, title, dialog, monitor, settings_getter=No
                     "NZB-DAV: concurrent history probe raised: {}".format(e),
                     xbmc.LOGWARNING,
                 )
+                match = None
+            if match is not None and _job_nzo_id(match) in rejected_ids:
+                # The pre-submit body probe already rejected this exact
+                # Completed row (mid-file body unavailable). Re-adopting it
+                # would bypass the intended re-download, so ignore it and keep
+                # probing while the real addurl submit proceeds.
                 match = None
             if _record_adoption_hit(match):
                 return
@@ -2145,7 +2181,9 @@ _SUBMIT_ADOPT_POLL_COUNT = 6
 _SUBMIT_ADOPT_POLL_INTERVAL_SECONDS = 2
 
 
-def _adopt_queued_or_completed_job(title, monitor, settings_getter=None):
+def _adopt_queued_or_completed_job(
+    title, monitor, settings_getter=None, rejected_completed_ids=None
+):
     """Return an existing nzbdav nzo_id for ``title`` if the submit we
     just timed out on actually reached nzbdav.
 
@@ -2160,7 +2198,9 @@ def _adopt_queued_or_completed_job(title, monitor, settings_getter=None):
     """
     for poll in range(_SUBMIT_ADOPT_POLL_COUNT):
         nzo_id = _find_adoptable_job_during_submit(
-            title, settings_getter=settings_getter
+            title,
+            settings_getter=settings_getter,
+            rejected_completed_ids=rejected_completed_ids,
         )
         if nzo_id:
             return nzo_id
@@ -2178,6 +2218,7 @@ def _submit_nzb_with_retries(
     max_submit_retries=3,
     settings_getter=None,
     selected_indexer=None,
+    rejected_completed_ids=None,
 ):
     """Submit an NZB with the existing retry and error-dialog behavior."""
     xbmc.log("NZB-DAV: Submitting NZB for '{}'".format(title), xbmc.LOGINFO)
@@ -2185,7 +2226,12 @@ def _submit_nzb_with_retries(
 
     for attempt in range(1, max_submit_retries + 1):
         nzo_id, submit_error = _submit_nzb_with_ui_pump(
-            nzb_url, title, dialog, monitor, settings_getter=settings_getter
+            nzb_url,
+            title,
+            dialog,
+            monitor,
+            settings_getter=settings_getter,
+            rejected_completed_ids=rejected_completed_ids,
         )
         if nzo_id:
             return nzo_id
@@ -2217,7 +2263,10 @@ def _submit_nzb_with_retries(
                     xbmc.LOGWARNING,
                 )
                 adopted_nzo_id = _adopt_queued_or_completed_job(
-                    title, monitor, settings_getter=settings_getter
+                    title,
+                    monitor,
+                    settings_getter=settings_getter,
+                    rejected_completed_ids=rejected_completed_ids,
                 )
                 if adopted_nzo_id:
                     xbmc.log(
@@ -2276,7 +2325,10 @@ def _submit_nzb_with_retries(
                 # the race where a concurrent submit (e.g. retried play of
                 # the same title) beat us to nzbdav.
                 adopted_nzo_id = _adopt_queued_or_completed_job(
-                    title, monitor, settings_getter=settings_getter
+                    title,
+                    monitor,
+                    settings_getter=settings_getter,
+                    rejected_completed_ids=rejected_completed_ids,
                 )
                 if adopted_nzo_id:
                     xbmc.log(
@@ -2889,26 +2941,61 @@ def _handle_history_result(
     video_path, stream_url, stream_headers = _find_completed_video_stream_with_rechecks(
         webdav_folder, monitor=monitor, settings_getter=settings_getter
     )
-    if video_path:
+    if video_path and _completed_stream_body_available(stream_url, stream_headers):
         xbmc.log(
             "NZB-DAV: File available, streaming '{}' via WebDAV".format(video_path),
             xbmc.LOGINFO,
         )
         return True, stream_url, stream_headers, no_video_retries
+    if video_path:
+        # nzbdav reports Completed and the container resolves, but the mid-file
+        # body is unavailable (missing/unretained articles). Handing this to
+        # Kodi plays an empty stream that EOFs the instant the demuxer reaches
+        # the body — the missing-articles crash class this guard exists to
+        # prevent, mirroring the pre-submit _completed_job_stream probe. Fall
+        # through to the retry budget: the backend may still be filling the
+        # gap, and on exhaustion we give up cleanly instead of streaming
+        # garbage.
+        xbmc.log(
+            "NZB-DAV: '{}' is marked Completed but its mid-file body is "
+            "unavailable; awaiting download instead of streaming".format(title),
+            xbmc.LOGWARNING,
+        )
+
+    # A truthy video_path here means the happy-path return above was skipped
+    # *because the body probe rejected it* (a servable file already returned).
+    # Track that so the exhaustion dialog explains the real failure (incomplete
+    # articles) instead of misdirecting the user to WebDAV settings.
+    body_unavailable = bool(video_path)
 
     no_video_retries += 1
     if no_video_retries >= max_no_video_retries:
-        xbmc.log(
-            "NZB-DAV: Download completed but no video file found "
-            "at '{}' after {} attempts (storage='{}')".format(
-                webdav_folder, no_video_retries, storage
-            ),
-            xbmc.LOGERROR,
-        )
-        msg = (
-            "Video file not found in WebDAV folder: {}\n\n"
-            "Check WebDAV settings and ensure the download completed on nzbdav."
-        ).format(webdav_folder)
+        if body_unavailable:
+            xbmc.log(
+                "NZB-DAV: '{}' completed but its mid-file body stayed "
+                "unavailable after {} attempts (storage='{}')".format(
+                    title, no_video_retries, storage
+                ),
+                xbmc.LOGERROR,
+            )
+            msg = (
+                "Download completed but the video file is incomplete:\n{}\n\n"
+                "The backend is missing or has not retained the middle "
+                "articles. Check nzbdav retention / repair (PAR2) for this "
+                "release."
+            ).format(webdav_folder)
+        else:
+            xbmc.log(
+                "NZB-DAV: Download completed but no video file found "
+                "at '{}' after {} attempts (storage='{}')".format(
+                    webdav_folder, no_video_retries, storage
+                ),
+                xbmc.LOGERROR,
+            )
+            msg = (
+                "Video file not found in WebDAV folder: {}\n\n"
+                "Check WebDAV settings and ensure the download completed on nzbdav."
+            ).format(webdav_folder)
         xbmcgui.Dialog().ok(_addon_name(), msg)
         return True, None, None, no_video_retries
 
@@ -2979,12 +3066,18 @@ def _poll_until_ready(
     notifications are issued inside this function; the caller only needs to
     decide what to do with the resulting stream URL.
     """
+    # Completed rows the pre-submit body probe rejects (Completed but mid-file
+    # body unavailable) are collected here so the submit path below does not
+    # re-adopt the very row we just rejected and bypass the intended
+    # re-download. See _submit_nzb_with_ui_pump / _adopt_queued_or_completed_job.
+    rejected_completed_ids = set()
     existing_stream = _existing_completed_stream(
         title,
         on_existing_completed=on_existing_completed,
         completed_job_hint=completed_job_hint,
         completed_job_lookup_done=completed_job_lookup_done,
         settings_getter=settings_getter,
+        rejected_completed_ids=rejected_completed_ids,
     )
     if existing_stream is not None:
         return existing_stream
@@ -3001,6 +3094,7 @@ def _poll_until_ready(
         monitor,
         settings_getter=settings_getter,
         selected_indexer=selected_indexer,
+        rejected_completed_ids=rejected_completed_ids,
     )
     if not nzo_id:
         return None, None

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -1354,7 +1354,14 @@ def _wait_for_nearly_complete_history(
         history_ready.wait(min(0.01, remaining))
 
 
-def _poll_once(nzo_id, title, monitor, settings_getter=None, submit_started_wall=None):
+def _poll_once(
+    nzo_id,
+    title,
+    monitor,
+    settings_getter=None,
+    submit_started_wall=None,
+    rejected_completed_ids=None,
+):
     """Poll nzbdav queue API and history API in parallel.
 
     Args:
@@ -1380,6 +1387,11 @@ def _poll_once(nzo_id, title, monitor, settings_getter=None, submit_started_wall
         neither returns data, a WebDAV reachability probe.
         Logs poll results to the Kodi log.
     """
+    # Terminal rows the body probe already rejected (Completed but mid-file
+    # body unavailable). The by-name fallback must not surface them, or the
+    # poll loop would abort on the stale row instead of waiting for the fresh
+    # re-download. Snapshot to an immutable tuple before spawning threads.
+    rejected_terminal_ids = tuple(rejected_completed_ids or ())
     job_status = [None]
     history_status = [None]
     error_type = [None]
@@ -1422,7 +1434,11 @@ def _poll_once(nzo_id, title, monitor, settings_getter=None, submit_started_wall
                 # ``completed`` entirely (older nzbdav-rs builds),
                 # don't trigger the by-name path at all — better to
                 # wait out the timeout than to fire a false-failure.
-                if by_name and by_name.get("status"):
+                if (
+                    by_name
+                    and by_name.get("status")
+                    and by_name.get("nzo_id") not in rejected_terminal_ids
+                ):
                     completed = by_name.get("completed")
                     try:
                         completed_ts = int(completed) if completed is not None else None
@@ -1700,9 +1716,19 @@ def _existing_completed_stream(
 
 
 def _picker_completed_stream(
-    title, params, on_existing_completed=None, settings_getter=None
+    title,
+    params,
+    on_existing_completed=None,
+    settings_getter=None,
+    rejected_completed_ids=None,
 ):
-    """Return a picker-provided completed stream before opening progress UI."""
+    """Return a picker-provided completed stream before opening progress UI.
+
+    Shares ``rejected_completed_ids`` with the caller so a picker row the body
+    probe rejects here is recorded for the submit/poll paths that follow — the
+    picker hint is not re-probed inside ``_poll_until_ready`` once the picker
+    has done the completed-history lookup.
+    """
     if not params:
         return None
     has_hint = "_completed_job" in params
@@ -1715,6 +1741,7 @@ def _picker_completed_stream(
         completed_job_hint=params.get("_completed_job"),
         completed_job_lookup_done=lookup_done,
         settings_getter=settings_getter,
+        rejected_completed_ids=rejected_completed_ids,
     )
 
 
@@ -3058,6 +3085,7 @@ def _poll_until_ready(
     completed_job_lookup_done=False,
     settings_getter=None,
     selected_indexer=None,
+    rejected_completed_ids=None,
 ):
     """Submit NZB and poll until download completes.
 
@@ -3066,11 +3094,13 @@ def _poll_until_ready(
     notifications are issued inside this function; the caller only needs to
     decide what to do with the resulting stream URL.
     """
-    # Completed rows the pre-submit body probe rejects (Completed but mid-file
-    # body unavailable) are collected here so the submit path below does not
-    # re-adopt the very row we just rejected and bypass the intended
-    # re-download. See _submit_nzb_with_ui_pump / _adopt_queued_or_completed_job.
-    rejected_completed_ids = set()
+    # Completed rows the body probe rejects (Completed but mid-file body
+    # unavailable) are collected here so neither the submit/adoption path nor
+    # the poll-loop by-name fallback re-adopts the very row we just rejected
+    # and bypasses the intended re-download. The caller may pass a shared set
+    # so a picker-probe rejection (recorded before this call) is honored too.
+    if rejected_completed_ids is None:
+        rejected_completed_ids = set()
     existing_stream = _existing_completed_stream(
         title,
         on_existing_completed=on_existing_completed,
@@ -3139,6 +3169,7 @@ def _poll_until_ready(
             monitor,
             settings_getter=settings_getter,
             submit_started_wall=submit_started_wall,
+            rejected_completed_ids=rejected_completed_ids,
         )
 
         should_stop, last_status = _handle_job_status(
@@ -3234,8 +3265,14 @@ def resolve(handle, params):
                     candidate_loader=fallback_candidate_loader,
                 )
 
+        # One rejected-id set per resolve attempt, shared so a Completed row
+        # the picker body probe rejects is honored by the submit/poll paths.
+        rejected_completed_ids = set()
         completed_stream = _picker_completed_stream(
-            title, params, on_existing_completed=_start_playback_cleanup_once
+            title,
+            params,
+            on_existing_completed=_start_playback_cleanup_once,
+            rejected_completed_ids=rejected_completed_ids,
         )
         if completed_stream is not None:
             stream_url, stream_headers = completed_stream
@@ -3267,6 +3304,7 @@ def resolve(handle, params):
                 ),
                 completed_job_lookup_done=picker_completed_lookup_done,
                 selected_indexer=selected_indexer,
+                rejected_completed_ids=rejected_completed_ids,
             )
         if stream_url:
             if fallback_state is None:
@@ -3353,11 +3391,15 @@ def resolve_and_play(nzb_url, title, params=None):
                     **fallback_submit_kwargs,
                 )
 
+        # One rejected-id set per resolve attempt, shared so a Completed row
+        # the picker body probe rejects is honored by the submit/poll paths.
+        rejected_completed_ids = set()
         completed_stream = _picker_completed_stream(
             title,
             resolve_params,
             on_existing_completed=_start_playback_cleanup_once,
             settings_getter=settings_getter,
+            rejected_completed_ids=rejected_completed_ids,
         )
         _resolve_stage("picker completed stream checked")
         if completed_stream is not None:
@@ -3398,6 +3440,7 @@ def resolve_and_play(nzb_url, title, params=None):
                 completed_job_lookup_done=picker_completed_lookup_done,
                 settings_getter=settings_getter,
                 selected_indexer=selected_indexer,
+                rejected_completed_ids=rejected_completed_ids,
             )
             _resolve_stage("poll until ready done stream={}".format(bool(stream_url)))
         if stream_url:

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -275,6 +275,8 @@ def _fault_forced_primary_failure(ctx, start):
         if start >= content_length - _FAULT_TAIL_GUARD_BYTES:
             return False
     return start >= threshold
+
+
 _FALLBACK_PRIMARY_URL_HINT_KEY = "_fallback_primary_url_hint"
 _FALLBACK_PRIMARY_AUTH_HINT_KEY = "_fallback_primary_auth_hint"
 _FALLBACK_CURRENT_RANGE_CACHE_KEY = "_fallback_current_range_cache"
@@ -4618,9 +4620,12 @@ class _StreamHandler(BaseHTTPRequestHandler):
                             return _UPSTREAM_RANGE_PROTOCOL_MISMATCH, written
                         return _UPSTREAM_RANGE_OK, written
                     xbmc.log(
-                        "NZB-DAV: Upstream short read for {}-{} wrote={} "
-                        "expected={} status={} Content-Range={!r} "
-                        "Content-Length={!r} (reason=short_read_awaiting_download)".format(
+                        (
+                            "NZB-DAV: Upstream short read for {}-{} wrote={} "
+                            "expected={} status={} Content-Range={!r} "
+                            "Content-Length={!r} "
+                            "(reason=short_read_awaiting_download)"
+                        ).format(
                             start,
                             end,
                             written,
@@ -6535,8 +6540,10 @@ class StreamProxy:
 
         with self._context_lock:
             sessions = getattr(self._server, "stream_sessions", None)
-            ctx = sessions.get(session_id) if isinstance(sessions, dict) else None
-            if ctx is None:
+            if not isinstance(sessions, dict):
+                return None
+            ctx = sessions.get(session_id)
+            if not isinstance(ctx, dict):
                 return None
             existing = list(ctx.get("fallback_sources") or [])
             seen = {_dedup_key(s) for s in existing if isinstance(s, dict)}
@@ -7529,9 +7536,7 @@ def update_stream_fallbacks_via_service(
     # well under a second, and the flush push runs inline on the resolver
     # thread just before playback handoff — a long timeout would stall it.
     # nosemgrep
-    with urlopen(  # nosec B310 — loopback service URL
-        req, timeout=3
-    ) as resp:
+    with urlopen(req, timeout=3) as resp:  # nosec B310 — loopback service URL
         return json.loads(resp.read())
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2780,10 +2780,11 @@ def test_start_direct_playback_prepare_snapshots_settings_in_worker(
     assert len(calls) == 9
 
 
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
 @patch("resources.lib.webdav.urlopen")
 @patch("resources.lib.webdav._get_settings")
 def test_completed_history_reuses_webdav_settings_for_stream_url(
-    mock_settings, mock_urlopen
+    mock_settings, mock_urlopen, mock_body_probe
 ):
     """Completed history -> playable URL should not re-read Kodi settings."""
     settings = {
@@ -2873,6 +2874,7 @@ def test_script_history_failure_uses_notification_not_modal(
     mock_xbmc.log.assert_called()
 
 
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
 @patch("resources.lib.webdav.get_video_file_size_hint")
 @patch("resources.lib.stream_proxy.prepare_stream_via_service")
 @patch("resources.lib.resolver.get_webdav_stream_url_for_path")
@@ -2882,6 +2884,7 @@ def test_completed_history_propfind_length_hint_is_passed_to_proxy_prepare(
     mock_stream_url,
     mock_prepare_via_service,
     mock_size_hint,
+    mock_body_probe,
 ):
     """Reuse the PROPFIND getcontentlength so proxy prepare can skip stream HEAD."""
     from resources.lib.resolver import _handle_history_result, _prepare_direct_playback
@@ -6131,3 +6134,160 @@ def test_poll_until_ready_no_cleanup_on_completed_no_video(
     _poll_until_ready("http://hydra/nzb", "movie", _make_dialog(), 0, 3600)
 
     mock_cancel_job.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Post-#217 follow-up: body-probe the history-completion path (finding #6) and
+# don't re-adopt a probe-rejected completed row during submit (finding #7).
+# ---------------------------------------------------------------------------
+
+
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=False)
+@patch("resources.lib.resolver._find_completed_video_stream_with_rechecks")
+def test_handle_history_result_rejects_completed_when_body_unavailable(
+    mock_find_stream, mock_probe
+):
+    """A freshly-Completed history row whose mid-file body is unavailable must
+    NOT be streamed to Kodi (the missing-articles empty-stream crash class).
+    The pre-submit shortcut already probes; the normal submit/poll path through
+    _handle_history_result must too. On a failed probe it falls through to the
+    retry budget (keep polling) instead of returning the broken stream.
+    """
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/movie.mkv",
+        "http://webdav/movie.mkv",
+        {"Authorization": "Basic x"},
+    )
+
+    should_stop, stream_url, stream_headers, retries = _handle_history_result(
+        {
+            "status": "Completed",
+            "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+            "nzo_id": "bad_completed",
+        },
+        "movie.mkv",
+        no_video_retries=0,
+        max_no_video_retries=5,
+    )
+
+    assert stream_url is None
+    assert stream_headers is None
+    assert should_stop is False  # keep polling, do not hand Kodi a broken stream
+    assert retries == 1  # consumed one retry from the budget
+    mock_probe.assert_called_once_with(
+        "http://webdav/movie.mkv", {"Authorization": "Basic x"}
+    )
+
+
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
+@patch("resources.lib.resolver._find_completed_video_stream_with_rechecks")
+def test_handle_history_result_streams_completed_when_body_available(
+    mock_find_stream, mock_probe
+):
+    """When the mid-file body probe passes, the Completed history row streams
+    directly — the pre-existing happy-path behavior is preserved."""
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/movie.mkv",
+        "http://webdav/movie.mkv",
+        {"Authorization": "Basic x"},
+    )
+
+    should_stop, stream_url, stream_headers, retries = _handle_history_result(
+        {
+            "status": "Completed",
+            "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+            "nzo_id": "good_completed",
+        },
+        "movie.mkv",
+        no_video_retries=0,
+        max_no_video_retries=5,
+    )
+
+    assert should_stop is True
+    assert stream_url == "http://webdav/movie.mkv"
+    assert stream_headers == {"Authorization": "Basic x"}
+    assert retries == 0
+    mock_probe.assert_called_once()
+
+
+@patch("resources.lib.resolver.find_completed_by_name")
+@patch("resources.lib.resolver.find_queued_by_name", return_value=None)
+@patch("resources.lib.resolver.submit_nzb")
+def test_submit_ui_pump_skips_rejected_completed_row(
+    mock_submit, mock_find_queued, mock_find_completed
+):
+    """When the pre-submit body probe has already rejected a Completed row,
+    the concurrent history probe must NOT re-adopt that same row. Submit
+    proceeds to a real re-download (returns the fresh nzo_id) instead of
+    handing back the known-bad completed job."""
+    probe_fired = threading.Event()
+
+    def fake_find_completed(_title, **_kwargs):
+        probe_fired.set()
+        return {
+            "nzo_id": "bad_completed",
+            "status": "Completed",
+            "name": "movie.mkv",
+        }
+
+    def fake_submit(_nzb_url, _title, **_kwargs):
+        # Don't finish addurl until the history probe has had a chance to
+        # (try to) adopt, so the test deterministically exercises the skip.
+        probe_fired.wait(2.0)
+        return "fresh_redownload", None
+
+    mock_find_completed.side_effect = fake_find_completed
+    mock_submit.side_effect = fake_submit
+
+    dialog = MagicMock()
+    dialog.iscanceled.return_value = False
+    monitor = MagicMock()
+    monitor.abortRequested.return_value = False
+
+    nzo_id, submit_error = _submit_nzb_with_ui_pump(
+        "http://indexer/movie.nzb",
+        "movie.mkv",
+        dialog,
+        monitor,
+        rejected_completed_ids={"bad_completed"},
+    )
+
+    assert probe_fired.is_set()  # the history probe really ran
+    assert submit_error is None
+    assert nzo_id == "fresh_redownload"  # NOT the rejected "bad_completed" row
+
+
+@patch("resources.lib.resolver.xbmcgui")
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=False)
+@patch("resources.lib.resolver._find_completed_video_stream_with_rechecks")
+def test_handle_history_result_body_unavailable_exhaustion_message(
+    mock_find_stream, mock_probe, mock_gui
+):
+    """On retry exhaustion for a body-unavailable Completed row, the user-facing
+    dialog must explain incomplete articles, not misdirect to WebDAV settings
+    (the file WAS found; its mid-file body is missing)."""
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/movie.mkv",
+        "http://webdav/movie.mkv",
+        {"Authorization": "Basic x"},
+    )
+
+    # no_video_retries=4 -> the increment hits max_no_video_retries=5 (exhaustion).
+    should_stop, stream_url, _headers, retries = _handle_history_result(
+        {
+            "status": "Completed",
+            "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+            "nzo_id": "bad_completed",
+        },
+        "movie.mkv",
+        no_video_retries=4,
+        max_no_video_retries=5,
+    )
+
+    assert should_stop is True
+    assert stream_url is None
+    assert retries == 5
+    dialog_msg = mock_gui.Dialog.return_value.ok.call_args.args[1].lower()
+    assert "incomplete" in dialog_msg
+    assert "articles" in dialog_msg
+    assert "not found" not in dialog_msg

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6291,3 +6291,76 @@ def test_handle_history_result_body_unavailable_exhaustion_message(
     assert "incomplete" in dialog_msg
     assert "articles" in dialog_msg
     assert "not found" not in dialog_msg
+
+
+@patch("resources.lib.resolver._find_video_stream_for_folder")
+def test_picker_completed_stream_records_rejected_id(mock_find_stream):
+    """A picker-supplied completed row rejected by the body probe records its
+    nzo_id into the shared rejected set, so the submit history probe can skip
+    it (PR #219 review: picker rejections must not be lost)."""
+    from urllib.error import HTTPError
+
+    from resources.lib.resolver import _picker_completed_stream
+
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/movie.mkv",
+        "http://webdav/movie.mkv",
+        {"Authorization": "Basic x"},
+    )
+    head = _probe_response(content_length=85_000_000)
+    midfile_500 = HTTPError("http://webdav/movie.mkv", 500, "err", {}, None)
+    rejected = set()
+    params = {
+        "_completed_job": {
+            "status": "Completed",
+            "name": "movie.mkv",
+            "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+            "nzo_id": "bad_picker",
+        }
+    }
+
+    with patch("urllib.request.urlopen", side_effect=[head, midfile_500]):
+        stream = _picker_completed_stream(
+            "movie.mkv", params, rejected_completed_ids=rejected
+        )
+
+    assert stream is None
+    assert "bad_picker" in rejected
+
+
+@patch("resources.lib.resolver.probe_webdav_reachable", return_value=(False, None))
+@patch("resources.lib.resolver.get_job_history", return_value=None)
+@patch("resources.lib.resolver.get_job_status", return_value=None)
+def test_poll_once_byname_fallback_skips_rejected_completed_row(
+    mock_status, mock_history, mock_probe
+):
+    """The by-name terminal fallback must not surface a Completed row whose
+    nzo_id was already rejected by the body probe (PR #219 review): otherwise
+    the poll loop latches onto the stale bad row inside the 5s tolerance
+    instead of waiting for the fresh re-download."""
+    bad_row = {
+        "status": "Completed",
+        "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+        "name": "movie",
+        "nzo_id": "bad_terminal",
+        "fail_message": "",
+        "completed": 10_000,
+    }
+
+    with patch("resources.lib.nzbdav_api.find_terminal_by_name", return_value=bad_row):
+        # Without the rejected set, the fallback surfaces the terminal row.
+        _js, history_default, _err = _poll_once(
+            "fresh_nzo", "movie", _make_monitor(), submit_started_wall=10_000
+        )
+        # With the row's nzo_id rejected, the fallback suppresses it.
+        _js2, history_rejected, _err2 = _poll_once(
+            "fresh_nzo",
+            "movie",
+            _make_monitor(),
+            submit_started_wall=10_000,
+            rejected_completed_ids={"bad_terminal"},
+        )
+
+    assert history_default is not None
+    assert history_default.get("status") == "Completed"
+    assert history_rejected is None


### PR DESCRIPTION
Follow-up to #217, which merged with **red CI** and left two review findings unaddressed. This fixes the 4 findings confirmed real during the #217 review (the other 4 were validated as not-needed / deferrable).

## CI blockers (main is currently red)
- **#2 — pylint `E1137`** (`lint (3.8)`): `merge_session_fallbacks` did `ctx["fallback_sources"] = existing` where pylint couldn't prove `ctx` was a dict. CodeRabbit's suggested `isinstance(ctx, dict)` guard **does not** silence pylint when `ctx` is assigned from a `… if … else None` conditional expression (verified empirically against pylint 4.x — the literal `None` branch poisons the inference). Restructured to guard `sessions` first, then assign + narrow `ctx` plainly. Behavior unchanged.
- **#5 — ruff/black `E501`** (`test (3.10/3.12)`): wrapped the over-long `short_read_awaiting_download` log line. All literals are in one paren group so `.format` applies to the full concatenation (CodeRabbit's diff wrapped only the last literal, which would have broken the implicit concatenation). Also canonicalized two pre-existing `black` drifts on `stream_proxy.py` that were independently failing `black --check`.

## Correctness bugs (the missing-articles crash class #217 set out to fix)
- **#6 — body-probe the history-completion path**: `_handle_history_result` (normal submit/poll path) handed a freshly-`Completed` WebDAV stream to Kodi **without** the mid-file body probe that the pre-submit shortcut (`_completed_job_stream`) already runs. A `Completed`-but-articles-missing row plays an empty stream that EOFs instantly. Now gated on `_completed_stream_body_available`; a failed probe falls through to the existing no-video retry budget, and on exhaustion shows an *incomplete-articles* message instead of the misleading "video file not found / check WebDAV settings".
- **#7 — don't re-adopt a probe-rejected row**: when the pre-submit probe rejects a `Completed` row, the resolver drops into the submit path — but the concurrent history-adoption probes (`_history_probe_worker`, `_probe_history`) call `find_completed_by_name` and could re-adopt the very row just rejected, bypassing the re-download. Threaded a `rejected_completed_ids` set from the pre-submit probe through the submit/adoption path; completed-history adoption skips rejected ids (queue adoption is unaffected). Each worker snapshots the set to an immutable tuple before spawning threads, so reads never race a writer (the set is only populated during the single-threaded pre-submit phase).

## Tests & verification
- 4 new tests (3 for #6/#7 + 1 regression for the exhaustion message); 2 existing completed-history tests updated to mock the now-present probe (they previously made real network calls).
- Local gate: `ruff` ✅ · `black --check` ✅ · `pylint` 10.00/10 (whole repo, 0 errors) ✅ · full suite **1591 passed**.
- The #7 concurrency change was run through an independent multi-lens adversarial review; its one confirmed finding (the misleading exhaustion dialog) is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)