### PR TITLE
fix: dark-screen fallback hard-close + wrong-sibling video selection

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -4283,19 +4283,31 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         )
                         continue
                     if ctx.get("fallback_sources"):
-                        terminal_reason = "fallback_exhausted"
+                        # Fallback sources are attached but none validated yet
+                        # (they may still be downloading). Closing here made a
+                        # fallback-enabled stream MORE brittle than a plain
+                        # one: the hard close skipped the retry ladder and
+                        # zero-fill rescue that a no-fallback stream still
+                        # gets, so a transient primary trickle/short read
+                        # bounced playback back to the TMDBHelper player
+                        # dialog (the "Silence of the Lambs went dark"
+                        # regression). Fall through so the primary gets a
+                        # fresh chance via the retry ladder; if it stays dead,
+                        # the existing skip-probe / zero-fill safeguards
+                        # (density breaker, session budget) bound the damage —
+                        # exactly as they do without fallbacks attached.
+                        #
+                        # The pending candidate stays set; its failure toast is
+                        # still emitted by the finally block (the single sink for
+                        # every terminal exit) whenever the stream does end, so
+                        # falling through here doesn't drop the notification.
                         xbmc.log(
                             "NZB-DAV: No validated fallback source available at "
-                            "byte {}; closing fallback-enabled stream before "
-                            "retry ladder or zero-fill rescue (reason={})".format(
-                                current, terminal_reason
-                            ),
-                            xbmc.LOGERROR,
+                            "byte {}; re-entering retry ladder on the primary "
+                            "instead of closing "
+                            "(reason=fallback_pending_retry_primary)".format(current),
+                            xbmc.LOGWARNING,
                         )
-                        # The pending candidate is still set here; its failure
-                        # toast is emitted by the finally block (single sink for
-                        # every terminal exit), so no inline notify is needed.
-                        return
 
                 if retry_ladder_enabled and result in (
                     _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE,

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -171,19 +171,27 @@ def probe_webdav_reachable(
 
 
 def _find_video_file_in_subdirs(subdirs, depth, visited, settings):
-    """Probe sibling WebDAV subfolders while preserving result order."""
+    """Probe sibling WebDAV subfolders and return the LARGEST video found.
+
+    Every sibling is scanned (no early-exit on the first match) so a polluted
+    release folder can't win by ordering — e.g. a smaller junk release listed
+    before the real, larger release must not hijack playback. Ties break toward
+    the earliest sibling so behavior stays stable. Sizes come from the
+    PROPFIND ``getcontentlength`` hint each recursive call records; a found
+    video whose size is unknown still beats "no video" so we never drop a
+    playable file just because the server omitted its length.
+    """
     if not subdirs:
         return None
 
     pending = list(subdirs)
     workers = max(1, min(_WEBDAV_SUBDIR_SCAN_WORKERS, len(pending)))
     result_queue = Queue()
-    stop_event = threading.Event()
     next_index = [0]
     index_lock = threading.Lock()
 
     def _scan_worker():
-        while not stop_event.is_set():
+        while True:
             with index_lock:
                 if next_index[0] >= len(pending):
                     return
@@ -211,20 +219,20 @@ def _find_video_file_in_subdirs(subdirs, depth, visited, settings):
         thread = threading.Thread(target=_scan_worker, daemon=True)
         thread.start()
 
-    completed = {}
-    completed_count = 0
-    next_to_return = 0
-    while completed_count < len(pending):
+    best_path = None
+    best_size = -1
+    best_index = None
+    for _ in range(len(pending)):
         index, result = result_queue.get()
-        completed[index] = result
-        completed_count += 1
-        while next_to_return in completed:
-            result = completed.pop(next_to_return)
-            if result:
-                stop_event.set()
-                return result
-            next_to_return += 1
-    return None
+        if not result:
+            continue
+        size = get_video_file_size_hint(result)
+        # Strictly-larger wins; on a tie keep the earlier-listed sibling.
+        if size > best_size or (size == best_size and index < best_index):
+            best_path = result
+            best_size = size
+            best_index = index
+    return best_path
 
 
 def _remember_video_file_size_hint(file_path, size):
@@ -409,8 +417,24 @@ def find_video_file(
             resource_type = response.find(".//D:resourcetype/D:collection", ns)
             if resource_type is not None:
                 # Skip the folder itself (href matches our request URL)
-                if href_path.rstrip("/") != request_path:
-                    subdirs.append(href_path.rstrip("/") + "/")
+                child = href_path.rstrip("/")
+                if child != request_path:
+                    # Skip hidden (dot-prefixed) subfolders. nzbdav release
+                    # folders sometimes get polluted with a leading-dot child
+                    # holding a different (often wrong, smaller) movie — e.g.
+                    # a '.and_justice_for_all...1080p...' folder hijacking a
+                    # 2160p release. Leading dots are not URL-encoded, so the
+                    # encoded path segment still starts with ".".
+                    segment = child.rsplit("/", 1)[-1]
+                    if segment.startswith("."):
+                        xbmc.log(
+                            "NZB-DAV: Skipping hidden WebDAV subfolder '{}'".format(
+                                child
+                            ),
+                            xbmc.LOGDEBUG,
+                        )
+                    else:
+                        subdirs.append(child + "/")
                 continue
 
             # Check if it's a video file

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -7745,7 +7745,13 @@ def test_serve_proxy_survives_five_stream_outages_with_backup_sources():
 
 def test_serve_proxy_notifies_fallback_failure_when_candidate_delivers_no_bytes():
     """A fallback candidate that is selected but delivers zero bytes before the
-    queue is exhausted is reported as a failure (not a success)."""
+    queue is exhausted is reported as a failure (not a success).
+
+    With no validated fallback left, the proxy no longer hard-closes at the
+    selection point — it falls through to the retry ladder / skip-probe (stubbed
+    here to terminate immediately as recovery_exhausted). The pending candidate's
+    failure toast still fires from the finally block on that terminal exit.
+    """
     from resources.lib.stream_proxy import _UPSTREAM_RANGE_UPSTREAM_ERROR
 
     ctx = {
@@ -7771,7 +7777,7 @@ def test_serve_proxy_notifies_fallback_failure_when_candidate_delivers_no_bytes(
         handler,
         "_stream_upstream_range",
         # primary errors (0 bytes) -> switch to candidate #1 -> it also errors
-        # with 0 bytes -> no more fallbacks -> exhausted.
+        # with 0 bytes -> no more fallbacks.
         side_effect=[
             (_UPSTREAM_RANGE_UPSTREAM_ERROR, 0),
             (_UPSTREAM_RANGE_UPSTREAM_ERROR, 0),
@@ -7780,6 +7786,12 @@ def test_serve_proxy_notifies_fallback_failure_when_candidate_delivers_no_bytes(
         handler,
         "_select_live_fallback_source",
         side_effect=[ctx["fallback_sources"][0], None],
+    ), patch.object(
+        handler,
+        "_retry_original_range",
+        return_value=(_UPSTREAM_RANGE_UPSTREAM_ERROR, 0, 0),
+    ), patch.object(
+        handler, "_find_skip_offset", return_value=None
     ), patch(
         "resources.lib.stream_proxy._notify"
     ) as mock_notify:
@@ -10988,8 +11000,16 @@ def test_standby_refresh_reuses_probe_bases_for_content_length_checks():
     assert [source["content_length"] for source in sources] == [10, 10, 10, 10, 10]
 
 
-def test_fallback_range_probe_failure_closes_before_retry_or_zero_fill():
-    """Fallback sessions stop when no validated fallback source can resume."""
+def test_fallback_range_probe_failure_reenters_retry_and_zero_fill_recovery():
+    """No validated fallback must NOT short-circuit the recovery machinery.
+
+    Previously, a fallback-enabled session whose fallback failed to validate
+    closed immediately (retry ladder and zero-fill skipped) — making it more
+    brittle than a stream with no fallbacks at all. Now it falls through to the
+    retry ladder and skip-probe exactly as a no-fallback stream would; only the
+    existing session zero-fill budget safeguard (1 byte of a 10-byte file is
+    already over the ratio cap) stops it, so no zeros are actually written.
+    """
     from resources.lib.stream_proxy import (
         _UPSTREAM_RANGE_UPSTREAM_ERROR,
     )
@@ -11038,8 +11058,13 @@ def test_fallback_range_probe_failure_closes_before_retry_or_zero_fill():
     assert ctx["remote_url"] == "http://webdav/primary.mkv"
     assert ctx["fallback_sources"][0]["failed"] is True
     assert ctx["fallback_switch_count"] == 0
-    retry_original.assert_not_called()
-    find_skip.assert_not_called()
+    # The fix: no validated fallback now re-enters the retry ladder and reaches
+    # the skip-probe, rather than hard-closing before either.
+    retry_original.assert_called()
+    find_skip.assert_called()
+    # The session zero-fill budget cap (1 byte already exceeds 5% of 10) blocks
+    # the actual zero-fill, so nothing is written — but only AFTER the recovery
+    # path ran, not by skipping it.
     write_zeros.assert_not_called()
     assert _collect_written(handler) == b""
 
@@ -11352,6 +11377,8 @@ def test_serve_proxy_trickle_triggers_cutover_when_fallback_attached(mock_xbmc):
     no-fallback case is covered by
     test_serve_proxy_stall_watchdog_aborts_on_low_throughput. See issue #214.
     """
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_OK
+
     ctx = {
         "remote_url": "http://host/movie.mkv",
         "auth_header": None,
@@ -11368,6 +11395,9 @@ def test_serve_proxy_trickle_triggers_cutover_when_fallback_attached(mock_xbmc):
     chunks = [b"A" * 1024, b"B" * 1024]
     monotonic_returns = iter([100.0, 105.0, 125.0] + [125.0] * 30)
 
+    # The retry ladder is mocked out (its own coverage lives elsewhere); here
+    # we only care that the cutover ran and handed off to it rather than
+    # blind-reconnecting or hard-closing.
     with patch(
         "resources.lib.stream_proxy.time.monotonic",
         side_effect=lambda: next(monotonic_returns),
@@ -11376,7 +11406,11 @@ def test_serve_proxy_trickle_triggers_cutover_when_fallback_attached(mock_xbmc):
         return_value=_mock_urlopen_response(chunks),
     ), patch.object(
         handler, "_select_live_fallback_source", return_value=None
-    ) as mock_select:
+    ) as mock_select, patch.object(
+        handler,
+        "_retry_original_range",
+        return_value=(_UPSTREAM_RANGE_OK, 1046528, 1048576),
+    ) as mock_retry:
         handler._serve_proxy(ctx)
 
     # Cutover was attempted (recoverable return -> _select_live_fallback_source)
@@ -11385,9 +11419,82 @@ def test_serve_proxy_trickle_triggers_cutover_when_fallback_attached(mock_xbmc):
     assert ctx.get("passthrough_stall_detected", False) is False
     logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
     assert "passthrough_stall_fallback" in logged
-    assert "reason=fallback_exhausted" in logged
     # The blind-reconnect path (outer handler) must NOT have run.
     assert "Pass-through stall at byte" not in logged
+    # The cutover failed to validate a fallback, but that must NOT hard-close
+    # the stream — it now re-enters the retry ladder on the primary (see
+    # test_serve_proxy_trickle_reenters_retry_ladder_when_no_validated_fallback).
+    mock_retry.assert_called()
+    assert "reason=fallback_exhausted" not in logged
+    assert "reason=fallback_pending_retry_primary" in logged
+
+
+@patch("resources.lib.stream_proxy.xbmc")
+def test_serve_proxy_trickle_reenters_retry_ladder_when_no_validated_fallback(
+    mock_xbmc,
+):
+    """No validated fallback must re-enter the retry ladder, not hard-close.
+
+    Regression for the live bug where *The Silence of the Lambs* went dark and
+    bounced back to TMDBHelper's player dialog: a pass-through trickle with
+    fallback sources attached returned recoverable to drive cutover, but
+    ``_select_live_fallback_source`` validated nothing (the fallbacks were
+    themselves still downloading). The old code then set
+    ``terminal_reason=fallback_exhausted`` and closed the stream BEFORE the
+    retry ladder / zero-fill rescue ran — making a fallback-enabled stream
+    MORE brittle than a plain one. The fix falls through to the retry ladder
+    so the primary gets a chance to recover, exactly as a no-fallback stream
+    would. See the dark-screen handoff and issue #214.
+    """
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_OK
+
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 4096,
+        "fallback_sources": [{"nzo_id": "alt", "stream_url": "http://host/alt.mkv"}],
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-4095")
+
+    # Same trickle as the cutover test: two 1 KB chunks, ~82 B/s over a 25 s
+    # window, so the watchdog trips at byte 2048 and returns recoverable.
+    chunks = [b"A" * 1024, b"B" * 1024]
+    monotonic_returns = iter([100.0, 105.0, 125.0] + [125.0] * 30)
+
+    # The retry ladder stands in for a primary that catches up: it writes the
+    # remaining bytes and reports the range complete. We assert it was CALLED —
+    # the regression is that the old code returned fallback_exhausted before
+    # ever reaching it.
+    def _fake_retry(active_ctx, start, end, contract_mode, first_byte=False):
+        remainder = b"C" * (end - start + 1)
+        handler.wfile.write(remainder)
+        return _UPSTREAM_RANGE_OK, len(remainder), end + 1
+
+    with patch(
+        "resources.lib.stream_proxy.time.monotonic",
+        side_effect=lambda: next(monotonic_returns),
+    ), patch(
+        "resources.lib.stream_proxy.urlopen",
+        return_value=_mock_urlopen_response(chunks),
+    ), patch.object(
+        handler, "_select_live_fallback_source", return_value=None
+    ) as mock_select, patch.object(
+        handler, "_retry_original_range", side_effect=_fake_retry
+    ) as mock_retry:
+        handler._serve_proxy(ctx)
+
+    # Cutover was attempted (recoverable -> _select_live_fallback_source).
+    mock_select.assert_called()
+    # ...and with no validated fallback we re-entered the retry ladder on the
+    # primary at the stalled offset, instead of hard-closing.
+    mock_retry.assert_called()
+    assert mock_retry.call_args.args[1] == 2048
+    # The primary recovered through the ladder, so the full range reached Kodi.
+    assert _collect_written(handler) == b"A" * 1024 + b"B" * 1024 + b"C" * 2048
+    logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
+    assert "reason=fallback_pending_retry_primary" in logged
+    assert "reason=fallback_exhausted" not in logged
 
 
 def test_serve_proxy_high_water_short_read_waits_instead_of_fallback_exhausted():

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -665,7 +665,13 @@ def test_find_video_file_parallelizes_sibling_subfolders_for_post_picker_start(
 def test_find_video_file_overlaps_first_sibling_probe_for_post_picker_start(
     mock_urlopen, mock_settings
 ):
-    """The first slow empty sibling should not delay probing later siblings."""
+    """Sibling probes run concurrently; a size tie keeps the earliest sibling.
+
+    We now scan every sibling (no early-exit) to pick the largest, so total
+    time tracks the SLOWEST sibling — but probes still overlap, so it stays
+    near max(sibling) rather than the serial sum. B and C are the same size,
+    so the tie resolves to the earlier-listed B.
+    """
     mock_settings.return_value = _SETTINGS_WITH_AUTH
     parent = _propfind_listing(
         [
@@ -711,7 +717,9 @@ def test_find_video_file_overlaps_first_sibling_probe_for_post_picker_start(
     elapsed = time.perf_counter() - started
 
     assert path == "/content/uncategorized/Overlap/B/Movie.mkv"
-    assert elapsed < 0.24, "first-sibling WebDAV overlap took {:.3f}s".format(elapsed)
+    # Overlapped: near the slowest sibling (~0.6s), well under the serial sum
+    # (0.16 + 0.16 + 0.6 = 0.92s).
+    assert elapsed < 0.85, "first-sibling WebDAV overlap took {:.3f}s".format(elapsed)
 
 
 @patch("resources.lib.webdav._get_settings")
@@ -773,9 +781,16 @@ def test_find_video_file_reuses_settings_during_recursive_post_picker_scan(
 
 @patch("resources.lib.webdav._get_settings")
 @patch("resources.lib.webdav.urlopen")
-def test_find_video_file_returns_before_slower_later_sibling_when_ordered_match_found(
+def test_find_video_file_waits_for_larger_slower_later_sibling(
     mock_urlopen, mock_settings
 ):
+    """A larger video in a slower, later-listed sibling must still win.
+
+    The old code returned the first sibling with any video (here B) and never
+    waited for the slower C. Now we scan all siblings and pick the largest, so
+    the bigger C wins even though it is listed later and responds slower —
+    exactly what prevents a smaller early release from hijacking the real one.
+    """
     mock_settings.return_value = _SETTINGS_WITH_AUTH
     parent = _propfind_listing(
         [
@@ -789,13 +804,13 @@ def test_find_video_file_returns_before_slower_later_sibling_when_ordered_match_
     with_video_b = _propfind_listing(
         [
             ("/content/uncategorized/Ordered/B/", True, None),
-            ("/content/uncategorized/Ordered/B/Movie.mkv", False, 1234),
+            ("/content/uncategorized/Ordered/B/Small.mkv", False, 1234),
         ]
     )
     with_video_c = _propfind_listing(
         [
             ("/content/uncategorized/Ordered/C/", True, None),
-            ("/content/uncategorized/Ordered/C/Slow.mkv", False, 1234),
+            ("/content/uncategorized/Ordered/C/Large.mkv", False, 999999),
         ]
     )
 
@@ -816,12 +831,102 @@ def test_find_video_file_returns_before_slower_later_sibling_when_ordered_match_
 
     mock_urlopen.side_effect = propfind
 
-    started = time.perf_counter()
     path = find_video_file("/content/uncategorized/Ordered/")
-    elapsed = time.perf_counter() - started
 
-    assert path == "/content/uncategorized/Ordered/B/Movie.mkv"
-    assert elapsed < 0.34, "ordered WebDAV match waited {:.3f}s".format(elapsed)
+    assert path == "/content/uncategorized/Ordered/C/Large.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_skips_hidden_dot_subfolders(mock_urlopen, mock_settings):
+    """Hidden (dot-prefixed) sibling folders must be ignored entirely.
+
+    Regression for the polluted FraMeSToR release whose hidden
+    '.and_justice_for_all...1080p...' child folder hijacked playback of the
+    real 2160p release. A leading-dot subfolder is skipped (never even
+    PROPFIND'd) regardless of how large its contents are.
+    """
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/uncategorized/Polluted/", True, None),
+            ("/content/uncategorized/Polluted/.and_justice_1080p/", True, None),
+            ("/content/uncategorized/Polluted/Real/", True, None),
+        ]
+    )
+    real = _propfind_listing(
+        [
+            ("/content/uncategorized/Polluted/Real/", True, None),
+            ("/content/uncategorized/Polluted/Real/Silence.2160p.mkv", False, 9000),
+        ]
+    )
+    visited_urls = []
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        visited_urls.append(url)
+        if url.endswith("/Polluted/"):
+            return _webdav_response(parent)
+        if url.endswith("/Real/"):
+            return _webdav_response(real)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/uncategorized/Polluted/")
+
+    assert path == "/content/uncategorized/Polluted/Real/Silence.2160p.mkv"
+    assert not any(
+        ".and_justice" in url for url in visited_urls
+    ), "hidden dot-folder must not be probed: {}".format(visited_urls)
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_returns_largest_across_sibling_folders(
+    mock_urlopen, mock_settings
+):
+    """Across sibling folders, the LARGEST video wins regardless of order.
+
+    The old code returned the first sibling that had any video, so a smaller
+    junk release in an earlier-listed sibling beat the real, larger release in
+    a later sibling.
+    """
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/uncategorized/Multi/", True, None),
+            ("/content/uncategorized/Multi/A/", True, None),
+            ("/content/uncategorized/Multi/B/", True, None),
+        ]
+    )
+    small_a = _propfind_listing(
+        [
+            ("/content/uncategorized/Multi/A/", True, None),
+            ("/content/uncategorized/Multi/A/Junk.1080p.mkv", False, 1000),
+        ]
+    )
+    large_b = _propfind_listing(
+        [
+            ("/content/uncategorized/Multi/B/", True, None),
+            ("/content/uncategorized/Multi/B/Real.2160p.mkv", False, 90000),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Multi/"):
+            return _webdav_response(parent)
+        if url.endswith("/Multi/A/"):
+            return _webdav_response(small_a)
+        if url.endswith("/Multi/B/"):
+            return _webdav_response(large_b)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/uncategorized/Multi/")
+    assert path == "/content/uncategorized/Multi/B/Real.2160p.mkv"
 
 
 _PROPFIND_CROSS_ORIGIN_HREFS = """<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Summary

Two playback fixes surfaced while debugging *The Silence of the Lambs* going dark and bouncing back to the TMDBHelper player dialog.

### 1. Stream proxy: re-enter retry ladder instead of `fallback_exhausted` hard-close
When a pass-through trickle/short read returned recoverable to drive a fallback cutover but no fallback validated, `_serve_proxy` set `terminal_reason="fallback_exhausted"` and returned immediately — **skipping the retry ladder, skip-probe, and zero-fill rescue** that a stream *without* fallback sources still gets. This made attaching fallbacks *more* brittle: a transient primary trickle hard-closed the stream and kicked Kodi back to the player dialog.

Now it falls through to the retry ladder (`reason=fallback_pending_retry_primary`) so the primary gets a fresh chance; if it stays dead, the existing density-breaker and session zero-fill-budget safeguards bound the damage — identical to the no-fallback path.

### 2. WebDAV: skip hidden subfolders, pick largest video across siblings
`find_video_file` recursed into sibling subfolders and returned the **first** sibling with any video, contradicting its own "largest video file" contract. A polluted release folder with a hidden `.and_justice...1080p` child hijacked playback of the real 2160p release.

- Skip hidden (leading-dot) sibling subfolders entirely (never PROPFIND'd).
- `_find_video_file_in_subdirs` now scans all siblings and returns the **largest** video (ties → earliest sibling) via the existing `getcontentlength` hint, dropping the first-match early-exit.

## Tests
- New: `test_serve_proxy_trickle_reenters_retry_ladder_when_no_validated_fallback`, `test_find_video_file_skips_hidden_dot_subfolders`, `test_find_video_file_returns_largest_across_sibling_folders`.
- Updated existing tests that encoded the old hard-close / first-match-early-exit behavior.

## Verification
- `just test` → **1607 passed, 5 skipped**
- `just lint` → ruff/black clean, pylint **10.00/10**
- Runtime changes stay Python 3.8-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)