### PR TITLE
fix(playback): prewarm file-tail cues + defer fallback prewarm to stop startup black-screen freeze

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -2816,10 +2816,27 @@ def _prefetch_fallback_candidate_loader(candidate_loader):
     return _load_prefetched_candidates
 
 
+# Seconds to hold the fallback prewarm burst after playback handoff so it does
+# not contend with the live stream for nzbdav connections while Kodi's read
+# cache is still filling. Long enough to cover the startup cache-fill window;
+# the cutover safety net is only briefly delayed, not removed.
+_FALLBACK_PREWARM_DELAY_SECONDS = 15
+
+
 def _start_fallback_submit_worker(
-    candidates=None, candidate_loader=None, settings_getter=None
+    candidates=None, candidate_loader=None, settings_getter=None, prewarm_delay=0
 ):
-    """Start background fallback submits and return shared state."""
+    """Start background fallback submits and return shared state.
+
+    ``prewarm_delay`` defers the submit/prevalidation burst by that many seconds
+    after playback hands off. The prewarm opens several concurrent connections to
+    nzbdav (one submit + one prevalidation probe per source); firing them during
+    the first seconds of playback — while Kodi's read cache is still filling —
+    competes for nzbdav's connection budget and can stall the live stream enough
+    to wedge the CoreELEC audio clock (black screen). Waiting until playback is
+    established keeps the cutover safety net while protecting startup. The wait is
+    cancellable: a session stop during the window aborts it with no submission.
+    """
 
     def _cancel_job(nzo_id):
         if settings_getter is None:
@@ -2864,6 +2881,12 @@ def _start_fallback_submit_worker(
 
     def _worker():
         try:
+            # Defer the prewarm burst until playback is established so it does
+            # not compete with the live stream for nzbdav connections during the
+            # fragile cache-fill window. Cancellable: a stop set during the wait
+            # returns True and aborts before any submit.
+            if prewarm_delay and state["stop"].wait(prewarm_delay):
+                return
             active_candidates = candidate_list
             candidate_lookup_disabled = False
             if candidate_loader is not None:
@@ -3493,6 +3516,7 @@ def resolve(handle, params):
                 fallback_state = _start_fallback_submit_worker(
                     fallback_candidates,
                     candidate_loader=fallback_candidate_loader,
+                    prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
                 )
 
         # One rejected-id set per resolve attempt, shared so a Completed row
@@ -3620,6 +3644,7 @@ def resolve_and_play(nzb_url, title, params=None):
             if fallback_state is None:
                 fallback_submit_kwargs = {
                     "candidate_loader": fallback_candidate_loader,
+                    "prewarm_delay": _FALLBACK_PREWARM_DELAY_SECONDS,
                 }
                 fallback_submit_kwargs.update(_settings_getter_kwargs(settings_getter))
                 fallback_state = _start_fallback_submit_worker(

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -298,6 +298,13 @@ _FALLBACK_FINGERPRINT_WORKERS = 10
 _MAX_PROXY_WORKERS = 64
 _FALLBACK_PRIMARY_DIGEST_CACHE_MAX = 512
 _INITIAL_RANGE_PREFETCH_WAIT_SECONDS = 0.08
+# Kodi reads the MKV cues/SeekHead at the FILE TAIL before playback. nzbdav
+# fetches those end-of-file usenet articles on demand, so the first tail read
+# stalls 1-4s mid-startup and can wedge the CoreELEC audio clock (black screen).
+# A throwaway read of the last _TAIL_PREWARM_BYTES during the prepare gap warms
+# nzbdav's article cache so Kodi's real cues read is fast. 1 MiB comfortably
+# covers the cues/SeekHead region Kodi reads at startup.
+_TAIL_PREWARM_BYTES = 1048576
 _PASSTHROUGH_RUNTIME_SETTINGS_KEY = "_passthrough_runtime_settings"
 _PASSTHROUGH_RUNTIME_SETTINGS_DONE_KEY = "_passthrough_runtime_settings_done"
 _PASSTHROUGH_RUNTIME_SETTINGS_ERROR_KEY = "_passthrough_runtime_settings_error"
@@ -6698,6 +6705,64 @@ class StreamProxy:
         except RuntimeError:
             ctx.pop("_initial_range_prefetch_thread", None)
 
+    def _prewarm_tail_range(self, ctx):
+        """Warm nzbdav's FILE-TAIL article cache (MKV cues) for instant startup.
+
+        Kodi reads the MKV cues/SeekHead at the file tail before it can play. For
+        a usenet-backed file nzbdav fetches those end-of-file articles on demand,
+        so Kodi's first tail read otherwise stalls 1-4s mid-startup — long enough
+        to drain its not-yet-full cache and wedge the CoreELEC audio clock
+        (permanent black screen). Issue a throwaway read of the last
+        _TAIL_PREWARM_BYTES here, during the prepare gap, so nzbdav has the tail
+        articles cached before Kodi asks. No proxy-side caching: the exact tail
+        offset Kodi requests isn't fixed, and nzbdav serves subsequent tail reads
+        fast once the articles are fetched. The body is discarded.
+        """
+        try:
+            content_length = int(ctx.get("content_length", 0) or 0)
+        except (TypeError, ValueError):
+            return
+        # Only warm a tail that is distinct from the byte-0 prefetch window;
+        # tiny files are already fully covered by _prefetch_initial_range.
+        if content_length <= _TAIL_PREWARM_BYTES + _UPSTREAM_READ_CHUNK:
+            return
+        tail_start = content_length - _TAIL_PREWARM_BYTES
+        try:
+            _StreamHandler._fetch_primary_range_bytes(
+                ctx["remote_url"],
+                ctx.get("auth_header"),
+                tail_start,
+                content_length - 1,
+                content_length,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            xbmc.log(
+                "NZB-DAV: Tail prewarm failed: {}".format(exc),
+                xbmc.LOGDEBUG,
+            )
+
+    def _start_tail_prewarm(self, ctx):
+        """Warm the file tail in parallel with the byte-0 prefetch at prepare.
+
+        Runs on its own thread so it neither delays /prepare nor serializes
+        behind the byte-0 prefetch — Kodi reads the tail FIRST, so warming it
+        must start as early as possible. Fails soft when out of thread budget,
+        matching the sibling prefetch spawns.
+        """
+        if not self._initial_range_prefetchable(ctx):
+            return
+        thread = threading.Thread(
+            target=self._prewarm_tail_range,
+            args=(ctx,),
+            name="nzbdav-tail-prewarm",
+        )
+        thread.daemon = True
+        ctx["_tail_prewarm_thread"] = thread
+        try:
+            thread.start()
+        except RuntimeError:
+            ctx.pop("_tail_prewarm_thread", None)
+
     def _start_passthrough_runtime_settings_prefetch(self, ctx):
         """Read pass-through recovery settings during the player handoff gap."""
         if isinstance(ctx.get(_PASSTHROUGH_RUNTIME_SETTINGS_KEY), dict):
@@ -7191,6 +7256,7 @@ class StreamProxy:
             )
         self._start_passthrough_runtime_settings_prefetch(ctx)
         self._start_initial_range_prefetch(ctx)
+        self._start_tail_prewarm(ctx)
         self._start_fallback_prevalidation(ctx)
 
         local_url = self._register_session(ctx)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from resources.lib.resolver import (
     _DOWNLOAD_TIMEOUT_MAX,
     _DOWNLOAD_TIMEOUT_MIN,
+    _FALLBACK_PREWARM_DELAY_SECONDS,
     _POLL_INTERVAL_MAX,
     _POLL_INTERVAL_MIN,
     MAX_POLL_ITERATIONS,
@@ -1116,7 +1117,9 @@ def test_resolve_starts_fallback_worker_after_primary_submit_and_uses_snapshot(
         assert mock_start_fallback.call_count == 0
         kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
         mock_start_fallback.assert_called_once_with(
-            fallback_candidates, candidate_loader=None
+            fallback_candidates,
+            candidate_loader=None,
+            prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
         )
         return (
             "http://webdav/content/primary/movie.mp4",
@@ -1151,7 +1154,9 @@ def test_resolve_starts_fallback_worker_after_primary_submit_and_uses_snapshot(
     assert call_order == ["poll"]
     mock_snapshot.assert_called_once_with(fallback_state, wait_seconds=8.0)
     mock_start_fallback.assert_called_once_with(
-        fallback_candidates, candidate_loader=None
+        fallback_candidates,
+        candidate_loader=None,
+        prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
     )
     mock_start_prepare.assert_called_once_with(
         "http://webdav/content/primary/movie.mp4",
@@ -2529,6 +2534,7 @@ def test_resolve_and_play_defers_fallback_loader_until_primary_accept(
     mock_start_fallback.assert_called_once_with(
         [],
         candidate_loader=loader_kwarg,
+        prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
     )
 
 
@@ -3112,6 +3118,26 @@ def test_fallback_submit_worker_loads_candidates_in_background(mock_xbmc, mock_s
             "content_length": 0,
         }
     ]
+
+
+@patch("resources.lib.resolver._submit_fallback_candidates")
+def test_fallback_submit_worker_defers_prewarm_burst(mock_submit):
+    """The fallback prewarm must wait ``prewarm_delay`` before submitting, so the
+    multi-source burst doesn't pile concurrent nzbdav connections onto a
+    just-started playback stream (the live black-screen freezes, 2026-05-31).
+
+    A stop during the deferral window cancels the burst with no submission.
+    """
+    mock_submit.return_value = ("SABnzbd_nzo_fallback", None)
+
+    state = _start_fallback_submit_worker(
+        candidates=[{"title": "Fallback A", "link": "http://hydra/getnzb/a"}],
+        prewarm_delay=30.0,
+    )
+    # Stop during the deferral window → burst cancelled, nothing submitted.
+    state["stop"].set()
+    assert state["finished"].wait(timeout=2)
+    mock_submit.assert_not_called()
 
 
 @patch("resources.lib.resolver._submit_fallback_candidates")

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -2603,6 +2603,69 @@ def test_fallback_prevalidation_does_not_delay_initial_prefetch_first_bytes():
     )
 
 
+def test_prefetch_tail_prewarms_nzbdav_cues_cache():
+    """Prepare-time prefetch must warm nzbdav's FILE-TAIL articles (MKV cues).
+
+    Kodi reads the MKV SeekHead/Cues at the file tail BEFORE playback. For a
+    usenet-backed file nzbdav fetches those end-of-file articles on demand, so
+    the first tail read stalls 1-4s mid-startup and can wedge the CoreELEC audio
+    clock (permanent black screen). A throwaway read of the tail during the
+    prepare gap warms nzbdav so Kodi's real cues read is fast. Regression for the
+    live Ballerina/Casino black-screen freezes (2026-05-31).
+    """
+    from resources.lib.stream_proxy import (
+        _TAIL_PREWARM_BYTES,
+        StreamProxy,
+        _StreamHandler,
+    )
+
+    sp = StreamProxy.__new__(StreamProxy)
+    content_length = 50 * 1024 * 1024  # 50 MiB — large enough for a distinct tail
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": "Basic primary",
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+    }
+    calls = []
+
+    def record(url, auth_header, start, end, cl):
+        calls.append((start, end))
+        return b"X" * (end - start + 1)
+
+    with patch.object(_StreamHandler, "_fetch_primary_range_bytes", side_effect=record):
+        sp._prewarm_tail_range(ctx)
+
+    assert calls, "tail prewarm issued no upstream read"
+    tail_start, tail_end = calls[-1]
+    assert tail_end == content_length - 1
+    assert tail_start == content_length - _TAIL_PREWARM_BYTES
+
+
+def test_tail_prewarm_skipped_when_file_smaller_than_tail_window():
+    """Tiny files have no distinct tail to warm — skip the read (the byte-0
+    prefetch already covers the whole file)."""
+    from resources.lib.stream_proxy import StreamProxy, _StreamHandler
+
+    sp = StreamProxy.__new__(StreamProxy)
+    ctx = {
+        "remote_url": "http://host/small.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 4096,
+    }
+    calls = []
+
+    with patch.object(
+        _StreamHandler,
+        "_fetch_primary_range_bytes",
+        side_effect=lambda *a, **k: calls.append(a) or b"",
+    ):
+        sp._prewarm_tail_range(ctx)
+
+    assert not calls, "small file should not trigger a tail prewarm read"
+
+
 def test_ready_fallback_is_prevalidated_before_upstream_error_cutover():
     """Cutover should not pay full fingerprint validation after the read error."""
     from resources.lib.stream_proxy import (


### PR DESCRIPTION
## Summary
Fixes the startup black-screen freeze where playback started, ran a few seconds, then went black with no OSD.

### Root cause (confirmed by live per-operation instrumentation)
Kodi reads the **MKV cues/SeekHead at the file tail** before it can play. nzbdav fetches those end-of-file articles **on demand**, so Kodi's first cues read stalled **1–4 s** during startup (cache still filling) — long enough to drain the buffer and **wedge the CoreELEC audio clock permanently** (black screen). Instrumentation showed the first tail OPEN at **3.75 s**; subsequent tail reads were fast (nzbdav caches once fetched).

### Fix 1 — tail prewarm (`stream_proxy.py`) — verified live
`_prewarm_tail_range`/`_start_tail_prewarm`: parallel prepare-time throwaway read of the last 1 MiB warms nzbdav's tail cache so Kodi's cues read is instant. A 90 GB UHD remux that froze at ~4 s now plays cleanly with zero slow opens.

### Fix 2 — defer fallback prewarm (`resolver.py`) — unit-tested, pending live verify
Cancellable `prewarm_delay` (default 0; 15 s at the 2 production sites) holds the multi-source prewarm burst until playback is established so it can't starve startup.

## Tests / verification
- New tests for tail prewarm + deferral; updated 2 production-path resolver tests for the new call signature.
- `just test` → 1635 passed, 5 skipped; `just lint` → 10.00/10. Python 3.8-compatible.

## Out of scope
A separate **mid-stream** black screen after seeking deep into a 90 GB remux was nzbdav becoming slow then **fully unreachable** (upstream throughput/stability limit), not addressable from the addon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)