### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XXE vulnerability in router.py XML parsing

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -1773,8 +1773,17 @@ def _xml_root_name(response):
     """Return the unqualified root XML tag name, lowercased."""
     import xml.etree.ElementTree as ET  # nosec B405 - trusted service response
 
+    parser = ET.XMLParser()  # nosec B314 - entities disabled below
     try:
-        root = ET.fromstring(response)  # nosec B314 - trusted service response
+        parser.parser.DefaultHandler = lambda _d: None
+        parser.parser.ExternalEntityRefHandler = lambda *_: False
+    except AttributeError:
+        pass
+
+    try:
+        root = ET.fromstring(
+            response, parser=parser
+        )  # nosec B314 - trusted service response
     except (TypeError, ET.ParseError):
         return ""
     return root.tag.rsplit("}", 1)[-1].lower()


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unsafe XML parsing with `xml.etree.ElementTree.fromstring` allowing External Entity Reference (XXE/SSRF) execution from untrusted API/RSS endpoints.
🎯 **Impact:** Could allow arbitrary local file reads on systems running Python versions or runtime parsers that do not securely default the parser handler.
🔧 **Fix:** Passed an explicit `ET.XMLParser()` instance where `ExternalEntityRefHandler` returns `False` to prevent execution and resolution.
✅ **Verification:** Verified safe via `pytest tests/` unit tests checking that XML payload routing operates accurately without entities, and confirmed using test cases that the explicit parser effectively catches and denies `<!ENTITY xxe SYSTEM...>` references. Recorded in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [119891634917233254](https://jules.google.com/task/119891634917233254) started by @xbmc4lyfe*