### PR TITLE
fix(stream_proxy): stop first-byte stall and thread-exhaustion playback wedge

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -234,6 +234,15 @@ _RECOVERABLE_HTTP_RANGE_ERROR_CODES = frozenset({416})
 _SESSION_ZERO_FILL_RATIO_MAX = 0.05
 _RECOVERY_NOTIFY_DEBOUNCE_SECONDS = 60.0
 _RANGE_RETRY_DELAYS = (2, 4, 8)
+# The (2, 4, 8) ladder above is the right backoff for a MID-STREAM rebuffer:
+# Kodi is already playing and will wait while a still-downloading file catches
+# up. Applying it to the FIRST byte, though, makes the proxy hold Kodi's initial
+# open silent for up to ~14 s — longer than the player's first-read patience —
+# so Kodi disconnects at byte 0 and the summary logs
+# ``streamed=0 reason=client_disconnected`` (no video plays). When nothing has
+# streamed yet, use a short schedule so byte 0 arrives promptly, or the
+# connection closes fast enough for Kodi's CCurlFile to reconnect and retry.
+_FIRST_BYTE_RANGE_RETRY_DELAYS = (0.25, 0.5, 1.0)
 _AUTH_HEADER_NOT_PROVIDED = object()
 _FALLBACK_SOURCE_STATE_NOT_PROVIDED = object()
 _FALLBACK_SOURCE_STREAM_URL_HINT_KEY = "_fallback_source_stream_url_hint"
@@ -281,6 +290,13 @@ _FALLBACK_PRIMARY_URL_HINT_KEY = "_fallback_primary_url_hint"
 _FALLBACK_PRIMARY_AUTH_HINT_KEY = "_fallback_primary_auth_hint"
 _FALLBACK_CURRENT_RANGE_CACHE_KEY = "_fallback_current_range_cache"
 _FALLBACK_FINGERPRINT_WORKERS = 10
+# Upper bound on concurrent pass-through handler threads. Kodi forces
+# Connection: close per response, so every seek/retry opens a fresh connection
+# and thus a fresh handler thread; without a cap a burst can exhaust the OS
+# thread/stack budget and raise "can't start new thread", after which the
+# listener stays up but cannot answer (the "background service unreachable"
+# wedge). Excess connections are dropped cleanly so Kodi reconnects.
+_MAX_PROXY_WORKERS = 64
 _FALLBACK_PRIMARY_DIGEST_CACHE_MAX = 512
 _INITIAL_RANGE_PREFETCH_WAIT_SECONDS = 0.08
 _PASSTHROUGH_RUNTIME_SETTINGS_KEY = "_passthrough_runtime_settings"
@@ -309,6 +325,19 @@ _ZERO_FILL_BUFFER = bytes(65536)
 _REMUX_WRITE_TIMEOUT = 60
 _REMUX_STDOUT_IDLE_TIMEOUT = 30.0
 _PREPARE_TOKEN_HEADER = "X-NZBDAV-Token"  # nosec B105 — HTTP header name, not a secret
+# /prepare client retry. A momentarily thread-starved proxy accepts then drops
+# the loopback connection (RemoteDisconnected / reset / refused) — a FAST
+# failure that clears in well under a second once a handler thread frees up. A
+# single POST would otherwise surface the terminal "background service
+# unreachable" dialog on that first transient hiccup, so retry the FAST
+# connection failures a few times with a short backoff. A genuine timeout is
+# NOT retried: it means the proxy accepted but is wedged, or a slow-but-
+# reachable prepare that already had the full budget — retrying another full
+# budget can't help and would multiply the wait. So the worst case stays the
+# original single timeout, not a multiple of it.
+_PREPARE_MAX_ATTEMPTS = 3
+_PREPARE_ATTEMPT_TIMEOUT = 60
+_PREPARE_RETRY_BACKOFF = 0.25
 _PROP_PROXY_TOKEN = "nzbdav.proxy_token"  # nosec B105 — settings key, not a secret
 # POST /stream/<session_id>/fallbacks — merge late-adopted fallback sources into
 # a live session whose /prepare snapshot was taken before the fallback worker
@@ -4209,7 +4238,18 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         retry_written,
                         current,
                     ) = self._retry_original_range(
-                        active_ctx, current, end, contract_mode
+                        active_ctx,
+                        current,
+                        end,
+                        contract_mode,
+                        # Key on the ABSOLUTE file offset, not total_streamed:
+                        # Kodi forces Connection: close, so every mid-file seek
+                        # is a fresh request with total_streamed=0. Only a
+                        # genuine byte-0 open (where the player's first-read
+                        # patience is short) takes the short schedule; a
+                        # mid-file AWAITING_DOWNLOAD keeps the long
+                        # wait-on-primary ladder.
+                        first_byte=(current == 0),
                     )
                     total_streamed += retry_written
                     _update_session_recovery_state(
@@ -4396,7 +4436,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 xbmc.LOGINFO if _benign_summary else xbmc.LOGWARNING,
             )
 
-    def _retry_original_range(self, ctx, start, end, contract_mode):
+    def _retry_original_range(self, ctx, start, end, contract_mode, first_byte=False):
         """Retry the still-unread upstream range before falling back to skip.
 
         Fast-fail when the session already knows upstream is down.
@@ -4404,6 +4444,13 @@ class _StreamHandler(BaseHTTPRequestHandler):
         retry ladder would otherwise sleep-and-retry through its entire
         delay schedule against a known-failing upstream on every range,
         turning a sustained outage into seconds of stall per seek.
+
+        ``first_byte`` selects a short backoff schedule
+        (``_FIRST_BYTE_RANGE_RETRY_DELAYS``) when no byte has been streamed
+        yet: the long (2, 4, 8) ladder would hold Kodi's initial open silent
+        past its first-read patience, so it disconnects at byte 0
+        (``streamed=0``). The long ladder is kept for mid-stream rebuffering,
+        where Kodi is already playing and will wait.
         """
         if ctx.get("upstream_down_notified"):
             xbmc.log(
@@ -4423,7 +4470,8 @@ class _StreamHandler(BaseHTTPRequestHandler):
         # the handler for the full delay even after Kodi started
         # tearing down. TODO.md §H.2-M14.
         monitor = xbmc.Monitor()
-        for delay in _RANGE_RETRY_DELAYS:
+        delays = _FIRST_BYTE_RANGE_RETRY_DELAYS if first_byte else _RANGE_RETRY_DELAYS
+        for delay in delays:
             if monitor.waitForAbort(delay):
                 return last_result, total_written, current
             result, written = self._stream_upstream_range(
@@ -4872,7 +4920,16 @@ class _StreamHandler(BaseHTTPRequestHandler):
 
 
 class _ThreadedHTTPServer(_ThreadingMixIn, HTTPServer):
-    """HTTPServer that handles each request in a new thread."""
+    """HTTPServer that handles each request in a new thread.
+
+    Hardened against thread/stack exhaustion: handler threads are bounded by a
+    semaphore (``_MAX_PROXY_WORKERS``) and the per-connection spawn is wrapped
+    so a transient ``RuntimeError: can't start new thread`` drops the accepted
+    connection cleanly (Kodi reconnects) instead of escaping as an unhandled
+    traceback while the listener stays up but unanswering. Stdlib
+    ``ThreadingMixIn`` does neither, which is what let a playback burst wedge
+    the proxy into "background service unreachable on 127.0.0.1:<port>".
+    """
 
     allow_reuse_address = True
     daemon_threads = True
@@ -4886,7 +4943,54 @@ class _ThreadedHTTPServer(_ThreadingMixIn, HTTPServer):
         self.ffmpeg_lock = threading.Lock()
         self.owner_proxy = None
         self.prepare_token = ""  # nosec B105 — empty init value, not a secret
+        self._worker_slots = threading.BoundedSemaphore(_MAX_PROXY_WORKERS)
         super().__init__(*args, **kwargs)
+
+    def process_request(self, request, client_address):
+        """Spawn a bounded, RuntimeError-tolerant handler thread.
+
+        ``__new__``-built test doubles (and any subclass that skips __init__)
+        have no ``_worker_slots`` — fall back to an unbounded-but-guarded spawn
+        in that case rather than erroring.
+        """
+        slots = getattr(self, "_worker_slots", None)
+        if slots is not None and not slots.acquire(blocking=False):
+            xbmc.log(
+                "NZB-DAV: Proxy at worker cap ({}); dropping connection so the "
+                "client reconnects (reason=worker_cap)".format(_MAX_PROXY_WORKERS),
+                xbmc.LOGWARNING,
+            )
+            self.shutdown_request(request)
+            return
+        try:
+            super().process_request(request, client_address)
+        except RuntimeError:
+            # Out of OS thread/stack budget. Release the slot we reserved and
+            # close the accepted socket so the client sees a reset and retries,
+            # instead of leaking the connection behind an unhandled traceback.
+            if slots is not None:
+                try:
+                    slots.release()
+                except ValueError:
+                    pass
+            xbmc.log(
+                "NZB-DAV: Could not start proxy handler thread; dropping "
+                "connection so the client reconnects (reason=thread_exhausted)",
+                xbmc.LOGWARNING,
+            )
+            self.shutdown_request(request)
+
+    def process_request_thread(self, request, client_address):
+        """Release the worker slot once the handler thread finishes."""
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            slots = getattr(self, "_worker_slots", None)
+            if slots is not None:
+                try:
+                    slots.release()
+                except ValueError:
+                    pass
 
 
 class HlsProducer:
@@ -6416,7 +6520,12 @@ class StreamProxy:
         thread = threading.Thread(target=_warm, name="nzbdav-fallback-prevalidate")
         thread.daemon = True
         ctx["_fallback_prevalidation_thread"] = thread
-        thread.start()
+        try:
+            thread.start()
+        except RuntimeError:
+            # Out of thread budget — match the sibling prefetch spawns and fail
+            # soft so prevalidation never wedges /prepare.
+            ctx.pop("_fallback_prevalidation_thread", None)
 
     @staticmethod
     def _initial_range_prefetchable(ctx):
@@ -7481,35 +7590,48 @@ def prepare_stream_via_service(
         prepare_token = get_service_proxy_token()
     if prepare_token:
         req.add_header(_PREPARE_TOKEN_HEADER, prepare_token)
-    try:
-        # nosemgrep
-        with urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
-            req, timeout=60
-        ) as resp:
-            result = json.loads(resp.read())
-            proxy_url = result.pop("proxy_url")
-            return proxy_url, result
-    except (ConnectionError, _socket.timeout, TimeoutError) as e:
-        # The loopback service isn't answering. Could be: service
-        # crashed, Kodi restart that didn't re-launch it, port stale
-        # from a previous run. Surface a specific error so the user
-        # sees "NZB-DAV background service unreachable" rather than
-        # a bare Errno 61.
-        raise ServiceProxyUnavailableError(
-            "NZB-DAV background service unreachable on 127.0.0.1:{} — "
-            "restart Kodi or toggle the addon".format(port)
-        ) from e
-    except URLError as e:
-        # URLError wraps the same family of errors when urlopen fails.
-        reason = getattr(e, "reason", None)
-        if isinstance(
-            reason, (ConnectionError, _socket.timeout, TimeoutError, OSError)
-        ):
-            raise ServiceProxyUnavailableError(
-                "NZB-DAV background service unreachable on 127.0.0.1:{} — "
-                "restart Kodi or toggle the addon".format(port)
-            ) from e
-        raise
+    unreachable = (
+        "NZB-DAV background service unreachable on 127.0.0.1:{} — "
+        "restart Kodi or toggle the addon".format(port)
+    )
+    last_error = None
+    for index in range(_PREPARE_MAX_ATTEMPTS):
+        try:
+            # nosemgrep
+            with urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
+                req, timeout=_PREPARE_ATTEMPT_TIMEOUT
+            ) as resp:
+                result = json.loads(resp.read())
+                proxy_url = result.pop("proxy_url")
+                return proxy_url, result
+        except ConnectionError as e:
+            # FAST transient: a momentarily thread-starved proxy accepted then
+            # dropped the loopback socket (RemoteDisconnected / reset / refused).
+            # It clears in well under a second once a handler thread frees up,
+            # so retry before surfacing the terminal error rather than failing
+            # the whole playback on the first transient hiccup.
+            last_error = e
+        except (_socket.timeout, TimeoutError) as e:
+            # The proxy accepted but never answered within the budget: wedged,
+            # not starved. Retrying another full budget won't help, so surface
+            # immediately — same worst case as before this retry loop existed.
+            raise ServiceProxyUnavailableError(unreachable) from e
+        except URLError as e:
+            # URLError wraps the same family of errors when urlopen fails. Retry
+            # only the fast connection-reset family; surface a wrapped timeout/
+            # OSError as unreachable; re-raise everything else (e.g. HTTPError,
+            # a 4xx/5xx from a reachable proxy — not a reachability problem).
+            reason = getattr(e, "reason", None)
+            if isinstance(reason, ConnectionError):
+                last_error = e
+            elif isinstance(reason, (_socket.timeout, TimeoutError, OSError)):
+                raise ServiceProxyUnavailableError(unreachable) from e
+            else:
+                raise
+        if index < _PREPARE_MAX_ATTEMPTS - 1:
+            time.sleep(_PREPARE_RETRY_BACKOFF)
+    # Every attempt failed with a fast connection reset.
+    raise ServiceProxyUnavailableError(unreachable) from last_error
 
 
 def update_stream_fallbacks_via_service(

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -12991,3 +12991,384 @@ def test_record_upstream_recovered_drops_stale_success_observations():
         # A fresher success (t=300) DOES clear the flag.
         _record_upstream_recovered(server, ctx, observed_at=300.0)
         assert ctx["upstream_down_notified"] is False
+
+
+# ---------------------------------------------------------------------------
+# Playback regression fixes: first-byte stall + proxy thread exhaustion
+# ---------------------------------------------------------------------------
+
+
+def test_serve_proxy_first_byte_uses_short_retry_schedule():
+    """Byte 0 must not block on the long (2,4,8) ladder.
+
+    When nothing has streamed yet and the first upstream read returns a clean
+    download-high-water short read (AWAITING_DOWNLOAD with zero bytes), the
+    proxy must NOT sleep through the full (2, 4, 8) = ~14s ladder before
+    delivering byte 0 — that exceeds the player's first-read patience, so Kodi
+    disconnects at byte 0 (the live ``streamed=0 reason=client_disconnected``
+    regression). The pre-first-byte wait must be short.
+    """
+    import sys
+
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 4096,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-4095")
+
+    # First open: byte 0 not fetched yet -> empty 206 body (AWAITING_DOWNLOAD, 0
+    # written). Second open (retry ladder): the download has caught up.
+    resp1 = _mock_urlopen_response(
+        [],
+        status=206,
+        headers={"Content-Range": "bytes 0-4095/4096", "Content-Length": "4096"},
+    )
+    resp2 = _mock_urlopen_response(
+        [b"B" * 4096],
+        status=206,
+        headers={"Content-Range": "bytes 0-4095/4096", "Content-Length": "4096"},
+    )
+
+    mock_addon = MagicMock()
+    mock_addon.getSetting.side_effect = lambda key: {
+        "strict_contract_mode": "warn",
+        "density_breaker_enabled": "false",
+        "zero_fill_budget_enabled": "true",
+        "retry_ladder_enabled": "true",
+    }.get(key, "")
+    original_addon = sys.modules["xbmcaddon"].Addon.return_value
+    sys.modules["xbmcaddon"].Addon.return_value = mock_addon
+
+    waited = []
+    monitor = sys.modules["xbmc"].Monitor.return_value
+    original_wait = monitor.waitForAbort.side_effect
+
+    def _record(timeout=0.0):
+        waited.append(timeout)
+        return False
+
+    monitor.waitForAbort.side_effect = _record
+    try:
+        with patch(
+            "resources.lib.stream_proxy.urlopen",
+            side_effect=[resp1, resp2],
+        ), patch.object(handler, "_select_live_fallback_source", return_value=None):
+            handler._serve_proxy(ctx)
+    finally:
+        sys.modules["xbmcaddon"].Addon.return_value = original_addon
+        monitor.waitForAbort.side_effect = original_wait
+
+    # Byte 0 was delivered after a SHORT wait, not the 2s first rung of the
+    # long ladder.
+    assert waited, "retry ladder did not run for the first byte"
+    assert waited[0] <= 1.0, "first-byte wait used the long ladder: {!r}".format(waited)
+    assert _collect_written(handler) == b"B" * 4096
+
+
+def test_serve_proxy_midstream_keeps_long_retry_schedule():
+    """Once bytes have streamed, a high-water short read keeps the long ladder.
+
+    Regression guard for the "Empire stalled at 1:11" fix: mid-stream
+    rebuffering on a still-downloading file should still wait on the primary
+    via the long (2, 4, 8) ladder. The short pre-first-byte schedule must apply
+    ONLY to byte 0 (nothing streamed yet).
+    """
+    import sys
+
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 4096,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-4095")
+
+    # First open delivers 1024 bytes (byte 0 IS served) then short-reads; the
+    # retry ladder serves the remainder.
+    resp1 = _mock_urlopen_response(
+        [b"A" * 1024],
+        status=206,
+        headers={"Content-Range": "bytes 0-4095/4096", "Content-Length": "4096"},
+    )
+    resp2 = _mock_urlopen_response(
+        [b"B" * 3072],
+        status=206,
+        headers={"Content-Range": "bytes 1024-4095/4096", "Content-Length": "3072"},
+    )
+
+    mock_addon = MagicMock()
+    mock_addon.getSetting.side_effect = lambda key: {
+        "strict_contract_mode": "warn",
+        "density_breaker_enabled": "false",
+        "zero_fill_budget_enabled": "true",
+        "retry_ladder_enabled": "true",
+    }.get(key, "")
+    original_addon = sys.modules["xbmcaddon"].Addon.return_value
+    sys.modules["xbmcaddon"].Addon.return_value = mock_addon
+
+    waited = []
+    monitor = sys.modules["xbmc"].Monitor.return_value
+    original_wait = monitor.waitForAbort.side_effect
+
+    def _record(timeout=0.0):
+        waited.append(timeout)
+        return False
+
+    monitor.waitForAbort.side_effect = _record
+    try:
+        with patch(
+            "resources.lib.stream_proxy.urlopen",
+            side_effect=[resp1, resp2],
+        ), patch.object(handler, "_select_live_fallback_source", return_value=None):
+            handler._serve_proxy(ctx)
+    finally:
+        sys.modules["xbmcaddon"].Addon.return_value = original_addon
+        monitor.waitForAbort.side_effect = original_wait
+
+    assert _collect_written(handler) == b"A" * 1024 + b"B" * 3072
+    # Mid-stream rebuffer still uses the long ladder (first rung == 2s).
+    assert waited, "retry ladder did not run"
+    assert waited[0] == 2.0, "mid-stream wait was shortened: {!r}".format(waited)
+
+
+def test_serve_proxy_midfile_awaiting_download_keeps_long_retry_schedule():
+    """A fresh connection seeking MID-FILE must keep the long wait-on-primary
+    ladder, not the short first-byte schedule.
+
+    Kodi forces Connection: close, so every seek is a new _serve_proxy request
+    with total_streamed reset to 0. The short first-byte schedule must therefore
+    key on the absolute file offset (current == 0), NOT on the per-request
+    counter — otherwise a mid-file seek to a byte at the download high-water mark
+    (first read returns AWAITING_DOWNLOAD with zero bytes) would wrongly use the
+    short ladder and close after ~1.75s instead of waiting ~14s for the
+    still-downloading primary to catch up (the "Empire stalled at 1:11" fix).
+    """
+    import sys
+
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 100000,
+    }
+    # Seek into the middle of the file (byte 50000), not byte 0.
+    handler = _make_handler_with_server(ctx, range_header="bytes=50000-53071")
+
+    # First read at the high-water mark: empty 206 body (AWAITING_DOWNLOAD, 0
+    # written). The retry ladder serves it once the download catches up.
+    resp1 = _mock_urlopen_response(
+        [],
+        status=206,
+        headers={
+            "Content-Range": "bytes 50000-53071/100000",
+            "Content-Length": "3072",
+        },
+    )
+    resp2 = _mock_urlopen_response(
+        [b"B" * 3072],
+        status=206,
+        headers={
+            "Content-Range": "bytes 50000-53071/100000",
+            "Content-Length": "3072",
+        },
+    )
+
+    mock_addon = MagicMock()
+    mock_addon.getSetting.side_effect = lambda key: {
+        "strict_contract_mode": "warn",
+        "density_breaker_enabled": "false",
+        "zero_fill_budget_enabled": "true",
+        "retry_ladder_enabled": "true",
+    }.get(key, "")
+    original_addon = sys.modules["xbmcaddon"].Addon.return_value
+    sys.modules["xbmcaddon"].Addon.return_value = mock_addon
+
+    waited = []
+    monitor = sys.modules["xbmc"].Monitor.return_value
+    original_wait = monitor.waitForAbort.side_effect
+
+    def _record(timeout=0.0):
+        waited.append(timeout)
+        return False
+
+    monitor.waitForAbort.side_effect = _record
+    try:
+        with patch(
+            "resources.lib.stream_proxy.urlopen",
+            side_effect=[resp1, resp2],
+        ), patch.object(handler, "_select_live_fallback_source", return_value=None):
+            handler._serve_proxy(ctx)
+    finally:
+        sys.modules["xbmcaddon"].Addon.return_value = original_addon
+        monitor.waitForAbort.side_effect = original_wait
+
+    assert _collect_written(handler) == b"B" * 3072
+    # A mid-file AWAITING_DOWNLOAD waits on the primary via the LONG ladder
+    # (first rung 2s), NOT the short first-byte schedule.
+    assert waited, "retry ladder did not run"
+    assert waited[0] == 2.0, "mid-file seek used the short schedule: {!r}".format(
+        waited
+    )
+
+
+def test_threaded_server_drops_connection_when_thread_cannot_start():
+    """A transient 'can't start new thread' must not abandon the socket.
+
+    When the OS thread/stack budget is momentarily exhausted, the per-connection
+    spawn raises RuntimeError. The server must catch it and close the accepted
+    socket deterministically (so the client reconnects) instead of letting the
+    error escape while leaving the listener up but unable to answer.
+    """
+    import socketserver
+
+    from resources.lib.stream_proxy import _ThreadedHTTPServer
+
+    srv = _ThreadedHTTPServer.__new__(_ThreadedHTTPServer)
+    srv.shutdown_request = MagicMock()
+    request = MagicMock()
+
+    with patch(
+        "socketserver.ThreadingMixIn.process_request",
+        side_effect=RuntimeError("can't start new thread"),
+    ):
+        # Must not raise.
+        srv.process_request(request, ("127.0.0.1", 12345))
+
+    assert isinstance(socketserver.ThreadingMixIn, type)  # import sanity
+    srv.shutdown_request.assert_called_once_with(request)
+
+
+def test_threaded_server_drops_connection_when_worker_cap_reached():
+    """When all worker slots are taken, a new connection is dropped, not spawned.
+
+    Bounding concurrent handler threads keeps the proxy below the thread/stack
+    ceiling that triggers 'can't start new thread'.
+    """
+    from resources.lib.stream_proxy import _ThreadedHTTPServer
+
+    srv = _ThreadedHTTPServer.__new__(_ThreadedHTTPServer)
+    srv._worker_slots = threading.BoundedSemaphore(1)
+    srv.shutdown_request = MagicMock()
+    request = MagicMock()
+
+    # Exhaust the single slot so the next request cannot acquire one.
+    assert srv._worker_slots.acquire(blocking=False) is True
+
+    with patch("socketserver.ThreadingMixIn.process_request") as super_pr:
+        srv.process_request(request, ("127.0.0.1", 1))
+        super_pr.assert_not_called()
+
+    srv.shutdown_request.assert_called_once_with(request)
+
+
+def _prepare_json_response(proxy_url="http://127.0.0.1:38699/stream/abc", **extra):
+    payload = {"proxy_url": proxy_url}
+    payload.update(extra)
+    return _mock_urlopen_response([json.dumps(payload).encode()], status=200)
+
+
+def test_prepare_stream_via_service_retries_transient_then_succeeds():
+    """A momentarily thread-starved proxy drops the loopback connection (a fast
+    reset); the client must retry rather than surface the terminal 'unreachable'
+    dialog on the first transient hiccup.
+    """
+    from resources.lib.stream_proxy import prepare_stream_via_service
+
+    good = _prepare_json_response(total_bytes=123)
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        side_effect=[ConnectionResetError("starved"), good],
+    ) as mock_urlopen, patch("resources.lib.stream_proxy.time.sleep") as mock_sleep:
+        proxy_url, info = prepare_stream_via_service(
+            38699, "http://nzbdav/movie.mkv", prepare_token="tok"
+        )
+
+    assert proxy_url == "http://127.0.0.1:38699/stream/abc"
+    assert info == {"total_bytes": 123}
+    assert mock_urlopen.call_count == 2
+    assert mock_sleep.called, "expected a backoff between retries"
+
+
+def test_prepare_stream_via_service_retries_remote_disconnect():
+    """A RemoteDisconnected (server closed the accepted socket without a
+    handler) is a transient thread-starvation symptom and must be retried.
+    """
+    import http.client
+
+    from resources.lib.stream_proxy import prepare_stream_via_service
+
+    good = _prepare_json_response()
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        side_effect=[
+            http.client.RemoteDisconnected("Remote end closed connection"),
+            good,
+        ],
+    ) as mock_urlopen, patch("resources.lib.stream_proxy.time.sleep"):
+        proxy_url, _info = prepare_stream_via_service(38699, "http://nzbdav/m.mkv")
+
+    assert proxy_url == "http://127.0.0.1:38699/stream/abc"
+    assert mock_urlopen.call_count == 2
+
+
+def test_prepare_stream_via_service_raises_after_retries_exhausted():
+    """A persistently reset connection still raises ServiceProxyUnavailableError
+    — after exhausting the retry budget, not on the first attempt.
+    """
+    from resources.lib.stream_proxy import (
+        ServiceProxyUnavailableError,
+        prepare_stream_via_service,
+    )
+
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        side_effect=ConnectionResetError("down"),
+    ) as mock_urlopen, patch("resources.lib.stream_proxy.time.sleep"):
+        with pytest.raises(ServiceProxyUnavailableError) as excinfo:
+            prepare_stream_via_service(38699, "http://nzbdav/m.mkv")
+
+    assert "38699" in str(excinfo.value)
+    assert mock_urlopen.call_count == 3, "expected the full retry budget"
+
+
+def test_prepare_stream_via_service_timeout_surfaces_without_retry():
+    """A genuine timeout means the proxy accepted but is wedged (not starved),
+    so retrying another full budget won't help and would multiply the wait. It
+    surfaces immediately as 'unreachable' — one attempt, same worst case as
+    before the retry loop existed.
+    """
+    import socket
+
+    from resources.lib.stream_proxy import (
+        ServiceProxyUnavailableError,
+        prepare_stream_via_service,
+    )
+
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        side_effect=socket.timeout("wedged"),
+    ) as mock_urlopen, patch("resources.lib.stream_proxy.time.sleep"):
+        with pytest.raises(ServiceProxyUnavailableError):
+            prepare_stream_via_service(38699, "http://nzbdav/m.mkv")
+
+    assert mock_urlopen.call_count == 1, "a timeout must not be retried"
+
+
+def test_prepare_stream_via_service_does_not_retry_http_error():
+    """A 4xx/5xx from /prepare is non-transient and must NOT be retried or
+    converted to the 'unreachable' error.
+    """
+    import urllib.error
+
+    from resources.lib.stream_proxy import prepare_stream_via_service
+
+    err = urllib.error.HTTPError("http://127.0.0.1:38699/prepare", 404, "nf", {}, None)
+    with patch(
+        "resources.lib.stream_proxy.urlopen", side_effect=err
+    ) as mock_urlopen, patch("resources.lib.stream_proxy.time.sleep"):
+        with pytest.raises(urllib.error.HTTPError):
+            prepare_stream_via_service(38699, "http://nzbdav/m.mkv")
+
+    assert mock_urlopen.call_count == 1, "HTTPError must not be retried"


### PR DESCRIPTION
## Symptom

On a CoreELEC box, playback failed for every title and escalated to the dialog **"NZB-DAV background service unreachable on 127.0.0.1:38699 — restart Kodi or toggle the addon."** Diagnosed from the Kodi log plus the live box state (port still `LISTEN`, transient `RuntimeError` in the proxy, system healthy again moments later).

## Root cause — two linked regressions in the pass-through proxy

**1. Thread exhaustion (the confirmed wedge).** `_ThreadedHTTPServer` inherits stdlib `ThreadingMixIn`'s unguarded per-connection `t.start()`. Kodi forces `Connection: close`, so every seek/retry opens a fresh connection (a new handler thread). Under a playback burst on a low-memory box (the file documents a 32-bit Kodi ~3 GB address-space constraint) the process hit:

```
RuntimeError: can't start new thread
  File ".../socketserver.py", line 711, in process_request
  File ".../threading.py", line 976, in start
```

stdlib closes the accepted socket and prints a traceback but `serve_forever` keeps listening — so the port stays bound (the service *looks* alive) yet cannot answer. The resolver's `/prepare` POST then fails and surfaces the terminal "unreachable" dialog, and Kodi's GETs are dropped (`Pass-through summary reason=client_disconnected streamed=0`). "Restart Kodi" fixes it because that resets the thread/memory budget.

**2. First-byte latency.** A clean download-high-water short read at the very first byte (`AWAITING_DOWNLOAD`, 0 bytes written) entered the `(2, 4, 8)` ≈14 s retry ladder before any byte reached Kodi — longer than the player's first-read patience.

## Fix

- **Bound + guard the proxy server.** A `BoundedSemaphore(_MAX_PROXY_WORKERS = 64)` caps concurrent handler threads; `process_request` catches `RuntimeError` and `shutdown_request`s the connection cleanly (so the client reconnects) instead of leaking it behind an unhandled traceback; the slot is released in `process_request_thread`. The lone fallback-prevalidation thread spawn is now `RuntimeError`-guarded like its siblings.
- **Client retry.** `prepare_stream_via_service` retries a *fast* connection reset (the actual starvation symptom — `RemoteDisconnected` / reset / refused) a few times with a short backoff before surfacing "unreachable", rather than failing the whole playback on the first transient hiccup. A genuine **timeout is not retried** (it means the proxy accepted but is wedged, or a slow-but-reachable prepare that already had the full budget), so the worst case stays the original single 60 s budget.
- **First byte.** At absolute file offset `0` only, use a short `(0.25, 0.5, 1.0)` schedule so byte 0 arrives promptly, or the connection closes fast enough for Kodi's `CCurlFile` to reconnect. Mid-file seeks keep the long wait-on-primary ladder — the schedule is keyed on the **absolute file offset**, not the per-request byte counter (which resets to 0 on every `Connection: close` reconnect). This preserves the "Empire stalled at 1:11" wait-on-primary behavior.

## Testing

10 new unit tests:
- first byte uses the short schedule; **mid-file** and **mid-stream** short reads keep the long ladder;
- the server drops the connection cleanly on `can't start new thread` and at the worker cap;
- `prepare_stream_via_service` retries fast resets, succeeds after a transient drop, surfaces a timeout **without** retry, and does **not** retry an `HTTPError`.

Full suite: **1604 passed, 5 skipped**. `ruff`, `black`, and `pylint` (10.00/10) all clean.

An adversarial multi-agent review of the diff caught and corrected an earlier version that (a) keyed the short schedule on the per-request counter — which would have regressed mid-file rebuffers — and (b) retried genuine timeouts, which would have tripled the worst-case `/prepare` latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
