### PR TITLE
fix(security): clear code-scanning backlog (44 alerts)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # Always run the Pages infra scripts from the trusted default branch
+          # rather than the workflow_run head SHA. The deploy reads releases via
+          # the API and downloads the published asset, so it never needs the
+          # triggering ref's tree. Avoids checking out untrusted code in this
+          # privileged (pages: write, id-token: write) context.
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       - ./kodi-config:/config
       - ./plugin.video.nzbdav:/config/addons/plugin.video.nzbdav
     restart: unless-stopped
+    # Prevent privilege escalation via setuid/setgid binaries in this test
+    # container. A read-only root filesystem is intentionally NOT set: the
+    # linuxserver/kodi image writes runtime state across the rootfs.
+    security_opt:
+      - "no-new-privileges:true"
     networks:
       - test-net
 
@@ -27,6 +32,10 @@ services:
     environment:
       - VNC_PASSWORD=test123
     restart: unless-stopped
+    # Prevent privilege escalation via setuid/setgid binaries. The desktop/X11
+    # image requires a writable root filesystem, so read_only is not set.
+    security_opt:
+      - "no-new-privileges:true"
     networks:
       - test-net
 

--- a/repo/plugin.video.nzbdav/addon.py
+++ b/repo/plugin.video.nzbdav/addon.py
@@ -10,7 +10,7 @@ import sys
 # the extreme functional test can pull it out of the kodi container even if
 # stderr/stdout are dropped on the floor when Kodi crashes.
 try:
-    _fh = open("/tmp/nzbdav-faulthandler.log", "a", buffering=1)
+    _fh = open("/tmp/nzbdav-faulthandler.log", "a", buffering=1)  # nosec B108
     faulthandler.enable(file=_fh, all_threads=True)
 except OSError:
     pass

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -17,7 +17,11 @@ from types import SimpleNamespace
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
 from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
-from xml.etree import ElementTree as ET
+
+try:
+    from defusedxml import ElementTree as ET
+except ImportError:  # pragma: no cover - Kodi installs may not bundle defusedxml
+    from xml.etree import ElementTree as ET
 
 import xbmc
 import xbmcaddon
@@ -525,8 +529,8 @@ _TITLE_STOP_TOKENS = frozenset(
         "x265",
     )
 )
-_TITLE_TOKEN_CACHE_TITLE_KEY = "_fallback_title_tokens_title"
-_TITLE_TOKEN_CACHE_VALUE_KEY = "_fallback_title_tokens"
+_TITLE_TOKEN_CACHE_TITLE_KEY = "_fallback_title_tokens_title"  # nosec B105 — cache key
+_TITLE_TOKEN_CACHE_VALUE_KEY = "_fallback_title_tokens"  # nosec B105 — cache key
 _PREFETCH_PROOF_KEY = "_fallback_prefetch_gate_proof"
 _SELECTION_POOL_FIRST_PEER_KEY = "_fallback_selection_pool_first_peer"
 FALLBACK_CANDIDATES_DISABLED = object()

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -777,7 +777,7 @@ def _start_direct_playback_service_config_lookup():
         "done": done,
         "error": None,
         "service_port": None,
-        "prepare_token": "",
+        "prepare_token": "",  # nosec B105 — empty init value, not a secret
         "thread": None,
     }
 

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -472,7 +472,10 @@ def _get_addon_setting(addon, key, default="", runtime_default=None):
 
 def _get_script_setting(key, default=""):
     """Read this addon's setting from settings.xml without Kodi settings APIs."""
-    from xml.etree import ElementTree as element_tree
+    try:
+        from defusedxml import ElementTree as element_tree
+    except ImportError:  # pragma: no cover - Kodi installs may not bundle defusedxml
+        from xml.etree import ElementTree as element_tree
 
     for settings_path in _script_settings_paths():
         try:

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -275,6 +275,8 @@ def _fault_forced_primary_failure(ctx, start):
         if start >= content_length - _FAULT_TAIL_GUARD_BYTES:
             return False
     return start >= threshold
+
+
 _FALLBACK_PRIMARY_URL_HINT_KEY = "_fallback_primary_url_hint"
 _FALLBACK_PRIMARY_AUTH_HINT_KEY = "_fallback_primary_auth_hint"
 _FALLBACK_CURRENT_RANGE_CACHE_KEY = "_fallback_current_range_cache"
@@ -306,8 +308,8 @@ _ZERO_FILL_BUFFER = bytes(65536)
 # buffering stall on a healthy client while still bounding zombie lifetime.
 _REMUX_WRITE_TIMEOUT = 60
 _REMUX_STDOUT_IDLE_TIMEOUT = 30.0
-_PREPARE_TOKEN_HEADER = "X-NZBDAV-Token"
-_PROP_PROXY_TOKEN = "nzbdav.proxy_token"
+_PREPARE_TOKEN_HEADER = "X-NZBDAV-Token"  # nosec B105 — HTTP header name, not a secret
+_PROP_PROXY_TOKEN = "nzbdav.proxy_token"  # nosec B105 — settings key, not a secret
 # POST /stream/<session_id>/fallbacks — merge late-adopted fallback sources into
 # a live session whose /prepare snapshot was taken before the fallback worker
 # finished adopting them (the cutover-never-fires race).
@@ -4880,7 +4882,7 @@ class _ThreadedHTTPServer(_ThreadingMixIn, HTTPServer):
         self.current_byte_pos = 0
         self.ffmpeg_lock = threading.Lock()
         self.owner_proxy = None
-        self.prepare_token = ""
+        self.prepare_token = ""  # nosec B105 — empty init value, not a secret
         super().__init__(*args, **kwargs)
 
 
@@ -7529,9 +7531,7 @@ def update_stream_fallbacks_via_service(
     # well under a second, and the flush push runs inline on the resolver
     # thread just before playback handoff — a long timeout would stall it.
     # nosemgrep
-    with urlopen(  # nosec B310 — loopback service URL
-        req, timeout=3
-    ) as resp:
+    with urlopen(req, timeout=3) as resp:  # nosec B310 — loopback service URL
         return json.loads(resp.read())
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -4620,9 +4620,12 @@ class _StreamHandler(BaseHTTPRequestHandler):
                             return _UPSTREAM_RANGE_PROTOCOL_MISMATCH, written
                         return _UPSTREAM_RANGE_OK, written
                     xbmc.log(
-                        "NZB-DAV: Upstream short read for {}-{} wrote={} "
-                        "expected={} status={} Content-Range={!r} "
-                        "Content-Length={!r} (reason=short_read_awaiting_download)".format(
+                        (
+                            "NZB-DAV: Upstream short read for {}-{} wrote={} "
+                            "expected={} status={} Content-Range={!r} "
+                            "Content-Length={!r} "
+                            "(reason=short_read_awaiting_download)"
+                        ).format(
                             start,
                             end,
                             written,
@@ -6537,8 +6540,10 @@ class StreamProxy:
 
         with self._context_lock:
             sessions = getattr(self._server, "stream_sessions", None)
-            ctx = sessions.get(session_id) if isinstance(sessions, dict) else None
-            if ctx is None:
+            if not isinstance(sessions, dict):
+                return None
+            ctx = sessions.get(session_id)
+            if not isinstance(ctx, dict):
                 return None
             existing = list(ctx.get("fallback_sources") or [])
             seen = {_dedup_key(s) for s in existing if isinstance(s, dict)}

--- a/repo/plugin.video.nzbdav/service.py
+++ b/repo/plugin.video.nzbdav/service.py
@@ -12,7 +12,7 @@ from enum import Enum
 # Same faulthandler hook as addon.py, but the service runs continuously so
 # this catches crashes during the long-lived stream-proxy thread too.
 try:
-    _fh = open("/tmp/nzbdav-faulthandler-service.log", "a", buffering=1)
+    _fh = open("/tmp/nzbdav-faulthandler-service.log", "a", buffering=1)  # nosec B108
     faulthandler.enable(file=_fh, all_threads=True)
 except OSError:
     pass
@@ -34,7 +34,7 @@ _PROP_STREAM_URL = "nzbdav.stream_url"
 _PROP_STREAM_TITLE = "nzbdav.stream_title"
 _PROP_ACTIVE = "nzbdav.active"
 _PROP_PROXY_PORT = "nzbdav.proxy_port"
-_PROP_PROXY_TOKEN = "nzbdav.proxy_token"
+_PROP_PROXY_TOKEN = "nzbdav.proxy_token"  # nosec B105 — settings key, not a secret
 
 _HOME_WINDOW = xbmcgui.Window(10000)
 _PLAYER_RUNTIME_ERRORS = (


### PR DESCRIPTION
Goes through the entire open GitHub code-scanning backlog (**44 alerts**) and resolves every one — real fixes / in-code suppressions where actionable, documented API dismissals for verified false positives and stale alerts. Each alert was triaged against the actual code and the security-relevant verdicts were adversarially re-verified.

## Fixed in code (12 — clear on the next Bandit/Semgrep scan)
- **Bandit B105 ×7** (`hardcoded_password_string`): `# nosec B105` on string *constants* the heuristic mis-flags — an HTTP header name (`X-NZBDAV-Token`), settings keys (`nzbdav.proxy_token`), fallback cache keys, empty init values. None are secrets.
- **Bandit B108 ×2** (`hardcoded_tmp_directory`): `# nosec B108` on the fixed faulthandler crash-log paths (intentional diagnostics).
- **Semgrep XXE ×2** (`use-defused-xml-parse`): `router.py` + `fallback_streams.py` now import `defusedxml.ElementTree` with a stdlib fallback (mirrors the existing `hydra.py` pattern) — hardens settings/PROPFIND XML parsing.
- **Semgrep docker-compose `no-new-privileges` ×2**: added `security_opt: ["no-new-privileges:true"]` to both test services.
- **Semgrep `workflow-run-target-code-checkout`**: `pages.yml` now checks out `ref: main` instead of the `workflow_run` head SHA, so the privileged Pages deploy never runs infra scripts from an untrusted ref.

## Dismissed with documented reasons (32)
- **CodeQL critical/high ×7** — `command-injection`, `full-ssrf` ×2, `clear-text-storage/logging` ×3, `weak-sensitive-data-hashing` — verified **false positives**: the ffmpeg path is `shell=False` + list argv gated by `_is_safe_ffmpeg_cmd` and `_validate_url` (http(s)-only, control-char reject); the proxy only fetches the user's own configured/validated backend; the flagged "passwords" are diagnostic strings / a content digest. (CodeQL ignores inline suppressions, so these are dismissed via the API.)
- **CodeQL ×4** in `tests/extreme/*` → `used in tests`.
- **docker-compose writable-filesystem ×2** → `won't fix` (dev/test containers need a writable rootfs; `no-new-privileges` added instead).
- **Codacy/Prospector/Pylint ×17** → `won't fix` (**stale** — they cite the pre-restructure top-level `plugin.video.nzbdav/` path that no longer exists; the tracked `repo/` copy passes pylint 10/10).

## Notes
- Also carries the pending CI-unblock from #219 (the `E1137`/`E501`/black fixes) since this branches off the currently-red `main`, so this PR's own CI is green.
- Verification: ruff ✅ · black ✅ · pylint 10.00/10 ✅ · full suite **1588 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)