### PR TITLE
🎨 Palette: Add explicit directional navigation mapping in results-dialog.xml

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -66,6 +66,8 @@
     <control type="list" id="50">
       <left>0</left><top>60</top><width>1910</width><height>975</height>
       <orientation>vertical</orientation>
+      <onleft>60</onleft>
+      <onright>60</onright>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
 
@@ -232,6 +234,8 @@
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
+      <onleft>50</onleft>
+      <onright>50</onright>
       <showonepage>false</showonepage>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>


### PR DESCRIPTION
💡 What: Added explicit `<onleft>` and `<onright>` tags to map bidirectional navigation between the search results `<list>` control and its corresponding `<scrollbar>` in the main results dialog.
🎯 Why: Kodi does not infer directional navigation mappings automatically for custom UI containers. Without these tags, users relying on a keyboard or TV remote cannot navigate left or right to access the scrollbar for rapid scrolling.
♿ Accessibility: Ensures full remote-control and keyboard operability for traversing horizontally within the UI, addressing a previously unreachable interactive element.

---
*PR created automatically by Jules for task [6985172319394346191](https://jules.google.com/task/6985172319394346191) started by @xbmc4lyfe*