### PR TITLE
style(tooling): clear ruff/black warnings in dev & CI scripts + gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
 
       - name: Lint
         run: |
-          ruff check repo/plugin.video.nzbdav/ tests/ --exclude="repo/plugin.video.nzbdav/resources/lib/ptt/"
-          black --check repo/plugin.video.nzbdav/ tests/ --exclude="ptt/"
+          ruff check repo/plugin.video.nzbdav/ tests/ scripts/ dev/ --exclude="repo/plugin.video.nzbdav/resources/lib/ptt/"
+          black --check repo/plugin.video.nzbdav/ tests/ scripts/ dev/ --exclude="ptt/"
 
       - name: Test
         run: python -m pytest tests/ -v --tb=short -m "not integration and not functional and not extreme"

--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -131,7 +131,10 @@ def _main():
     ap.add_argument(
         "--nzbdav-url",
         default=os.environ.get("NZBDAV_URL", "http://localhost:8180"),
-        help="default: %(default)s (nzbdav-rs container listens on 8080; host-published on NZBDAV_PORT, default 8180)",
+        help=(
+            "default: %(default)s (nzbdav-rs container listens on 8080; "
+            "host-published on NZBDAV_PORT, default 8180)"
+        ),
     )
     ap.add_argument(
         "--nzbdav-api-key",

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -275,6 +275,8 @@ def _fault_forced_primary_failure(ctx, start):
         if start >= content_length - _FAULT_TAIL_GUARD_BYTES:
             return False
     return start >= threshold
+
+
 _FALLBACK_PRIMARY_URL_HINT_KEY = "_fallback_primary_url_hint"
 _FALLBACK_PRIMARY_AUTH_HINT_KEY = "_fallback_primary_auth_hint"
 _FALLBACK_CURRENT_RANGE_CACHE_KEY = "_fallback_current_range_cache"
@@ -4618,9 +4620,12 @@ class _StreamHandler(BaseHTTPRequestHandler):
                             return _UPSTREAM_RANGE_PROTOCOL_MISMATCH, written
                         return _UPSTREAM_RANGE_OK, written
                     xbmc.log(
-                        "NZB-DAV: Upstream short read for {}-{} wrote={} "
-                        "expected={} status={} Content-Range={!r} "
-                        "Content-Length={!r} (reason=short_read_awaiting_download)".format(
+                        (
+                            "NZB-DAV: Upstream short read for {}-{} wrote={} "
+                            "expected={} status={} Content-Range={!r} "
+                            "Content-Length={!r} "
+                            "(reason=short_read_awaiting_download)"
+                        ).format(
                             start,
                             end,
                             written,
@@ -6535,8 +6540,10 @@ class StreamProxy:
 
         with self._context_lock:
             sessions = getattr(self._server, "stream_sessions", None)
-            ctx = sessions.get(session_id) if isinstance(sessions, dict) else None
-            if ctx is None:
+            if not isinstance(sessions, dict):
+                return None
+            ctx = sessions.get(session_id)
+            if not isinstance(ctx, dict):
                 return None
             existing = list(ctx.get("fallback_sources") or [])
             seen = {_dedup_key(s) for s in existing if isinstance(s, dict)}
@@ -7529,9 +7536,7 @@ def update_stream_fallbacks_via_service(
     # well under a second, and the flush push runs inline on the resolver
     # thread just before playback handoff — a long timeout would stall it.
     # nosemgrep
-    with urlopen(  # nosec B310 — loopback service URL
-        req, timeout=3
-    ) as resp:
+    with urlopen(req, timeout=3) as resp:  # nosec B310 — loopback service URL
         return json.loads(resp.read())
 
 

--- a/scripts/build_zip.py
+++ b/scripts/build_zip.py
@@ -64,9 +64,9 @@ def build_zip(addon_dir="repo/plugin.video.nzbdav", output_dir="."):
                 if f in skip_files or os.path.splitext(f)[1] in skip_ext:
                     continue
                 filepath = os.path.join(root, f)
-                arcname = os.path.relpath(
-                    filepath, os.path.dirname(addon_dir)
-                ).replace(os.sep, "/")
+                arcname = os.path.relpath(filepath, os.path.dirname(addon_dir)).replace(
+                    os.sep, "/"
+                )
                 info = zipfile.ZipInfo(arcname)
                 info.compress_type = zipfile.ZIP_DEFLATED
                 info.external_attr = FILE_ATTR

--- a/scripts/chroma_dev_search.py
+++ b/scripts/chroma_dev_search.py
@@ -56,7 +56,7 @@ AGENT_SKILL_PATHS = (
 )
 AGENT_MCP_INSTALL_HINTS = {
     "chroma": (
-        'codex mcp add chroma --env CHROMA_CLIENT_TYPE=cloud '
+        "codex mcp add chroma --env CHROMA_CLIENT_TYPE=cloud "
         '--env CHROMA_HOST="$CHROMA_HOST" '
         '--env CHROMA_API_KEY="$CHROMA_API_KEY" '
         '--env CHROMA_TENANT="$CHROMA_TENANT" '
@@ -64,8 +64,7 @@ AGENT_MCP_INSTALL_HINTS = {
         "uvx chroma-mcp --client-type cloud"
     ),
     "chroma-docs": (
-        "codex mcp add chroma-docs -- "
-        "npx mcp-remote https://docs.trychroma.com/mcp"
+        "codex mcp add chroma-docs -- " "npx mcp-remote https://docs.trychroma.com/mcp"
     ),
     "package-search": (
         'codex mcp add package-search --env X_CHROMA_TOKEN="$CHROMA_API_KEY" -- '
@@ -299,9 +298,7 @@ def ensure_chroma_config(
 
     prompted = {}
     if missing:
-        print(
-            "Chroma Cloud dev search needs configuration before indexing/searching."
-        )
+        print("Chroma Cloud dev search needs configuration before indexing/searching.")
         prompted = _prompt_for_required_chroma_values(
             missing,
             input_func=input_func,
@@ -331,9 +328,7 @@ def ensure_chroma_config(
     if values_to_append:
         _append_chroma_env(env_file, values_to_append)
     if values_to_rewrite or values_to_append:
-        print(
-            "Updated {} with Chroma dev search keys.".format(env_file.as_posix())
-        )
+        print("Updated {} with Chroma dev search keys.".format(env_file.as_posix()))
     else:
         print("Chroma dev search configuration is present.")
     return 0
@@ -378,7 +373,8 @@ def check_agent_chroma_setup(
         config = merged_chroma_config(env_file)
         print(
             "Chroma config: present "
-            "host={host} tenant={tenant} database={database} collection={collection}".format(
+            "host={host} tenant={tenant} "
+            "database={database} collection={collection}".format(
                 host=config["CHROMA_HOST"],
                 tenant=config["CHROMA_TENANT"],
                 database=config["CHROMA_DATABASE"],
@@ -1600,10 +1596,9 @@ def _normalize_search_argv(
     sentinel_index = contains_index + 1
     if sentinel_index >= len(normalized) or normalized[sentinel_index] != "--":
         return normalized
-    return (
-        normalized[:sentinel_index]
-        + [" ".join(normalized[sentinel_index + 1 :]).strip()]
-    )
+    return normalized[:sentinel_index] + [
+        " ".join(normalized[sentinel_index + 1 :]).strip()
+    ]
 
 
 def build_check_config_parser() -> argparse.ArgumentParser:

--- a/scripts/fetch_comments.py
+++ b/scripts/fetch_comments.py
@@ -157,9 +157,7 @@ def _fetch_remaining_comments(thread, runner=run_command):
             ],
             runner=runner,
         )
-        next_comments = (
-            data.get("data", {}).get("node", {}).get("comments", {})
-        )
+        next_comments = data.get("data", {}).get("node", {}).get("comments", {})
         nodes.extend(next_comments.get("nodes") or [])
         if not _has_next_page(next_comments):
             break
@@ -188,9 +186,7 @@ def review_threads(owner, name, number, runner=run_command):
             runner=runner,
         )
         pull_request = (
-            last_payload.get("data", {})
-            .get("repository", {})
-            .get("pullRequest", {})
+            last_payload.get("data", {}).get("repository", {}).get("pullRequest", {})
         )
         connection = pull_request.get("reviewThreads") or {}
         for thread in connection.get("nodes") or []:

--- a/scripts/generate_repo.py
+++ b/scripts/generate_repo.py
@@ -75,12 +75,16 @@ def _verify_sha256_file(path):
     checksum_path = "{}.sha256".format(path)
     filename = os.path.basename(path)
     if not os.path.isfile(checksum_path):
-        raise SystemExit("generate_repo: missing sha256 checksum for {}".format(filename))
+        raise SystemExit(
+            "generate_repo: missing sha256 checksum for {}".format(filename)
+        )
     expected = hashlib.sha256(open(path, "rb").read()).hexdigest()
     checksum = open(checksum_path, "r", encoding="ascii").read().strip()
     checksum_parts = checksum.split()
     if not checksum_parts or checksum_parts[0] != expected:
-        raise SystemExit("generate_repo: sha256 checksum does not match {}".format(filename))
+        raise SystemExit(
+            "generate_repo: sha256 checksum does not match {}".format(filename)
+        )
 
 
 def _copy_addon_zip_for_pages(output_dir, addon_zip, addon_id, version):
@@ -161,7 +165,7 @@ def _read_addon_version_from_zip(zip_path, addon_id):
 
 
 def _write_html_index(path, links):
-    html = "<!doctype html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n</head>\n<body>\n"
+    html = '<!doctype html>\n<html>\n<head>\n<meta charset="utf-8">\n</head>\n<body>\n'
     for name in links:
         html += '<a href="{n}">{n}</a><br>\n'.format(n=name)
     html += "</body>\n</html>\n"
@@ -314,9 +318,8 @@ def generate_repo(
             addon_xmls.append(read_addon_xml(main_addon, metadata_url))
         else:
             print(
-                "generate_repo: skipping {} metadata because addon zip not found: {!r}".format(
-                    main_addon_id, local_addon_zip
-                ),
+                "generate_repo: skipping {} metadata because addon zip "
+                "not found: {!r}".format(main_addon_id, local_addon_zip),
                 file=sys.stderr,
             )
 
@@ -377,7 +380,8 @@ def smoke_check_pages(output_dir, repository_addon_dir="repo/repository.nzbdav")
         path = metadata.findtext("path") if metadata is not None else ""
         if path and not _is_repository_relative_path(path):
             raise SystemExit(
-                "generate_repo: plugin.video.nzbdav path must be relative to repository datadir"
+                "generate_repo: plugin.video.nzbdav path must be relative "
+                "to repository datadir"
             )
         if path:
             addon_zip_path = os.path.join(output_dir, path)
@@ -424,9 +428,7 @@ def smoke_check_pages(output_dir, repository_addon_dir="repo/repository.nzbdav")
     with zipfile.ZipFile(repo_zip_path) as zf:
         if repo_addon_xml_member not in zf.namelist():
             raise SystemExit(
-                "generate_repo: repository zip missing {}".format(
-                    repo_addon_xml_member
-                )
+                "generate_repo: repository zip missing {}".format(repo_addon_xml_member)
             )
 
     repo_dir = os.path.join(output_dir, repo_id)
@@ -438,9 +440,8 @@ def smoke_check_pages(output_dir, repository_addon_dir="repo/repository.nzbdav")
         ]
         if repo_dir_zip_names != repo_zip_names:
             raise SystemExit(
-                "generate_repo: {} directory must contain one matching repository zip".format(
-                    repo_id
-                )
+                "generate_repo: {} directory must contain one matching "
+                "repository zip".format(repo_id)
             )
         _verify_sha256_file(os.path.join(repo_dir, repo_dir_zip_names[0]))
 
@@ -472,7 +473,9 @@ def main(argv=None):
         repository_addon_dir=args.repository_addon_dir,
     )
     if args.smoke_check:
-        smoke_check_pages(args.output_dir, repository_addon_dir=args.repository_addon_dir)
+        smoke_check_pages(
+            args.output_dir, repository_addon_dir=args.repository_addon_dir
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/pr_agent_context.py
+++ b/scripts/pr_agent_context.py
@@ -147,7 +147,9 @@ def _collect_comments(pr_number, include_resolved, runner, context_pr=None):
 
     try:
         owner, name = fetch_comments.current_repo(runner=runner)
-        threads = fetch_comments.review_threads(owner, name, pr["number"], runner=runner)
+        threads = fetch_comments.review_threads(
+            owner, name, pr["number"], runner=runner
+        )
     except (OSError, subprocess.CalledProcessError, SystemExit) as exc:
         threads = _empty_thread_data()
         errors.append(_error_payload("review_threads", exc))

--- a/scripts/pr_review_context.py
+++ b/scripts/pr_review_context.py
@@ -13,7 +13,9 @@ import sys
 PR_JSON_FIELDS = (
     "number,title,url,baseRefName,headRefName,statusCheckRollup,reviewDecision,comments"
 )
-PR_FALLBACK_JSON_FIELDS = "number,title,url,baseRefName,headRefName,reviewDecision,comments"
+PR_FALLBACK_JSON_FIELDS = (
+    "number,title,url,baseRefName,headRefName,reviewDecision,comments"
+)
 FAILING_CHECK_STATES = (
     "FAILURE",
     "ERROR",

--- a/tmdbhelper-warmup-rs/ssd-trim.py
+++ b/tmdbhelper-warmup-rs/ssd-trim.py
@@ -26,7 +26,9 @@ SG_UNMAP = "/storage/.opt/bin/sg_unmap"
 
 
 def get_fs_params():
-    info = subprocess.check_output(["tune2fs", "-l", PART], text=True, stderr=subprocess.DEVNULL)
+    info = subprocess.check_output(
+        ["tune2fs", "-l", PART], text=True, stderr=subprocess.DEVNULL
+    )
     block_size = int(re.search(r"Block size:\s+(\d+)", info).group(1))
     blocks_per_group = int(re.search(r"Blocks per group:\s+(\d+)", info).group(1))
     block_count = int(re.search(r"Block count:\s+(\d+)", info).group(1))
@@ -41,7 +43,6 @@ def read_block_bitmap(fd, bitmap_block, block_size, blocks_in_group):
     fd.seek(offset)
     bitmap = fd.read(block_size)
 
-    pos = 0
     run_start = None
 
     for byte_idx in range(blocks_in_group // 8):
@@ -107,7 +108,9 @@ def trim_ranges(ranges, total_sectors):
         while lba_count > 0:
             chunk = min(lba_count, MAX_UNMAP_LBA)
             cmd = [SG_UNMAP, f"--lba={lba_start}", f"--num={chunk}", "--force", DEV]
-            r = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False)
+            r = subprocess.run(
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False
+            )
             if r.returncode != 0:
                 errors += 1
                 break
@@ -124,9 +127,11 @@ def trim_ranges(ranges, total_sectors):
             remaining_sectors = total_sectors - sectors_done
             eta_s = remaining_sectors / rate if rate > 0 else 0
             eta_m = eta_s / 60
-            msg = (f"TRIM progress: {i+1}/{len(ranges)} ranges, "
-                   f"{pct:.1f}%, {errors} errors, "
-                   f"ETA {eta_m:.1f} min")
+            msg = (
+                f"TRIM progress: {i+1}/{len(ranges)} ranges, "
+                f"{pct:.1f}%, {errors} errors, "
+                f"ETA {eta_m:.1f} min"
+            )
             print(msg)
             syslog.syslog(msg)
             last_log = now
@@ -141,8 +146,12 @@ def freeze_disk():
     """Remount CACHE_DRIVE read-only to prevent ALL writes during TRIM."""
     subprocess.run(["sync"], check=False)
     time.sleep(1)
-    r = subprocess.run(["mount", "-o", "remount,ro", MOUNT_POINT],
-                       capture_output=True, text=True, check=False)
+    r = subprocess.run(
+        ["mount", "-o", "remount,ro", MOUNT_POINT],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     if r.returncode != 0:
         print(f"WARNING: remount ro failed: {r.stderr.strip()}")
         print("Falling back to SIGSTOP on warmup-rs processes")
@@ -161,6 +170,7 @@ def thaw_disk(state):
 def _freeze_processes():
     """Fallback: SIGSTOP all warmup-rs processes."""
     import signal
+
     pids = []
     try:
         out = subprocess.check_output(["pidof", "warmup-rs"], text=True).strip()
@@ -181,6 +191,7 @@ def _freeze_processes():
 def _thaw_processes(pids):
     """Fallback: SIGCONT previously frozen processes."""
     import signal
+
     for pid in pids:
         try:
             os.kill(pid, signal.SIGCONT)
@@ -200,15 +211,25 @@ def main():
         syslog.syslog(f"frozen {len(state)} PIDs (remount-ro fallback)")
 
     try:
-        block_size, blocks_per_group, block_count, free_blocks, first_data_block = get_fs_params()
+        block_size, blocks_per_group, block_count, free_blocks, first_data_block = (
+            get_fs_params()
+        )
         num_groups = (block_count + blocks_per_group - 1) // blocks_per_group
 
-        free_gb = (free_blocks * block_size) / (1024 ** 3)
-        print(f"ext4: {block_count} blocks, {free_blocks} free ({free_gb:.1f} GB), {num_groups} groups")
-        syslog.syslog(f"starting TRIM: {free_blocks} free blocks ({free_gb:.1f} GB) across {num_groups} groups")
+        free_gb = (free_blocks * block_size) / (1024**3)
+        print(
+            f"ext4: {block_count} blocks, {free_blocks} free ({free_gb:.1f} GB),"
+            f" {num_groups} groups"
+        )
+        syslog.syslog(
+            f"starting TRIM: {free_blocks} free blocks ({free_gb:.1f} GB) across"
+            f" {num_groups} groups"
+        )
 
         with open(PART, "rb") as fd:
-            bitmaps = read_group_descriptors(fd, block_size, num_groups, first_data_block)
+            bitmaps = read_group_descriptors(
+                fd, block_size, num_groups, first_data_block
+            )
             print(f"read {len(bitmaps)} group descriptors")
 
             lba_ranges = []
@@ -219,33 +240,54 @@ def main():
                 remaining = block_count - (group_idx * blocks_per_group)
                 blocks_in_group = min(blocks_per_group, remaining)
 
-                for rel_start, count in read_block_bitmap(fd, bitmap_block, block_size, blocks_in_group):
-                    abs_block = group_idx * blocks_per_group + first_data_block + rel_start
+                for rel_start, count in read_block_bitmap(
+                    fd, bitmap_block, block_size, blocks_in_group
+                ):
+                    abs_block = (
+                        group_idx * blocks_per_group + first_data_block + rel_start
+                    )
                     lba_start = abs_block * SECTORS_PER_BLOCK + PART_START_SECTORS
                     lba_count = count * SECTORS_PER_BLOCK
                     lba_ranges.append((lba_start, lba_count))
                     total_free += count
 
                 if (group_idx + 1) % 500 == 0:
-                    print(f"  scanned {group_idx + 1}/{num_groups} groups, {len(lba_ranges)} free ranges so far")
+                    print(
+                        f"  scanned {group_idx + 1}/{num_groups} groups,"
+                        f" {len(lba_ranges)} free ranges so far"
+                    )
 
         scan_time = time.time() - t0
-        free_found_gb = (total_free * block_size) / (1024 ** 3)
-        print(f"scan complete: {len(lba_ranges)} free ranges ({free_found_gb:.1f} GB) in {scan_time:.1f}s")
-        syslog.syslog(f"scan: {len(lba_ranges)} ranges ({free_found_gb:.1f} GB) in {scan_time:.1f}s")
+        free_found_gb = (total_free * block_size) / (1024**3)
+        print(
+            f"scan complete: {len(lba_ranges)} free ranges ({free_found_gb:.1f} GB)"
+            f" in {scan_time:.1f}s"
+        )
+        syslog.syslog(
+            f"scan: {len(lba_ranges)} ranges ({free_found_gb:.1f} GB)"
+            f" in {scan_time:.1f}s"
+        )
 
         merged = coalesce_ranges(lba_ranges)
         print(f"coalesced to {len(merged)} ranges (from {len(lba_ranges)})")
 
         total_sectors = sum(c for _, c in merged)
-        print(f"sending TRIM via sg_unmap ({len(merged)} ranges, {total_sectors} sectors, max {MAX_UNMAP_LBA} LBAs each)...")
-        syslog.syslog(f"TRIM starting: {len(merged)} ranges, {total_sectors * 512 / (1024**3):.1f} GB")
+        print(
+            f"sending TRIM via sg_unmap ({len(merged)} ranges, {total_sectors} sectors,"
+            f" max {MAX_UNMAP_LBA} LBAs each)..."
+        )
+        syslog.syslog(
+            f"TRIM starting: {len(merged)} ranges,"
+            f" {total_sectors * 512 / (1024**3):.1f} GB"
+        )
         t1 = time.time()
         trimmed, errors = trim_ranges(merged, total_sectors)
         trim_time = time.time() - t1
 
         print(f"TRIM complete: {trimmed} commands in {trim_time:.1f}s, {errors} errors")
-        syslog.syslog(f"TRIM complete: {trimmed} commands in {trim_time:.1f}s, {errors} errors")
+        syslog.syslog(
+            f"TRIM complete: {trimmed} commands in {trim_time:.1f}s, {errors} errors"
+        )
     finally:
         thaw_disk(state)
         if state == "ro":


### PR DESCRIPTION
The shipped addon (`repo/`) and `tests/` are lint-clean, but the project's own `ruff` config (`select = E,F,W,I`) flagged **26 violations in dev/CI tooling** that CI never scoped (CI ran ruff/black only on `repo/` + `tests/`).

## Fixed
- **25× E501** (long lines) — wrapped over-long log/`help=` f-strings in `scripts/generate_repo.py`, `scripts/chroma_dev_search.py`, `dev/smoke.py`, and `tmdbhelper-warmup-rs/ssd-trim.py` (adjacent-literal splits preserve the exact output string).
- **1× F841** — removed a dead `pos = 0` local in `ssd-trim.py`.
- **black** — formatted the dev tooling for consistency.

## Durability
- Extended the CI **Lint** step to run ruff + black on `scripts/` and `dev/` too, so these don't regress. (`pylint` already lints every `.py` via `git ls-files`.)

Pure formatting / dead-code removal — **no behavior change**. Carries #219's CI-unblock commit so its own CI is green off the currently-red `main`.

**Verified:** ruff ✅ · black ✅ · pylint 10.00/10 ✅ (widened scope) · full suite green (one timing-sensitive stream_proxy test flaked under parallel load, passes in isolation — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)