### PR TITLE
fix(proxy/fallback): tiered same-release matching + bounded recovery, blackscreen & dropout hardening

### DIFF
--- a/FALLBACK_INFO.md
+++ b/FALLBACK_INFO.md
@@ -1,0 +1,301 @@
+# nzbdav Kodi Addon — Stream-Fallback System
+
+> Definitive reference for the multi-tier stream-fallback mechanism. All
+> file:line references point into `repo/plugin.video.nzbdav/resources/lib/`.
+
+## Overview
+
+The stream-fallback system submits alternate Usenet releases as *standby
+candidates* during playback and automatically switches to one when the primary
+stream fails at a byte range. It spans five components:
+
+| Component | File | Role |
+|-----------|------|------|
+| Resolver / orchestration | `resolver.py` | drives the flow, threads `fallback_state`, arms live push |
+| Candidate gating | `fallback_streams.py` | content-identity + metadata gates, fingerprinting, payload build |
+| Stream proxy | `stream_proxy.py` | serves bytes, prevalidates, executes the live cutover |
+| Dead-candidate tracking | `dead_candidates.py` | permanently blacklists provably-dead releases per session |
+| Backend submit | `nzbdav_api.py` | submits NZB jobs to nzbdav |
+
+The lifecycle is deliberately lazy: a healthy playback that never stalls
+submits **zero** fallback candidates. Backups are only fetched well after the
+video is confirmed playing, so the burst never contends with the fragile
+startup cache-fill window.
+
+### End-to-end lifecycle
+
+```mermaid
+flowchart TD
+    A["Picker captures candidates<br/>params._fallback_candidates / _fallback_candidate_loader"] --> B["resolver.resolve()"]
+    B --> C["Submit primary NZB<br/>_submit_nzb_with_retries"]
+    C --> D["on_primary_submitted fires<br/>_start_fallback_submit_worker"]
+    D --> E["Daemon thread 'nzbdav-fallback-submit'<br/>waits for playback start"]
+    C --> F["_poll_until_ready primary"]
+    F --> G["Primary resolves to WebDAV URL"]
+    G --> H["Snapshot pending jobs<br/>build_prepare_fallback_payload"]
+    H --> I["POST /prepare with fallback_sources<br/>prepare_stream()"]
+    I --> J["_attach_fallback_context_fields<br/>start prevalidation thread"]
+    G --> K["_arm_live_fallback_push<br/>on_append hook"]
+    J --> L["Playback running"]
+    E -->|"after prewarm_delay"| M["Submit candidate NZBs<br/>push to /stream/id/fallbacks"]
+    M --> K
+    L --> N{"Primary fails<br/>at byte range?"}
+    N -->|"healthy"| O["No cutover<br/>serve to EOF"]
+    N -->|"RECOVERABLE"| P["_select_live_fallback_source"]
+    P --> Q{"tri-state<br/>_fallback_source_matches"}
+    Q -->|"MATCH"| R["_activate_fallback_source<br/>demote primary, swap remote_url+auth"]
+    Q -->|"MISMATCH"| S["mark failed=True"]
+    Q -->|"INCONCLUSIVE"| T["transient_miss_count++"]
+    R --> L
+    S --> P
+    T --> P
+    Q -->|"exhausted"| U["terminal: zero-fill to end"]
+```
+
+### Background-worker interactions
+
+```mermaid
+sequenceDiagram
+    participant R as resolver.resolve()
+    participant W as submit worker<br/>(daemon thread)
+    participant API as nzbdav_api
+    participant P as stream_proxy
+    participant PV as prevalidation thread
+
+    R->>API: submit primary NZB
+    API-->>R: nzo_id
+    R->>W: _start_fallback_submit_worker (wait_for_playback=True)
+    Note over W: blocks in _await_playback_start
+    R->>P: POST /prepare (fallback_sources snapshot)
+    P->>PV: _start_fallback_prevalidation(ctx)
+    Note over PV: fingerprints candidates,<br/>sets validated / failed
+    R->>R: _finish_direct_playback (handoff to Kodi)
+    R->>W: _signal_fallback_playback_started
+    Note over W: wakes, waits prewarm_delay (120s)
+    W->>API: submit candidate NZBs
+    API-->>W: nzo_id per job
+    W->>R: on_job -> _append_job
+    R->>P: POST /stream/<id>/fallbacks (live push)
+    P->>P: merge_session_fallbacks (dedup by nzo_id)
+    P->>PV: prevalidate additions
+    Note over P: on primary failure -><br/>_select_live_fallback_source -><br/>_activate_fallback_source (swap)
+```
+
+The `fallback_state` dict (`resolver.py:2966-2974`: `lock`, `jobs`, `stop`,
+`finished`, `playback_started`, `thread`, `cancel_job`) is the shared channel
+between the resolver and the worker. The `ctx` dict is the proxy session's
+master state (`stream_proxy.py:8018-8026`), holding `remote_url`,
+`auth_header`, `fallback_sources`, `fallback_active_index`,
+`fallback_switch_count`, and per-cutover validation hints. The
+`DeadCandidates` set (`dead_candidates.py:22-40`) is threaded through every
+path to exclude poisoned candidates.
+
+## Candidate Selection
+
+Candidates originate from the **same search-result pool** that the picker
+passes to the resolver — not a separate indexer query
+(`fallback_streams.py:2011-2042`, `attach_fallback_candidates(results)`). They
+are filtered through strict content-identity gates and then ranked by a
+similarity tier.
+
+**Gates** (`fallback_streams.py:1376-1404`, `_fallback_peer_matches`):
+
+1. Different NZB link (`:1380`)
+2. Different article digest (`:1385`) — exact re-uploads rejected
+3. `_same_content()` — the authoritative content-identity gate
+   (`:1388-1391`, defined `:629-743`): title / year / seasons / episodes /
+   part / edition / proper / repack
+4. Title-token relatedness via `_titles_look_related()` (`:1394`)
+5. `_metadata_profiles_match(require_same_group=True)` (`:1401`)
+6. `_fallback_manifest_peer_matches()` (`:1404`)
+
+**Tier ranking** (`fallback_streams.py:746-777`, `_release_similarity`) — all
+tiers hard-reject (return `None`) if `_same_content()` fails (`:756`):
+
+- **Tier 0** — same resolution + codec + group + size within 3% (`:770-773`)
+- **Tier 1** — same resolution + codec (`:769-774`). *Note:* tier
+  classification does **not** itself enforce a size tolerance; the ~10% size
+  tolerance (`_PEER_BYTES_TOLERANCE_FRACTION = 0.10`, `:1416`) is deferred to
+  `_fallback_manifest_peer_matches()` (`:1520`), not the tier check.
+- **Tier 2** — same resolution, different codec (`:775-776`)
+- **Tier 3** — same content, anything else (`:777`)
+
+When `require_same_group=True` (`_metadata_profiles_match`, `:1238-1252`) both
+the **group** and the **resolution** must parse and be equal — fail-closed:
+unknown/unparsed group or resolution is rejected (`:1239-1242`, `:1249-1252`).
+
+`_manifest_group_key()` (`:1293-1313`) returns `(kind, name, size)` for video
+or `(kind, name)` for archive. Archive matches short-circuit on
+`archive_base_name` alone (`:1491-1496`); video matches bypass the size
+tolerance when the key matches (`:1497-1500`). **The manifest key does NOT
+include the article digest** — digest dedup is a *separate* mechanism in
+`_attach_candidates_for_target()` (`seen_article_digests`, `:1688-1691`,
+`:1704-1705`).
+
+Maximum fallbacks: `_MAX_FALLBACKS = 5` (`:84`), clamped via the
+`fallback_streams_max` setting (`:1562`).
+
+> Note on gate ordering: `first_prefetchable_fallback_peer()`
+> (`:1137-1214`) and `_fallback_peer_matches()` enforce the gates in
+> **different sequences**. `first_prefetchable_fallback_peer` runs
+> `_metadata_profiles_match` (`:1163-1170`) → title tokens (`:1173-1174`) →
+> `_same_content` (`:1175`), whereas `_fallback_peer_matches` runs
+> `_same_content` *first* (`:1390-1391`) then the title/group checks. The end
+> result is the same admission set, but a developer tracing one path should
+> not assume the other matches order-for-order.
+
+### Duplicate-proneness
+
+**Direct answer: same-post-date / different-group / different-resolution
+duplicates are NOT submitted as fallbacks.** Same-post-date collapsing is now
+explicit (`_dedupe_candidates_by_pubdate()`, see Honest gaps below). On top of
+that, when `require_same_group=True` (the active prefetch path),
+different-group *or* different-resolution candidates are rejected outright at
+`fallback_streams.py:1239-1252`.
+
+**Honest gaps:**
+
+- **Same-post-date dedup IS enforced.** `_dedupe_candidates_by_pubdate()`
+  (`fallback_streams.py`) collapses candidates whose Usenet post dates fall
+  within `_SAME_POST_WINDOW_SECONDS` (3600s, inclusive) of each other down to a
+  single survivor (highest similarity tier kept), and drops any candidate within
+  that window of the primary's own post date. Anchor-based clustering means a
+  chain of near-posts does not transitively merge. Runs in both ranking paths
+  (`_attach_candidates_for_target`, `_rank_fallback_candidates`) before the
+  `_MAX_FALLBACKS` clamp. Candidates with no parseable `pubdate` are treated as
+  always-distinct and are never collapsed.
+- **Article-digest dedup only fires when BOTH digests exist and are equal**
+  (`:1383-1386`). If either side's digest is missing, the digest check is
+  skipped; the content-identity and group/resolution gates remain the only
+  defense.
+- If a legacy or non-prefetch path runs with `require_same_group=False`, the
+  different-group / different-resolution rejection no longer applies, and two
+  releases from the same posting time with different groups *could* both pass
+  provided they satisfy `_same_content()`.
+
+## Submission Timing
+
+Fallback submission is a **two-stage, deliberately delayed** process anchored
+to **playback start**, not picker selection and not primary submission.
+
+**Trigger point.** Submission is armed at *primary NZB submission* time:
+`_submit_nzb_with_retries()` returns, then `on_primary_submitted(nzo_id)` fires
+inside `_poll_until_ready()` (`resolver.py:3533-3535`). That callback is
+`_start_fallback_after_primary` (resolve path `:3667-3678`, resolve_and_play
+path `:3807-3824`), which launches the worker via
+`_start_fallback_submit_worker()`.
+
+**The worker.** A daemon thread named `nzbdav-fallback-submit`
+(`resolver.py:3059-3063`), stored as `state['thread']`, runs until
+`state['stop']` is set. It does **not** submit immediately — both paths pass
+`wait_for_playback=True` (`:3675`, `:3816`). The worker first blocks in
+`_await_playback_start(state)` (`:3010-3013`).
+
+**The deliberate delay.** After playback is handed off to Kodi,
+`_signal_fallback_playback_started(fallback_state)` is called (resolve `:3754`,
+resolve_and_play `:3924`), setting the `playback_started` event (`:2927-2934`).
+The worker then waits an additional `prewarm_delay` via
+`state['stop'].wait(prewarm_delay)` (`:3012`):
+
+```python
+# resolver.py:2869
+_FALLBACK_PREWARM_DELAY_SECONDS = 120
+```
+
+> "Seconds INTO playback to hold the fallback prewarm/submit burst. Anchored
+> to actual playback start (not primary submission, which can precede playback
+> by a whole download for a slow primary), so backups are only fetched well
+> after the video is established: a working playback that never needs them
+> submits none, and the burst never contends with the fragile startup
+> cache-fill window." — `resolver.py:2863-2868`
+
+The delay is configurable via the `fallback_submit_delay` setting, passed as
+`prewarm_delay` (`:3674`, `:3813`). Only after it elapses does
+`_submit_fallback_candidates()` run (`:3041-3049`), appending each job to
+`state['jobs']` (`:2986`) and firing the `on_job` hook (`:2798`).
+
+**Parallel candidate loading.** `_prefetch_fallback_candidate_loader()`
+(`:2817-2860`) loads candidates on its own daemon thread during the primary
+download, so the worker is not blocked when the delay expires.
+
+**Live adoption.** `_arm_live_fallback_push()` (`:530-576`, armed at `:3750` /
+`:3920`) installs an `on_append` hook (`:575`) that calls
+`update_stream_fallbacks_via_service()` (`stream_proxy.py:8942-8967`),
+POSTing newly-adopted jobs to `http://127.0.0.1:{port}/stream/{session_id}/fallbacks`
+(3s timeout). The handler `_handle_fallback_update()`
+(`stream_proxy.py:2405-2466`) calls `merge_session_fallbacks()`.
+
+**Cancellation.** `_stop_fallback_submit_worker()` (`:3158-3179`) sets
+`state['stop']`; both the playback-start wait and the prewarm wait check
+`stop.is_set()` and return early, so an aborted session submits nothing.
+
+Both `resolve()` (setResolvedUrl) and `resolve_and_play()` (service-side)
+paths are functionally identical for fallback submission.
+
+## Byte-Stream Verification
+
+Fallback candidates are verified to be **byte-identical** before they are
+allowed to take over, using `content_length` equality plus SHA256
+fingerprinting of sampled byte ranges.
+
+**Stage 1 — content_length equality.** Two sources are eligible for comparison
+only if their `content_length` values are exactly equal
+(`stream_proxy.py:3778-3783`; immediate rejection on inequality). Every
+fallback record carries `content_length` (`fallback_streams.py:2198`).
+
+**Stage 2 — fingerprinting.** `_fingerprint_ranges_for_length()`
+(`fallback_streams.py:2209-2235`):
+
+- For `content_length <= 4096`: a single range `(0, content_length-1)`.
+- For larger files: up to 100 ranges, each 4096 bytes, distributed
+  deterministically by a seed `hashlib.sha256("{}:{}".format(content_length, counter))`.
+
+Digests are compared at `stream_proxy.py:4141-4167`:
+`if primary_digest != fallback_digest: return _FALLBACK_MISMATCH`.
+
+**Eager vs lazy validation.** Both occur:
+
+- **Eager (prevalidation thread)** — warms candidates *before* any failure.
+  The loop skips already-resolved sources:
+  `if source.get("failed") or source.get("validated"): continue`
+  (`stream_proxy.py:3864`), and sets `source["validated"] = True` after a
+  successful prevalidation (`:3917`). This thread is a daemon and is **never
+  joined before cutover**.
+- **Lazy (at cutover)** — `if source.get("validated")` skips the full
+  fingerprint and only probes the current range (`:3787`), setting
+  `source["validated"] = True` after a lazy match (`:3850`).
+
+**The `validated` flag** means a source has been byte-proven (all sampled
+digests matched) *in this session*; it prevents re-fingerprinting. It is also
+stamped on a **demoted** primary at cutover (`stream_proxy.py:3298-3302`,
+`:3319`): that source was just actively serving these exact bytes, so it is
+content-identical by construction — without the flag the prevalidation warmer
+would re-fingerprint it on a fresh upstream open.
+
+**Offset preservation on cutover.** `_activate_fallback_source()`
+(`stream_proxy.py:3285-3360`) swaps `ctx["remote_url"] = fallback["stream_url"]`
+and the `auth_header` (`:3322-3323`), demotes the dead primary into
+`ctx["fallback_sources"]` with `demoted=True, validated=True` (`:3303-3321`),
+and resets throughput / AWAITING_DOWNLOAD counters (`:3330-3335`,
+`passthrough_window_t0`, `passthrough_window_bytes`,
+`_awaiting_download_no_progress`). The byte position `ctx["current_byte_pos"]`
+persists unchanged across the swap — it is managed separately by
+`_update_current_byte_pos` (`:2086`, `:2113-2114`, `:2143`) — so playback
+resumes at the exact offset (cutover log: "Switched pass-through source at byte
+{}", `:3350-3351`). `fallback_switch_count` and `fallback_active_index` are
+updated (`:3336-3342`).
+
+**Failure handling — tri-state** (`_apply_fallback_match_result`,
+`stream_proxy.py:3363-3390`):
+
+- **MATCH** → activate.
+- **MISMATCH** (different content_length or digest) → `source["failed"] = True`
+  permanently (`:3389`), counter reset (`:3386-3387`).
+- **INCONCLUSIVE** → increment `transient_miss_count`. The source is abandoned
+  (`source["failed"] = True`, `:3381`) only when
+  `misses > _FALLBACK_SOURCE_TRANSIENT_MISS_MAX`
+  (`_FALLBACK_SOURCE_TRANSIENT_MISS_MAX = 4`, `:291`; check at `:3378`) — i.e.
+  **after exceeding 4 misses, on the 5th**, not on the 4th.
+
+Failed sources are permanently skipped during selection:
+`if source.get("failed"): continue` (`stream_proxy.py:3405`).

--- a/docs/superpowers/specs/2026-06-05-nzbget-backend-design.md
+++ b/docs/superpowers/specs/2026-06-05-nzbget-backend-design.md
@@ -1,0 +1,226 @@
+# NZBGet streaming backend — design
+
+**Date:** 2026-06-05
+**Status:** Approved (brainstorm), pending implementation plan
+**Branch context:** authored on `fix/proxy-fallback-resilience`
+
+## Summary
+
+Add an alternative download-and-playback backend to the `plugin.video.nzbdav`
+Kodi addon. Today, selecting a release in the picker submits the NZB *URL* to
+nzbdav's SABnzbd-compatible `addurl` API, polls nzbdav for job status with a
+`DialogProgress` bar, and streams the finished file through the local
+WebDAV-backed stream proxy.
+
+This feature adds a **flip**: when enabled, the same picker selection instead
+submits the NZB to a configured **NZBGet** instance, waits (with a progress
+bar) for NZBGet to finish downloading *and* post-processing, then plays the
+resulting file directly from an **SMB share** that maps onto NZBGet's
+completed-downloads folder. Kodi plays the `smb://` URL natively — the WebDAV
+stream proxy is not involved on this path.
+
+All NZBGet configuration lives in a new **NZBGet** tab in addon settings.
+
+## Decisions (from brainstorm)
+
+1. **The flip is a global setting toggle** (`nzbget_enabled`). When true, every
+   play routes through NZBGet. nzbdav/WebDAV/search settings are untouched and
+   still used for searching — NZBGet only replaces the download + playback
+   backend.
+2. **SMB mapping:** the configured SMB root *is* NZBGet's completed dir. We take
+   the per-release subfolder NZBGet reports in `DestDir`, append it to the SMB
+   root, list it over SMB, and pick the largest video file.
+3. **Completion = full post-processing.** Wait until NZBGet reports the job in
+   history with a terminal `SUCCESS` status (par2 repair + unrar done), then
+   resolve the file. Guarantees a repaired, unpacked, playable file.
+4. **Submit method:** the addon fetches the NZB bytes itself and uploads them to
+   NZBGet base64-encoded via `append` (works even if NZBGet can't reach the
+   indexer).
+5. **Integration approach A:** separate NZBGet modules; `resolve_and_play`
+   branches at the entry point. No changes to the nzbdav streaming, fallback,
+   dead-candidate, or WebDAV machinery.
+6. **Progress UI:** full-screen `DialogProgress` with a cancel button, matching
+   the current nzbdav resolve flow.
+7. **SMB credentials** are embedded directly in the `smb://user:pass@host/...`
+   root URL (single text setting), not split into separate fields.
+8. **On explicit cancel:** delete the NZBGet job *and* its files
+   (`editqueue`/`GroupDelete`). On timeout: leave the job running.
+
+## Architecture
+
+Integration is **Approach A — separate modules, branch at the entry point**:
+
+- New `resources/lib/nzbget_api.py` — JSON-RPC client.
+- New `resources/lib/nzbget_resolver.py` — submit → poll → resolve-over-SMB →
+  `setResolvedUrl`, plus the pure SMB path-mapping function.
+- `resources/lib/resolver.py` — one small branch near the top of
+  `resolve_and_play`: if `nzbget_enabled`, delegate to
+  `nzbget_resolver.resolve_and_play_nzbget(...)` and return. Everything else is
+  unchanged.
+- `resources/lib/router.py` — route `test_nzbget` and `test_nzbget_smb` actions.
+- `resources/settings.xml` + i18n strings — new NZBGet category.
+
+Rationale: the NZBGet flow (whole-file, SMB, post-processing wait) is
+semantically different enough from nzbdav's streaming/fallback model that
+forcing both through one code path adds coupling without payoff. Isolation also
+means the battle-tested nzbdav path cannot regress — the new code is almost
+entirely additive.
+
+## Components
+
+### 1. Settings (new "NZBGet" tab)
+
+New `<category>` in `settings.xml` with new i18n label strings:
+
+- `nzbget_enabled` (bool, default `false`) — the flip.
+- `nzbget_url` (text, default `http://localhost:6789`) — NZBGet host.
+- `nzbget_username` / `nzbget_password` (text, password `option="hidden"`) —
+  NZBGet control credentials (JSON-RPC uses HTTP Basic auth).
+- `nzbget_category` (text, optional) — category to tag submissions with.
+- `Test NZBGet` action → `RunPlugin(plugin://plugin.video.nzbdav/test_nzbget)`.
+- `nzbget_smb_root` (text, e.g. `smb://user:pass@host/completed`) — SMB base
+  mapping onto NZBGet's completed dir. Credentials embedded in the URL.
+- `Test SMB` action → `RunPlugin(plugin://plugin.video.nzbdav/test_nzbget_smb)`.
+
+### 2. NZBGet API client (`nzbget_api.py`)
+
+Pure-Python JSON-RPC 2.0 client mirroring `nzbdav_api.py`'s conventions:
+settings-getter injectable for tests, redacted logging, `(value, error)` tuple
+returns. RPC endpoint `<nzbget_url>/jsonrpc`, HTTP Basic auth from settings.
+
+Methods:
+
+- **`append`** — submit. Args: `NZBFilename` (release name + `.nzb`), `Content`
+  (base64 of fetched NZB bytes), `Category` (from settings), `Priority`,
+  `DupeMode`. Returns **NZBID** (`int > 0`) on success; `0`/negative on failure.
+  NZBID is the lifecycle handle.
+- **`listgroups`** — poll queue/active. Per-job `Status` (`QUEUED`,
+  `DOWNLOADING`, `PP_*`/`POST_PROCESSING`, ...), `DownloadedSizeMB` /
+  `FileSizeMB` for progress %, `NZBID`.
+- **`history`** — poll completion. Terminal `Status` (`SUCCESS/*`,
+  `FAILURE/*`, `WARNING/*`), `DestDir` (server-local final folder), `Name`,
+  `NZBID`.
+- **`version` / `status`** — connectivity test.
+- **`editqueue`** (`GroupDelete` / `HistoryDelete`) — cancel/cleanup.
+
+NZB-byte fetch reuses the existing fetch path
+(`nzbdav_api._dump_submitted_nzb` already downloads NZB bodies); the shared
+fetch helper is extracted rather than duplicated (AGENTS.md: don't duplicate
+HTTP helpers).
+
+**Lifecycle:** `append` → NZBID → poll `listgroups` until the NZBID leaves the
+queue → poll `history` until the NZBID shows a terminal status → on `SUCCESS`
+take `DestDir`. Failure/warning aborts with a notification.
+
+### 3. Resolver branch & progress (`nzbget_resolver.py`)
+
+`resolve_and_play_nzbget(handle, params, ...)` honors the same
+**`setResolvedUrl`-on-failure contract**: exactly one `setResolvedUrl(handle,
+True/False, li)` per exit, whole body wrapped so any unexpected raise still
+resolves `False` (AGENTS.md invariant).
+
+Flow:
+
+1. Read NZBGet + SMB settings; missing/blank → notify + resolve `False`.
+2. Fetch NZB bytes from `params["nzburl"]`, base64-encode, `append`.
+   NZBID ≤ 0 → notify + resolve `False`.
+3. Open `DialogProgress` with cancel. Poll loop built on
+   `xbmc.Monitor.waitForAbort(interval)` — never `time.sleep` (AGENTS.md
+   invariant) — so Kodi shuts down cleanly. Reuse backend-agnostic
+   clamp/poll-interval helpers.
+4. Each tick: `listgroups` for the NZBID → show `Downloading NN%` from
+   `DownloadedSizeMB/FileSizeMB`; once gone from `listgroups`, switch to
+   `history` → show `Post-processing…` / `Repairing…` from history `Status`.
+5. Terminal `SUCCESS` → resolve file over SMB (component 4). Terminal failure,
+   user-cancel, or timeout → notify + resolve `False`.
+
+### 4. SMB file resolution
+
+A small **pure, Kodi-VFS-agnostic path-mapping function** (separately unit
+tested):
+
+1. Derive the per-release subfolder from NZBGet's `DestDir` (primarily the final
+   path component; `MainDir`/`DestDir` config is available via the API to
+   compute the relative portion precisely if needed).
+2. Join `nzbget_smb_root` + subfolder → `smb://…/<release-folder>/`.
+3. `xbmcvfs.listdir(...)` and pick the **largest video file**, reusing the
+   video-extension / biggest-file selection logic from `webdav.find_video_file`
+   (shared VFS-agnostic part extracted, not duplicated).
+4. Build a `ListItem` at `smb://…/file.mkv` and `setResolvedUrl(handle, True,
+   li)`. **Kodi plays SMB natively — no stream proxy / WebDAV on this path.**
+
+Edge cases: folder not yet visible over SMB → brief `waitForAbort` retry to
+absorb write-visibility lag; no video file → notify + resolve `False`;
+multiple video files → largest wins.
+
+### 5. Error handling, cancel, test actions
+
+Every path ends in exactly one `setResolvedUrl` (success `True` / failure
+`False`):
+
+| Condition | Action |
+|-----------|--------|
+| Config missing/blank | notify "NZBGet not configured", resolve `False` |
+| NZB fetch fails | notify, resolve `False` |
+| `append` rejected (NZBID ≤ 0, auth, dupe) | surface redacted NZBGet message, resolve `False` |
+| Job fails in NZBGet (`FAILURE/*`, unusable `WARNING/*`) | notify "Download failed in NZBGet", resolve `False` |
+| Timeout (clamped `download_timeout`, same as nzbdav) | notify, resolve `False`, **leave job running** |
+| User cancels `DialogProgress` | `editqueue`/`GroupDelete` job **+ files**, resolve `False` |
+| SMB unreachable / no video file | notify, resolve `False` |
+
+All NZBGet errors go through existing redacting log/notify helpers
+(`http_util`); Basic-auth creds and the SMB password in the URL are redacted in
+logs — same discipline as existing WebDAV/apikey redaction.
+
+**Test actions** (router handlers + settings buttons, mirroring `test_nzbdav` /
+`test_webdav`):
+
+- `test_nzbget` → `version` + `status`; notify OK / specific failure.
+- `test_nzbget_smb` → `xbmcvfs.listdir(nzbget_smb_root)`; notify reachable /
+  failure.
+
+## Testing
+
+Follows the repo pytest + Kodi-mock pattern (`tests/conftest.py` pre-mocks
+`xbmc*`):
+
+- `tests/test_nzbget_api.py` — `append` payload shape (base64 content, category,
+  NZBID parsing), `listgroups`/`history` status parsing, `(value, error)`
+  contract, auth header, redacted logging. HTTP layer mocked.
+- `tests/test_nzbget_smb_path.py` — pure path-mapping function across
+  trailing-slash / category / nested-folder variants. No Kodi.
+- `tests/test_nzbget_resolver.py` — orchestration with mocked api +
+  `xbmcvfs`/`DialogProgress`/`Monitor`: each failure branch resolves `False`
+  exactly once; success resolves `True` with the right `smb://` URL; cancel
+  triggers `GroupDelete`; timeout leaves the job; status transitions drive
+  progress text; largest-video-file selection.
+- `tests/test_router.py` additions — `nzbget_enabled` routes to the NZBGet
+  resolver; `test_nzbget` / `test_nzbget_smb` handlers wired.
+
+Constraints: `just lint` + `just test` green; runtime code stays **Python
+3.8-pure** (no walrus / `match` / `removeprefix`); no new compiled deps.
+
+## Difficulty estimate
+
+**Moderate — roughly 2–4 days, low-to-medium risk.**
+
+- *Easy:* settings tab, test actions, resolver entry branch, SMB path-mapping
+  function (mirror existing patterns).
+- *Moderate:* JSON-RPC client + poll/progress loop — needs careful status
+  state machine (queue → post-processing → history) and real-NZBGet
+  verification.
+- *Highest-uncertainty:* SMB path translation + write-visibility timing, and
+  NZBGet `DestDir`/category folder-layout edge cases. Field-test on the real
+  NZBGet + SMB setup.
+
+Big de-risker: Approach A isolation — none of this touches nzbdav streaming,
+fallback, or WebDAV code, so the existing playback path can't regress.
+
+## Out of scope (YAGNI)
+
+- Per-play backend override / picker context menu (global toggle only).
+- nzbdav-style partial streaming from NZBGet (NZBGet writes whole files).
+- Playing before post-processing completes.
+- Path-prefix substitution / name-based folder guessing (SMB root = completed
+  dir, trailing subfolder appended).
+- Separate SMB user/pass fields (credentials embedded in the URL).

--- a/repo/plugin.video.nzbdav/addon.xml
+++ b/repo/plugin.video.nzbdav/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.nzbdav"
        name="NZB-DAV"
-       version="1.2.4"
+       version="1.2.5"
        provider-name="nzbdav">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -22,7 +22,7 @@
         <license>GPL-3.0-or-later</license>
         <source>https://github.com/Appz4Fun/nzbdavkodi</source>
         <website>https://appz4fun.github.io/nzbdavkodi/</website>
-        <news>v1.2.4: Fix startup black-screen; harden live fallback cutover.</news>
+        <news>v1.2.5: Fallback backups now require the same release group; defer backup submission until ~2 min into playback; fix pass-through startup stall (first-byte retry ladder) on very large files.</news>
         <assets>
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>

--- a/repo/plugin.video.nzbdav/addon.xml
+++ b/repo/plugin.video.nzbdav/addon.xml
@@ -22,7 +22,7 @@
         <license>GPL-3.0-or-later</license>
         <source>https://github.com/Appz4Fun/nzbdavkodi</source>
         <website>https://appz4fun.github.io/nzbdavkodi/</website>
-        <news>v1.2.5: Fallback backups now require the same release group; defer backup submission until ~2 min into playback; fix pass-through startup stall (first-byte retry ladder) on very large files.</news>
+        <news>v1.2.5: Same-group fallback backups, deferred submission, startup-stall fix.</news>
         <assets>
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>

--- a/repo/plugin.video.nzbdav/changelog.txt
+++ b/repo/plugin.video.nzbdav/changelog.txt
@@ -1,2 +1,1 @@
-v1.2.5: Fallback backups now require the same release group (no cross-group encodes); defer backup submission until ~2 min into playback (anchored to playback start); fix pass-through startup stall on very large files (first-byte retry ladder kept short after the byte-0 prefetch prefix).
-v1.2.4: Fix startup black-screen; harden live fallback cutover and queue clear.
+v1.2.5: Same-group fallback backups, deferred submission, startup-stall fix.

--- a/repo/plugin.video.nzbdav/changelog.txt
+++ b/repo/plugin.video.nzbdav/changelog.txt
@@ -1,1 +1,2 @@
+v1.2.5: Fallback backups now require the same release group (no cross-group encodes); defer backup submission until ~2 min into playback (anchored to playback start); fix pass-through startup stall on very large files (first-byte retry ladder kept short after the byte-0 prefetch prefix).
 v1.2.4: Fix startup black-screen; harden live fallback cutover and queue clear.

--- a/repo/plugin.video.nzbdav/resources/language/resource.language.en_gb/strings.po
+++ b/repo/plugin.video.nzbdav/resources/language/resource.language.en_gb/strings.po
@@ -785,3 +785,7 @@ msgstr "Clear the queue before starting this download?"
 msgctxt "#30205"
 msgid "Seconds into playback before submitting fallback backups"
 msgstr "Seconds into playback before submitting fallback backups"
+
+msgctxt "#30206"
+msgid "Max seconds to wait for a slow/stalled backend before giving up (0=off)"
+msgstr "Max seconds to wait for a slow/stalled backend before giving up (0=off)"

--- a/repo/plugin.video.nzbdav/resources/language/resource.language.en_gb/strings.po
+++ b/repo/plugin.video.nzbdav/resources/language/resource.language.en_gb/strings.po
@@ -789,3 +789,7 @@ msgstr "Seconds into playback before submitting fallback backups"
 msgctxt "#30206"
 msgid "Max seconds to wait for a slow/stalled backend before giving up (0=off)"
 msgstr "Max seconds to wait for a slow/stalled backend before giving up (0=off)"
+
+msgctxt "#30207"
+msgid "Read-ahead buffer size in MB (keeps filling while paused; 0=off)"
+msgstr "Read-ahead buffer size in MB (keeps filling while paused; 0=off)"

--- a/repo/plugin.video.nzbdav/resources/language/resource.language.en_gb/strings.po
+++ b/repo/plugin.video.nzbdav/resources/language/resource.language.en_gb/strings.po
@@ -781,3 +781,7 @@ msgstr "The download queue has {} item(s):"
 msgctxt "#30204"
 msgid "Clear the queue before starting this download?"
 msgstr "Clear the queue before starting this download?"
+
+msgctxt "#30205"
+msgid "Seconds into playback before submitting fallback backups"
+msgstr "Seconds into playback before submitting fallback backups"

--- a/repo/plugin.video.nzbdav/resources/lib/dead_candidates.py
+++ b/repo/plugin.video.nzbdav/resources/lib/dead_candidates.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Per-session tracking of provably-dead fallback candidates.
+
+A "dead" candidate is a Usenet release that has failed in a way re-trying
+cannot fix: its first article is missing, the NNTP server rejected it, or its
+nzbdav job reached a terminal Failed/Deleted state. Such a release must never
+be (re-)admitted to the fallback pool for the rest of the playback session.
+
+A *timeout* is deliberately NOT dead: on a slow nzbdav backend a timeout often
+means load, not a missing post, so a timed-out candidate stays eligible.
+
+Keyed primarily by ``nzb_url`` (the indexer ``link``) because that is the only
+identifier stable across both the picker's primary attempt and the fallback
+worker -- ``job_name`` embeds a per-position index and an nzb_url digest, and
+``nzo_id`` changes on every resubmit. ``nzo_id`` is tracked additionally so the
+live push path (which knows only ``nzo_id``) can drop an adopted standby.
+"""
+
+
+class DeadCandidates:
+    """A small per-session set of dead candidate identities."""
+
+    def __init__(self):
+        self._urls = set()
+        self._nzo_ids = set()
+
+    def add(self, nzb_url=None, nzo_id=None):
+        """Record a dead candidate by nzb_url and/or nzo_id (empties ignored)."""
+        if nzb_url:
+            self._urls.add(nzb_url)
+        if nzo_id:
+            self._nzo_ids.add(nzo_id)
+
+    def has_url(self, nzb_url):
+        return bool(nzb_url) and nzb_url in self._urls
+
+    def has_nzo(self, nzo_id):
+        return bool(nzo_id) and nzo_id in self._nzo_ids
+
+
+def is_provably_dead_submit_error(submit_error):
+    """Return True when a ``submit_nzb`` error means the post is dead.
+
+    ``submit_nzb`` returns ``(None, {"status": <int|str>, "message": str})`` on
+    failure. Any status other than ``"timeout"`` is treated as provably dead
+    (HTTP 5xx, ``"rejected"``, or an unknown status -- conservatively dead so we
+    do not loop on a doomed candidate). A bare ``None`` (or any non-dict) is not
+    a classified submit error, so it is not provably dead.
+    """
+    if not isinstance(submit_error, dict):
+        return False
+    return submit_error.get("status") != "timeout"

--- a/repo/plugin.video.nzbdav/resources/lib/dead_candidates.py
+++ b/repo/plugin.video.nzbdav/resources/lib/dead_candidates.py
@@ -40,15 +40,27 @@ class DeadCandidates:
         return bool(nzo_id) and nzo_id in self._nzo_ids
 
 
+# Statuses the primary submit path (resolver.py) retries, so a single such
+# failure is a transient backend hiccup, not proof the post is dead. Kept as a
+# local constant to avoid a circular import (resolver imports this module).
+_TRANSIENT_HTTP_STATUSES = (408, 502, 503, 504)
+
+
 def is_provably_dead_submit_error(submit_error):
     """Return True when a ``submit_nzb`` error means the post is dead.
 
     ``submit_nzb`` returns ``(None, {"status": <int|str>, "message": str})`` on
-    failure. Any status other than ``"timeout"`` is treated as provably dead
-    (HTTP 5xx, ``"rejected"``, or an unknown status -- conservatively dead so we
-    do not loop on a doomed candidate). A bare ``None`` (or any non-dict) is not
-    a classified submit error, so it is not provably dead.
+    failure. A ``"timeout"`` status and the transient HTTP statuses the primary
+    submit path retries (``408/502/503/504``) are NOT provably dead -- they
+    signal a slow or hiccuping backend, so the candidate stays eligible. Any
+    other status (HTTP 5xx like ``500``, ``"rejected"``, or an unknown status)
+    is treated as provably dead -- conservatively dead so we do not loop on a
+    doomed candidate. A bare ``None`` (or any non-dict) is not a classified
+    submit error, so it is not provably dead.
     """
     if not isinstance(submit_error, dict):
         return False
-    return submit_error.get("status") != "timeout"
+    status = submit_error.get("status")
+    if status == "timeout" or status in _TRANSIENT_HTTP_STATUSES:
+        return False
+    return True

--- a/repo/plugin.video.nzbdav/resources/lib/download_ledger.py
+++ b/repo/plugin.video.nzbdav/resources/lib/download_ledger.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Persistent record of the Usenet post-dates of NZBs we have downloaded.
+
+nzbdav history is keyed by NAME and stores only the *download-completion*
+timestamp, never the release's Usenet post date. So a same-name, same-size
+repost is indistinguishable from the file we actually fetched using history
+alone, and the picker's "DL"/cached-stream tag would land on both.
+
+We capture the selected result's ``pubdate`` at submit time here and consult
+it from ``router._tag_available`` so the tag stays on the release we really
+downloaded (or another we also downloaded), not on a look-alike repost posted
+on a different day. The stored value is the absolute UTC epoch (see
+``http_util.pubdate_to_epoch``) rather than the drifting human "age" label.
+
+Fails soft throughout: any read/parse/write error degrades to "no record",
+which makes the picker fall back to its prior name+size behavior rather than
+hide a real cache hit.
+"""
+
+import json
+import os
+
+import xbmc
+import xbmcvfs
+
+from resources.lib.http_util import pubdate_to_epoch
+
+# Resolve the profile dir via the special:// path rather than
+# ``xbmcaddon.Addon().getAddonInfo("profile")``: the file-path RunScript
+# context must never touch ``xbmcaddon.Addon`` (it can crash CoreELEC inside
+# the profile lookup), and ``translatePath`` of a special:// path needs no
+# Addon handle. Both forms resolve to the same addon_data directory.
+_PROFILE_SPECIAL_PATH = "special://profile/addon_data/plugin.video.nzbdav"
+_LEDGER_FILENAME = "download_pubdates.json"
+# Bound growth: most names get one or two entries; a pathological case
+# (a generic filename re-uploaded constantly) is capped so the file and
+# the per-lookup scan stay small. Oldest entries are dropped first.
+_MAX_NAMES = 500
+_MAX_EPOCHS_PER_NAME = 20
+
+
+def _ledger_dir():
+    profile = xbmcvfs.translatePath(_PROFILE_SPECIAL_PATH)
+    os.makedirs(profile, exist_ok=True)
+    return profile
+
+
+def _ledger_path():
+    return os.path.join(_ledger_dir(), _LEDGER_FILENAME)
+
+
+def _load():
+    """Return the ledger dict, or an empty dict on any read/parse error."""
+    try:
+        with open(_ledger_path(), "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _save(data):
+    try:
+        with open(_ledger_path(), "w", encoding="utf-8") as handle:
+            json.dump(data, handle)
+    except OSError as error:
+        xbmc.log(
+            "NZB-DAV: Could not persist download ledger: {}".format(error),
+            xbmc.LOGWARNING,
+        )
+
+
+def _coerce_epoch_list(value):
+    """Return value as a list of int epochs, dropping anything non-numeric."""
+    if not isinstance(value, list):
+        return []
+    epochs = []
+    for item in value:
+        try:
+            epochs.append(int(item))
+        except (TypeError, ValueError):
+            continue
+    return epochs
+
+
+def record_download(name, pubdate, size=None):
+    """Record that the NZB ``name`` posted at ``pubdate`` was downloaded.
+
+    ``size`` is accepted for call-site symmetry with the picker's size
+    gate but is not currently stored — the post-date alone disambiguates
+    same-name reposts, and size is already gated separately against the
+    completed job's bytes. No-op when ``name`` is empty or ``pubdate``
+    cannot be parsed (we simply have nothing to disambiguate by).
+    """
+    del size  # reserved for future use; see docstring
+    if not name:
+        return
+    epoch = pubdate_to_epoch(pubdate)
+    if epoch is None:
+        return
+    try:
+        data = _load()
+        existing = _coerce_epoch_list(data.get(name))
+        if epoch in existing:
+            return
+        existing.append(epoch)
+        if len(existing) > _MAX_EPOCHS_PER_NAME:
+            existing = existing[-_MAX_EPOCHS_PER_NAME:]
+        data[name] = existing
+        if len(data) > _MAX_NAMES:
+            # Drop arbitrary oldest-inserted names; dict preserves insertion
+            # order, so slicing the tail keeps the most recently touched.
+            data = dict(list(data.items())[-_MAX_NAMES:])
+        _save(data)
+    except Exception as error:  # pylint: disable=broad-except
+        # Best-effort bookkeeping must never break a download. Any storage
+        # surprise (unwritable profile, odd path) degrades to "not recorded".
+        xbmc.log(
+            "NZB-DAV: download-ledger record skipped: {}".format(error),
+            xbmc.LOGDEBUG,
+        )
+
+
+def downloaded_pubdate_epochs(name):
+    """Return the recorded pubdate epochs (ints) for ``name``, or ``[]``.
+
+    Fails soft to ``[]`` on any error so the picker's pubdate gate degrades
+    to its prior name+size behavior rather than raising into the lookup.
+    """
+    if not name:
+        return []
+    try:
+        return _coerce_epoch_list(_load().get(name))
+    except Exception as error:  # pylint: disable=broad-except
+        xbmc.log(
+            "NZB-DAV: download-ledger read failed: {}".format(error),
+            xbmc.LOGDEBUG,
+        )
+        return []

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -1240,6 +1240,16 @@ def _metadata_profiles_match(
         right_group = _meta_value_from_meta(candidate_meta, "group")
         if not left_group or left_group != right_group:
             return False
+        # require same RESOLUTION too (user requirement): fail CLOSED like the
+        # group gate -- reject when either side's resolution is unparsed or
+        # differs, so an unparsed-resolution candidate can never slip a
+        # different-resolution encode past the gate. The shared resolution
+        # check below only fails OPEN when one side is unknown, so this stricter
+        # gate is what enforces "same resolution as parsed by PTT".
+        left_res = _meta_value_from_meta(primary_meta, "resolution")
+        right_res = _meta_value_from_meta(candidate_meta, "resolution")
+        if not left_res or left_res != right_res:
+            return False
     for key in ("resolution", "codec", "container"):
         left = _meta_value_from_meta(primary_meta, key)
         right = _meta_value_from_meta(candidate_meta, key)
@@ -1346,6 +1356,21 @@ def _manifest_group_bytes(result):
         return int(manifest.get("group_bytes", 0) or 0)
     except (TypeError, ValueError):
         return 0
+
+
+def _manifest_normalized_video_name(result):
+    """Return the candidate's normalized video filename from its manifest, else "".
+
+    Used to PREFER an exact-same-filename repost (a different upload of the
+    byte-identical file, already de-duplicated from the primary by article
+    digest) ahead of the looser tier/size ranking, per the user requirement to
+    try exact-filename matches first.
+    """
+    manifest = result.get("_fallback_manifest") if isinstance(result, dict) else None
+    if not isinstance(manifest, dict):
+        return ""
+    name = manifest.get("normalized_video_name", "")
+    return name.strip().lower() if isinstance(name, str) else ""
 
 
 def _fallback_peer_matches(primary, candidate):
@@ -1654,6 +1679,7 @@ def _attach_candidates_for_target(target, pool, max_candidates):
     target_digest = _article_digest(target)
     seen_article_digests = {target_digest} if target_digest else set()
     target_size = _release_size_bytes(target)
+    target_name = _manifest_normalized_video_name(target)
     for candidate in pool:
         if candidate is target:
             continue
@@ -1671,14 +1697,17 @@ def _attach_candidates_for_target(target, pool, max_candidates):
             continue
         candidate_size = _release_size_bytes(candidate)
         size_delta = abs(target_size - candidate_size) if target_size else 0
-        matched.append((tier, size_delta, candidate))
+        candidate_name = _manifest_normalized_video_name(candidate)
+        exact_name = 0 if target_name and candidate_name == target_name else 1
+        matched.append((exact_name, tier, size_delta, candidate))
         seen_links.add(candidate_link)
         if candidate_digest:
             seen_article_digests.add(candidate_digest)
-    # Tiered ranking: most-similar first (lower tier), then smallest size delta.
-    # Sort is stable so equal (tier, delta) keeps pool order.
-    matched.sort(key=lambda item: (item[0], item[1]))
-    target["_fallback_candidates"] = [item[2] for item in matched[:max_candidates]]
+    # Exact-same-filename first (0 before 1), then tiered ranking: most-similar
+    # first (lower tier), then smallest size delta. Sort is stable so equal keys
+    # keep pool order.
+    matched.sort(key=lambda item: (item[0], item[1], item[2]))
+    target["_fallback_candidates"] = [item[3] for item in matched[:max_candidates]]
 
 
 def _attach_manifest_candidate_if_matching(
@@ -2112,11 +2141,13 @@ def attach_fallback_candidates_for_selection(selected, results, fallback_setting
 def _rank_fallback_candidates(target, candidates):
     """Return candidates ordered best-first by fallback tier, then size delta.
 
-    Tiered ranking (lower tier = tried first) so the most-similar release is
-    submitted before a looser same-content peer. Sort is stable, preserving the
-    original arrival order within a (tier, size-delta) bucket.
+    An exact-same-filename repost (a different upload of the byte-identical
+    file) is preferred first; then tiered ranking (lower tier = tried first) so
+    the most-similar release is submitted before a looser same-content peer.
+    Sort is stable, preserving original arrival order within a bucket.
     """
     target_size = _release_size_bytes(target)
+    target_name = _manifest_normalized_video_name(target)
     ranked = []
     for candidate in candidates:
         tier = _release_similarity(target, candidate)
@@ -2126,9 +2157,11 @@ def _rank_fallback_candidates(target, candidates):
             tier = 3
         candidate_size = _release_size_bytes(candidate)
         size_delta = abs(target_size - candidate_size) if target_size else 0
-        ranked.append((tier, size_delta, candidate))
-    ranked.sort(key=lambda item: (item[0], item[1]))
-    return [item[2] for item in ranked]
+        candidate_name = _manifest_normalized_video_name(candidate)
+        exact_name = 0 if target_name and candidate_name == target_name else 1
+        ranked.append((exact_name, tier, size_delta, candidate))
+    ranked.sort(key=lambda item: (item[0], item[1], item[2]))
+    return [item[3] for item in ranked]
 
 
 def build_fallback_job_name(title, nzb_url, index):

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -731,6 +731,13 @@ def _same_content(primary, candidate):
             return False
         if bool(primary_seasons) != bool(candidate_seasons):
             return False
+        # A differing parsed year marks a distinct production sharing the same
+        # SxxExx (a reboot/remake, e.g. "Doctor Who 2005 S01E01" vs the 2023
+        # reboot). Mirror the movie-path year reject. Only rejects when BOTH
+        # sides parsed a year and they differ, so same-episode reposts where one
+        # side omits the year are unaffected.
+        if primary_year and candidate_year and primary_year != candidate_year:
+            return False
         return True
 
     if bool(primary_part) != bool(candidate_part):

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -1165,6 +1165,7 @@ def first_prefetchable_fallback_peer(
                 result,
                 primary_meta=selected_meta,
                 candidate_meta=candidate_meta,
+                require_same_group=True,
             ):
                 continue
             if selected_tokens is None:
@@ -1190,6 +1191,7 @@ def first_prefetchable_fallback_peer(
                 result,
                 primary_meta=selected_meta,
                 candidate_meta=candidate_meta,
+                require_same_group=True,
             ) and _same_content(selected, result):
                 _remember_prefetch_gate_match(
                     selected, result, selected_meta, candidate_meta
@@ -1200,7 +1202,7 @@ def first_prefetchable_fallback_peer(
             selected_meta = _result_meta(selected)
             selected_meta_ready = True
         if _metadata_profiles_match(
-            selected, result, primary_meta=selected_meta
+            selected, result, primary_meta=selected_meta, require_same_group=True
         ) and _same_content(selected, result):
             candidate_meta = result.get("_meta")
             if not isinstance(candidate_meta, dict):
@@ -1213,19 +1215,31 @@ def first_prefetchable_fallback_peer(
 
 
 def _metadata_profiles_match(
-    primary, candidate, primary_meta=None, candidate_meta=None
+    primary, candidate, primary_meta=None, candidate_meta=None, require_same_group=False
 ):
     """Return whether two releases are plausible same-file fallback peers.
 
     This is intentionally looser than manifest equality. The stream proxy still
     verifies content length and sampled byte fingerprints before switching to a
     fallback source, so this stage should gather plausible peers instead of
-    rejecting reposts because their NZB subject used a different filename/group.
+    rejecting reposts because their NZB subject used a different filename.
+
+    ``require_same_group`` adds the user-requested same-release-group gate: a
+    backup must come from the SAME group as the primary, because a different
+    group's encode is a different file that can never byte-match for a seamless
+    cutover. Both groups must be parsed and equal (fail closed on an unknown
+    group). The check reuses the metadata already computed here, so it adds no
+    extra title-metadata parses and runs only after the cheap title prefilter.
     """
     if primary_meta is None:
         primary_meta = _result_meta(primary)
     if candidate_meta is None:
         candidate_meta = _result_meta(candidate)
+    if require_same_group:
+        left_group = _meta_value_from_meta(primary_meta, "group")
+        right_group = _meta_value_from_meta(candidate_meta, "group")
+        if not left_group or left_group != right_group:
+            return False
     for key in ("resolution", "codec", "container"):
         left = _meta_value_from_meta(primary_meta, key)
         right = _meta_value_from_meta(candidate_meta, key)
@@ -1355,7 +1369,11 @@ def _fallback_peer_matches(primary, candidate):
         if not _titles_look_related(primary, candidate):
             return False
 
-        if not _metadata_profiles_match(primary, candidate):
+        # require_same_group: a backup must come from the SAME release group as
+        # the primary (user requirement) -- a different group's encode is a
+        # different file that can never byte-match for a seamless cutover. When
+        # the prefetch gate already matched, the group was validated there.
+        if not _metadata_profiles_match(primary, candidate, require_same_group=True):
             return False
 
     return _fallback_manifest_peer_matches(primary, candidate)
@@ -1933,12 +1951,20 @@ def _prefetch_candidate_matches(
         if not _title_token_sets_look_related(target_tokens, _title_tokens(candidate)):
             return False
         if not _metadata_profiles_match(
-            target, candidate, primary_meta=target_meta, candidate_meta=candidate_meta
+            target,
+            candidate,
+            primary_meta=target_meta,
+            candidate_meta=candidate_meta,
+            require_same_group=True,
         ):
             return False
         return _same_content(target, candidate)
     if not _metadata_profiles_match(
-        target, candidate, primary_meta=target_meta, candidate_meta=candidate_meta
+        target,
+        candidate,
+        primary_meta=target_meta,
+        candidate_meta=candidate_meta,
+        require_same_group=True,
     ):
         return False
     if target_tokens is None:

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -401,6 +401,312 @@ def _normalize_title(value):
     return " ".join(normalized.split())
 
 
+# Ordinal words PTT keeps inside a movie title (e.g. "Dune Part Two",
+# "John Wick Chapter 4"). A movie's part/chapter number is a content
+# discriminator, not an encode attribute, so the content-identity gate
+# must treat "Part Two" and "Part One" as different content.
+_PART_ORDINAL_WORDS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "i": 1,
+    "ii": 2,
+    "iii": 3,
+    "iv": 4,
+    "v": 5,
+    "vi": 6,
+    "vii": 7,
+    "viii": 8,
+    "ix": 9,
+    "x": 10,
+}
+_PART_LABEL_RE = re.compile(
+    r"\b(?:part|chapter|vol(?:ume)?|book)\b[\s._-]*([0-9]{1,3}|[ivx]{1,4}|"
+    r"one|two|three|four|five|six|seven|eight|nine|ten)\b",
+    re.IGNORECASE,
+)
+_RELEASE_IDENTITY_CACHE_TITLE_KEY = "_fallback_identity_title"  # nosec B105
+_RELEASE_IDENTITY_CACHE_VALUE_KEY = "_fallback_identity"  # nosec B105
+
+
+def _part_number_from_title(title):
+    """Return the part/chapter/volume number embedded in a title, or 0."""
+    if not isinstance(title, str) or not title:
+        return 0
+    match = _PART_LABEL_RE.search(title)
+    if not match:
+        return 0
+    token = match.group(1).strip().lower()
+    if token.isdigit():
+        try:
+            return int(token)
+        except ValueError:
+            return 0
+    return _PART_ORDINAL_WORDS.get(token, 0)
+
+
+def _release_identity(result):
+    """Return PTT-derived content identity for a release.
+
+    Returns a tuple ``(title, year, seasons, episodes, part)`` where
+    ``title`` is the normalized PTT show/movie title, ``year`` is the
+    parsed year (0 when absent), ``seasons``/``episodes`` are sorted
+    tuples, and ``part`` is a part/chapter/volume number (0 when absent).
+    This is the authoritative content fingerprint used by the fallback
+    content-identity gate. Falls back to the normalized raw title when
+    PTT cannot parse.
+    """
+    if not isinstance(result, dict):
+        raw = result if isinstance(result, str) else ""
+        return (_normalize_title(raw), 0, (), (), 0)
+    title = result.get("title", "")
+    cached = result.get(_RELEASE_IDENTITY_CACHE_VALUE_KEY)
+    if result.get(_RELEASE_IDENTITY_CACHE_TITLE_KEY) == title and isinstance(
+        cached, tuple
+    ):
+        return cached
+    parsed = {}
+    try:
+        from resources.lib.ptt import parse_title
+
+        parsed = parse_title(title) or {}
+    except Exception:  # pylint: disable=broad-except
+        parsed = {}
+    parsed_title = parsed.get("title") if isinstance(parsed, dict) else ""
+    norm_title = _normalize_title(parsed_title or title)
+    try:
+        year = int(parsed.get("year") or 0)
+    except (TypeError, ValueError):
+        year = 0
+
+    def _int_tuple(values):
+        if isinstance(values, (int, str)):
+            values = [values]
+        if not isinstance(values, (list, tuple)):
+            return ()
+        out = []
+        for value in values:
+            try:
+                out.append(int(value))
+            except (TypeError, ValueError):
+                continue
+        return tuple(sorted(set(out)))
+
+    seasons = _int_tuple(parsed.get("seasons"))
+    episodes = _int_tuple(parsed.get("episodes"))
+    part = _part_number_from_title(title)
+    identity = (norm_title, year, seasons, episodes, part)
+    if isinstance(result, dict):
+        result[_RELEASE_IDENTITY_CACHE_TITLE_KEY] = title
+        result[_RELEASE_IDENTITY_CACHE_VALUE_KEY] = identity
+    return identity
+
+
+def _titles_core_related(primary_title, candidate_title, corroborated=False):
+    """Return whether two normalized core titles plausibly name the same work.
+
+    Reposts often differ only by a junk suffix (e.g. "Movie" vs "Movie
+    mirror"), so a single trailing extra token on one side is treated as noise
+    and accepted. A multi-token extra tail looks like a distinguishing subtitle
+    (e.g. "Avatar" vs "Avatar The Way Of Water") and is rejected unless
+    ``corroborated`` positive identity (matching year/episode) backs it up. An
+    empty token set on either side fails closed unless corroborated.
+    """
+    left_tokens = primary_title.split()
+    right_tokens = candidate_title.split()
+    left = frozenset(left_tokens)
+    right = frozenset(right_tokens)
+    if not left or not right:
+        # Fail closed on a missing core title unless positive identity agrees.
+        return corroborated
+    if left == right:
+        return True
+    if left <= right or right <= left:
+        if corroborated:
+            return True
+        # Accept only a junk-SUFFIX repost: the longer title's extra tokens are
+        # a single trailing noise token. More than one extra token, or extra
+        # tokens that are not a trailing tail, look like a distinguishing
+        # subtitle and are rejected without corroboration.
+        if left <= right:
+            shorter, longer = left_tokens, right_tokens
+        else:
+            shorter, longer = right_tokens, left_tokens
+        prefix_match = longer[: len(shorter)] == shorter
+        extra = len(longer) - len(shorter)
+        if prefix_match and extra <= 1:
+            return True
+        return False
+    return _title_token_sets_look_related(left, right)
+
+
+def _content_discriminators_match(primary, candidate):
+    """Return whether two same-titled releases are the same *cut* of the work.
+
+    Edition (Theatrical vs Extended/Director's) and PROPER/REPACK status are
+    content discriminators: a Theatrical encode is not a valid fallback for an
+    Extended encode even though title/year match. Resolution, codec, group,
+    HDR, and audio are deliberately *not* checked here — those only affect the
+    fallback tier, not whether the candidate is the same content.
+    """
+    primary_meta = _result_meta(primary)
+    candidate_meta = _result_meta(candidate)
+    left_edition = _normalize_title(_meta_value_from_meta(primary_meta, "edition"))
+    right_edition = _normalize_title(_meta_value_from_meta(candidate_meta, "edition"))
+    if left_edition != right_edition:
+        return False
+    for key in ("proper", "repack", "upscaled"):
+        if _meta_bool_from_meta(primary_meta, key) != _meta_bool_from_meta(
+            candidate_meta, key
+        ):
+            return False
+    return True
+
+
+def _same_content(primary, candidate):
+    """Return whether two releases are the SAME content (content-identity gate).
+
+    Movies: same core title and same year (when both parsed a year).
+    Episodes: same show title, season, and episode set.
+    Any parsed part/chapter/volume number must match. Edition and
+    PROPER/REPACK status (the same-cut discriminators) must also match. This
+    is the authoritative hard gate that prevents falling back to a different
+    release (different movie part, year, episode, edition, etc.).
+    """
+    if not _content_discriminators_match(primary, candidate):
+        return False
+    (
+        primary_title,
+        primary_year,
+        primary_seasons,
+        primary_episodes,
+        primary_part,
+    ) = _release_identity(primary)
+    (
+        candidate_title,
+        candidate_year,
+        candidate_seasons,
+        candidate_episodes,
+        candidate_part,
+    ) = _release_identity(candidate)
+
+    # Corroborating positive identity rescues otherwise-ambiguous title
+    # relations: a matching parsed year, or a matching season+episode set.
+    corroborated = bool(
+        (primary_year and candidate_year and primary_year == candidate_year)
+        or (
+            primary_seasons
+            and candidate_seasons
+            and primary_episodes
+            and candidate_episodes
+            and primary_seasons == candidate_seasons
+            and primary_episodes == candidate_episodes
+        )
+    )
+
+    if not _titles_core_related(
+        primary_title, candidate_title, corroborated=corroborated
+    ):
+        return False
+
+    # Part/chapter number is a content discriminator (Part One vs Part Two).
+    if primary_part and candidate_part and primary_part != candidate_part:
+        return False
+    if bool(primary_part) != bool(candidate_part):
+        # PTT keeps the part word inside the title ("Dune Part Two"), so the
+        # core titles never compare equal to the bare original. One side naming
+        # an explicit part while the other names none is a sequel-vs-original
+        # mismatch (e.g. "Dune Part Two" vs "Dune"); treat it as different
+        # content. A differing explicit part is already rejected above.
+        return False
+
+    primary_is_episode = bool(primary_seasons or primary_episodes)
+    candidate_is_episode = bool(candidate_seasons or candidate_episodes)
+    if primary_is_episode or candidate_is_episode:
+        if (
+            primary_seasons
+            and candidate_seasons
+            and primary_seasons != candidate_seasons
+        ):
+            return False
+        if (
+            primary_episodes
+            and candidate_episodes
+            and primary_episodes != candidate_episodes
+        ):
+            return False
+        # An episode must not peer with a different episode that simply omitted
+        # its SxxExx tokens; require both to carry the same episode evidence.
+        if bool(primary_episodes) != bool(candidate_episodes):
+            return False
+        if bool(primary_seasons) != bool(candidate_seasons):
+            return False
+        return True
+
+    # Movies: a differing year is different content.
+    if primary_year and candidate_year and primary_year != candidate_year:
+        return False
+    return True
+
+
+def _release_similarity(primary, candidate):
+    """Return a fallback tier for ``candidate`` vs ``primary``, or None.
+
+    None means different content (hard reject). Otherwise:
+      0  same resolution + codec + group, size within ~3%
+      1  same resolution + codec, size within ~10%
+      2  same resolution, different codec
+      3  same content, anything else (last resort)
+    Lower tiers are tried first.
+    """
+    if not _same_content(primary, candidate):
+        return None
+    primary_res = _meta_value(primary, "resolution")
+    candidate_res = _meta_value(candidate, "resolution")
+    primary_codec = _meta_value(primary, "codec")
+    candidate_codec = _meta_value(candidate, "codec")
+    primary_group = _meta_value(primary, "group")
+    candidate_group = _meta_value(candidate, "group")
+
+    same_res = bool(primary_res) and primary_res == candidate_res
+    same_codec = bool(primary_codec) and primary_codec == candidate_codec
+    same_group = bool(primary_group) and primary_group == candidate_group
+
+    if same_res and same_codec:
+        if same_group and _release_size_within(
+            primary, candidate, _TIER0_SIZE_FRACTION
+        ):
+            return 0
+        return 1
+    if same_res:
+        return 2
+    return 3
+
+
+def _release_size_bytes(result):
+    """Return the best-known release size: manifest group bytes or indexer size."""
+    manifest_bytes = _manifest_group_bytes(result)
+    if manifest_bytes > 0:
+        return manifest_bytes
+    return _result_indexer_size(result)
+
+
+def _release_size_within(primary, candidate, fraction):
+    """Return whether two releases' known sizes are within ``fraction``."""
+    primary_size = _release_size_bytes(primary)
+    candidate_size = _release_size_bytes(candidate)
+    if primary_size <= 0 or candidate_size <= 0:
+        return True
+    return abs(primary_size - candidate_size) <= primary_size * fraction
+
+
 def _quality_key(result):
     """Return the conservative duplicate-grouping quality key for a result."""
     meta = _result_meta(result)
@@ -776,7 +1082,9 @@ def first_prefetchable_fallback_peer(
                 continue
             if selected_tokens is None:
                 selected_tokens = _title_tokens(selected)
-            if _title_token_sets_look_related(selected_tokens, _title_tokens(result)):
+            if _title_token_sets_look_related(
+                selected_tokens, _title_tokens(result)
+            ) and _same_content(selected, result):
                 _remember_prefetch_gate_match(
                     selected, result, selected_meta, candidate_meta
                 )
@@ -795,7 +1103,7 @@ def first_prefetchable_fallback_peer(
                 result,
                 primary_meta=selected_meta,
                 candidate_meta=candidate_meta,
-            ):
+            ) and _same_content(selected, result):
                 _remember_prefetch_gate_match(
                     selected, result, selected_meta, candidate_meta
                 )
@@ -804,7 +1112,9 @@ def first_prefetchable_fallback_peer(
         if not selected_meta_ready:
             selected_meta = _result_meta(selected)
             selected_meta_ready = True
-        if _metadata_profiles_match(selected, result, primary_meta=selected_meta):
+        if _metadata_profiles_match(
+            selected, result, primary_meta=selected_meta
+        ) and _same_content(selected, result):
             candidate_meta = result.get("_meta")
             if not isinstance(candidate_meta, dict):
                 candidate_meta = None
@@ -949,6 +1259,11 @@ def _fallback_peer_matches(primary, candidate):
     if primary_digest and candidate_digest and candidate_digest == primary_digest:
         return False
 
+    # Authoritative content-identity gate (F2): never fall back to a different
+    # movie part / year / episode / edition even when release tokens overlap.
+    if not _same_content(primary, candidate):
+        return False
+
     if not _has_prefetch_gate_match(primary, candidate):
         if not _titles_look_related(primary, candidate):
             return False
@@ -959,7 +1274,19 @@ def _fallback_peer_matches(primary, candidate):
     return _fallback_manifest_peer_matches(primary, candidate)
 
 
-_PEER_BYTES_TOLERANCE_FRACTION = 0.20
+# Per-tier size bands used for fallback ranking. The content-identity gate
+# (``_same_content``) is the authoritative reject; these bands only separate a
+# near-identical same-encode repost (Tier 0/1) from looser same-content peers.
+_TIER0_SIZE_FRACTION = 0.03
+# Manifest group-bytes tolerance for same-resolution + same-codec peers (the
+# Tier 1 band). The stream proxy still fingerprint-verifies byte identity
+# before cutover, so this only needs to be loose enough to absorb yEnc
+# segmentation noise across two uploads of the same encode while still
+# rejecting a wildly different file (different tracks/runtime).
+_PEER_BYTES_TOLERANCE_FRACTION = 0.10
+# Indexer-size prefilter band before fetching a manifest. Content identity is
+# enforced separately; this only avoids fetching manifests for releases whose
+# advertised size is implausibly far from the primary.
 _PREFETCH_INDEXER_SIZE_TOLERANCE_FRACTION = 0.25
 
 
@@ -1049,13 +1376,12 @@ def _fallback_manifest_peer_matches(primary, candidate):
     candidate_kind = _manifest_payload_kind(candidate)
     if not primary_kind or not candidate_kind:
         return False
-    # Apply the same +/-20% group_bytes tolerance whenever both kinds are
-    # plausible video payloads (direct MKV or RAR archive). Title and profile
-    # gates already proved the candidate is a related release; allow the
-    # configured tolerance band so yEnc segmentation noise across uploads
-    # does not block peers and so a direct-MKV upload can peer with a RAR
-    # upload of the same release. Reject pairs whose group_bytes gap exceeds
-    # the band (e.g., a Theatrical-UHD RAR vs. an Extended-UHD RAR).
+    # Both kinds are plausible video payloads (direct MKV or RAR archive). The
+    # content-identity gate (_same_content) and the same-resolution/codec
+    # profile gate already ran upstream, so two peers reaching here are the
+    # same content and the same encode; their group_bytes should differ only by
+    # yEnc segmentation noise. Tightened from the old +/-20% band to +/-10% so a
+    # large gap (different tracks/runtime) is rejected.
     if primary_kind in ("video", "archive") and candidate_kind in ("video", "archive"):
         primary_bytes = _manifest_group_bytes(primary)
         candidate_bytes = _manifest_group_bytes(candidate)
@@ -1218,10 +1544,11 @@ def _ensure_fallback_manifest(result, manifest_cache):
 
 
 def _attach_candidates_for_target(target, pool, max_candidates):
-    candidates = []
+    matched = []
     seen_links = {target.get("link", "")}
     target_digest = _article_digest(target)
     seen_article_digests = {target_digest} if target_digest else set()
+    target_size = _release_size_bytes(target)
     for candidate in pool:
         if candidate is target:
             continue
@@ -1234,13 +1561,19 @@ def _attach_candidates_for_target(target, pool, max_candidates):
             or not _fallback_peer_matches(target, candidate)
         ):
             continue
-        candidates.append(candidate)
+        tier = _release_similarity(target, candidate)
+        if tier is None:
+            continue
+        candidate_size = _release_size_bytes(candidate)
+        size_delta = abs(target_size - candidate_size) if target_size else 0
+        matched.append((tier, size_delta, candidate))
         seen_links.add(candidate_link)
         if candidate_digest:
             seen_article_digests.add(candidate_digest)
-        if len(candidates) >= max_candidates:
-            break
-    target["_fallback_candidates"] = candidates
+    # Tiered ranking: most-similar first (lower tier), then smallest size delta.
+    # Sort is stable so equal (tier, delta) keeps pool order.
+    matched.sort(key=lambda item: (item[0], item[1]))
+    target["_fallback_candidates"] = [item[2] for item in matched[:max_candidates]]
 
 
 def _attach_manifest_candidate_if_matching(
@@ -1512,9 +1845,11 @@ def _prefetch_candidate_matches(
     if target_tokens is not None and (not candidate_has_meta or target_meta is None):
         if not _title_token_sets_look_related(target_tokens, _title_tokens(candidate)):
             return False
-        return _metadata_profiles_match(
+        if not _metadata_profiles_match(
             target, candidate, primary_meta=target_meta, candidate_meta=candidate_meta
-        )
+        ):
+            return False
+        return _same_content(target, candidate)
     if not _metadata_profiles_match(
         target, candidate, primary_meta=target_meta, candidate_meta=candidate_meta
     ):
@@ -1527,7 +1862,8 @@ def _prefetch_candidate_matches(
         )
     if not titles_match:
         return False
-    return True
+    # Authoritative content-identity gate after the cheap profile/title checks.
+    return _same_content(target, candidate)
 
 
 def attach_fallback_candidates(results):
@@ -1656,8 +1992,30 @@ def attach_fallback_candidates_for_selection(selected, results, fallback_setting
         pool=_safe_len(results or []),
         selected_manifest_fetch=selected_manifest_fetch,
     )
-    selected["_fallback_candidates"] = candidates
+    selected["_fallback_candidates"] = _rank_fallback_candidates(selected, candidates)
     return selected
+
+
+def _rank_fallback_candidates(target, candidates):
+    """Return candidates ordered best-first by fallback tier, then size delta.
+
+    Tiered ranking (lower tier = tried first) so the most-similar release is
+    submitted before a looser same-content peer. Sort is stable, preserving the
+    original arrival order within a (tier, size-delta) bucket.
+    """
+    target_size = _release_size_bytes(target)
+    ranked = []
+    for candidate in candidates:
+        tier = _release_similarity(target, candidate)
+        if tier is None:
+            # Content gate already ran upstream; keep as last-resort if it
+            # somehow lacks a tier (defensive — should not happen).
+            tier = 3
+        candidate_size = _release_size_bytes(candidate)
+        size_delta = abs(target_size - candidate_size) if target_size else 0
+        ranked.append((tier, size_delta, candidate))
+    ranked.sort(key=lambda item: (item[0], item[1]))
+    return [item[2] for item in ranked]
 
 
 def build_fallback_job_name(title, nzb_url, index):

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -27,6 +27,7 @@ import xbmc
 import xbmcaddon
 
 from resources.lib import telemetry
+from resources.lib.http_util import pubdate_to_epoch
 from resources.lib.nzb_manifest import fetch_nzb_video_manifest, make_empty_manifest
 
 
@@ -82,6 +83,12 @@ _FINGERPRINT_DENSE_SAMPLE_MIN_BYTES = 1024 * 1024 * 1024
 _FINGERPRINT_BYTES = 4096
 
 _MAX_FALLBACKS = 5
+# Two fallback candidates whose Usenet post dates fall within this window are
+# treated as the same upload re-listed and collapsed to one (highest tier kept).
+# A candidate within this window of the primary's post date is the same upload
+# as the primary and is dropped — the primary cannot be its own backup. The
+# bound is inclusive: exactly 1h apart counts as the same article.
+_SAME_POST_WINDOW_SECONDS = 3600
 _FALLBACK_MANIFEST_STALL_SPECULATION_SECONDS = 0.05
 _FALLBACK_MANIFEST_OPTIONAL_TAIL_WAIT_SECONDS = 0.1
 _FALLBACK_MANIFEST_CACHE_TTL_SECONDS = 10.0
@@ -1671,6 +1678,83 @@ def _ensure_fallback_manifest(result, manifest_cache):
     result["_fallback_manifest"] = manifest
     result["_fallback_manifest_error"] = manifest.get("unsupported_reason", "")
     return manifest
+
+
+def _candidate_pubdate_epoch(candidate):
+    """Return a candidate's Usenet post date as UTC epoch seconds, or None.
+
+    None (missing or unparseable pubdate) means "always distinct": such a
+    candidate is never collapsed against another and is never suppressed by the
+    primary's date — we cannot prove two undated posts are the same upload.
+    """
+    if not isinstance(candidate, dict):
+        return None
+    pubdate = candidate.get("pubdate", "")
+    if not isinstance(pubdate, str) or not pubdate.strip():
+        return None
+    return pubdate_to_epoch(pubdate)
+
+
+def _best_ranked_in_cluster(cluster):
+    """Return the best fallback tuple from a same-post-date cluster.
+
+    ``cluster`` is a list of ``(order_index, item)`` where ``item`` is a
+    ``(exact_name, tier, size_delta, candidate)`` ranking tuple. Best = lowest
+    ``(exact_name, tier, size_delta)`` (highest similarity tier), with original
+    arrival order as a deterministic final tie-break.
+    """
+    return min(
+        cluster,
+        key=lambda entry: (entry[1][0], entry[1][1], entry[1][2], entry[0]),
+    )[1]
+
+
+def _dedupe_candidates_by_pubdate(target, ranked):
+    """Collapse ranked fallback tuples posted within the same-article window.
+
+    ``ranked`` is a list of ``(exact_name, tier, size_delta, candidate)`` tuples.
+    Candidates whose post dates fall within ``_SAME_POST_WINDOW_SECONDS`` of each
+    other are the same upload re-listed; only the best-ranked member of each such
+    cluster is kept. Candidates within the window of ``target``'s own post date
+    are dropped (the primary cannot be its own backup). Candidates with no
+    parseable post date are always kept.
+
+    Clustering is anchor-based: a candidate joins a cluster only when it is within
+    the window of that cluster's EARLIEST member, so a chain of near-posts does
+    not transitively merge into one blob. The returned list is unordered with
+    respect to rank; callers re-sort before clamping.
+    """
+    primary_epoch = _candidate_pubdate_epoch(target)
+    undated = []
+    dated = []  # (epoch, order_index, item)
+    for order_index, item in enumerate(ranked):
+        epoch = _candidate_pubdate_epoch(item[3])
+        if epoch is None:
+            undated.append(item)
+            continue
+        if (
+            primary_epoch is not None
+            and abs(epoch - primary_epoch) <= _SAME_POST_WINDOW_SECONDS
+        ):
+            continue  # same upload as the primary -> not a real backup
+        dated.append((epoch, order_index, item))
+
+    dated.sort(key=lambda entry: (entry[0], entry[1]))
+    survivors = []
+    cluster = []
+    anchor_epoch = None
+    for epoch, order_index, item in dated:
+        if anchor_epoch is None or epoch - anchor_epoch > _SAME_POST_WINDOW_SECONDS:
+            if cluster:
+                survivors.append(_best_ranked_in_cluster(cluster))
+            cluster = [(order_index, item)]
+            anchor_epoch = epoch
+        else:
+            cluster.append((order_index, item))
+    if cluster:
+        survivors.append(_best_ranked_in_cluster(cluster))
+
+    return undated + survivors
 
 
 def _attach_candidates_for_target(target, pool, max_candidates):

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -542,6 +542,14 @@ def _titles_core_related(primary_title, candidate_title, corroborated=False):
         prefix_match = longer[: len(shorter)] == shorter
         extra = len(longer) - len(shorter)
         if prefix_match and extra <= 1:
+            # A lone trailing numeric token ("Avatar" -> "Avatar 2") is a sequel
+            # discriminator, not junk. PTT leaves the sequel number inside the
+            # title (years/resolutions are already stripped into year/meta), so a
+            # numeric tail that survives normalization is content-distinguishing.
+            # Reject it without corroboration; a non-numeric trailing token
+            # ("Movie" -> "Movie mirror") stays a legitimate junk-suffix repost.
+            if extra == 1 and longer[-1].isdigit():
+                return False
             return True
         return False
     return _title_token_sets_look_related(left, right)
@@ -619,6 +627,25 @@ def _same_content(primary, candidate):
     # Part/chapter number is a content discriminator (Part One vs Part Two).
     if primary_part and candidate_part and primary_part != candidate_part:
         return False
+
+    # A movie whose release-group suffix mis-parses as a season (e.g.
+    # "...HEVC-REMUX-ALT01" -> seasons=[1], episodes=[]) would otherwise look
+    # episodic, and the season-presence parity check below would then reject the
+    # same movie posted by a normal group (seasons=[]). When BOTH sides have no
+    # episode, the season PRESENCE differs, and both parsed the SAME year, treat
+    # the lone "season" as the phantom it is and collapse it away. The
+    # matching-year gate is required: genuine TV is always season-tagged on both
+    # sides (presence matches), so it never reaches this collapse and stays
+    # subject to season equality.
+    same_year = bool(primary_year) and primary_year == candidate_year
+    if (
+        not primary_episodes
+        and not candidate_episodes
+        and bool(primary_seasons) != bool(candidate_seasons)
+        and same_year
+    ):
+        primary_seasons = ()
+        candidate_seasons = ()
 
     primary_is_episode = bool(primary_seasons or primary_episodes)
     candidate_is_episode = bool(candidate_seasons or candidate_episodes)

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -432,6 +432,33 @@ _PART_LABEL_RE = re.compile(
     r"one|two|three|four|five|six|seven|eight|nine|ten)\b",
     re.IGNORECASE,
 )
+# Trailing sequel discriminators PTT leaves inside the title ("Rocky IV",
+# "Rambo III", "Iron Man Three"). Mirror the numeric-tail reject for these.
+# MULTI-CHARACTER tokens ONLY: single-letter romans i/v/x collide with junk
+# suffixes (a stray "v"/"x"), and "one" is never a real sequel tail, so they
+# are deliberately excluded to avoid false-rejecting legit junk-suffix reposts.
+# Ordinal WORDS stop at "ten" (no "eleven"+) so titles like "Ocean's Eleven"
+# are not affected.
+_SEQUEL_TAIL_TOKENS = frozenset(
+    {
+        "ii",
+        "iii",
+        "iv",
+        "vi",
+        "vii",
+        "viii",
+        "ix",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+    }
+)
 _RELEASE_IDENTITY_CACHE_TITLE_KEY = "_fallback_identity_title"  # nosec B105
 _RELEASE_IDENTITY_CACHE_VALUE_KEY = "_fallback_identity"  # nosec B105
 
@@ -546,9 +573,16 @@ def _titles_core_related(primary_title, candidate_title, corroborated=False):
             # discriminator, not junk. PTT leaves the sequel number inside the
             # title (years/resolutions are already stripped into year/meta), so a
             # numeric tail that survives normalization is content-distinguishing.
-            # Reject it without corroboration; a non-numeric trailing token
-            # ("Movie" -> "Movie mirror") stays a legitimate junk-suffix repost.
-            if extra == 1 and longer[-1].isdigit():
+            # The same holds for MULTI-CHARACTER Roman-numeral / ordinal-word
+            # sequel tails ("Rocky" -> "Rocky IV", "Iron Man" -> "Iron Man
+            # Three"). Single-letter romans (i/v/x) and "one"/"eleven"+ are
+            # deliberately NOT in _SEQUEL_TAIL_TOKENS, so a stray "Movie x"/junk
+            # tail stays a legitimate junk-suffix repost. Reject these tails
+            # without corroboration; any other trailing token ("Movie" ->
+            # "Movie mirror") stays a legitimate junk-suffix repost.
+            if extra == 1 and (
+                longer[-1].isdigit() or longer[-1] in _SEQUEL_TAIL_TOKENS
+            ):
                 return False
             return True
         return False

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -2247,6 +2247,8 @@ def _rank_fallback_candidates(target, candidates):
         candidate_name = _manifest_normalized_video_name(candidate)
         exact_name = 0 if target_name and candidate_name == target_name else 1
         ranked.append((exact_name, tier, size_delta, candidate))
+    # Collapse same-post-date duplicates (same upload re-listed) before ordering.
+    ranked = _dedupe_candidates_by_pubdate(target, ranked)
     ranked.sort(key=lambda item: (item[0], item[1], item[2]))
     return [item[3] for item in ranked]
 

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -619,13 +619,6 @@ def _same_content(primary, candidate):
     # Part/chapter number is a content discriminator (Part One vs Part Two).
     if primary_part and candidate_part and primary_part != candidate_part:
         return False
-    if bool(primary_part) != bool(candidate_part):
-        # PTT keeps the part word inside the title ("Dune Part Two"), so the
-        # core titles never compare equal to the bare original. One side naming
-        # an explicit part while the other names none is a sequel-vs-original
-        # mismatch (e.g. "Dune Part Two" vs "Dune"); treat it as different
-        # content. A differing explicit part is already rejected above.
-        return False
 
     primary_is_episode = bool(primary_seasons or primary_episodes)
     candidate_is_episode = bool(candidate_seasons or candidate_episodes)
@@ -649,6 +642,17 @@ def _same_content(primary, candidate):
         if bool(primary_seasons) != bool(candidate_seasons):
             return False
         return True
+
+    if bool(primary_part) != bool(candidate_part):
+        # PTT keeps the part word inside the title ("Dune Part Two"), so the
+        # core titles never compare equal to the bare original. One side naming
+        # an explicit part while the other names none is a sequel-vs-original
+        # mismatch (e.g. "Dune Part Two" vs "Dune"); treat it as different
+        # content. A differing explicit part is already rejected above. This is
+        # the movie discriminator only: episodes routinely keep an episode-title
+        # token ("Chapter One") that PTT leaves in the title, so the same SxxExx
+        # posted with and without that token must still peer (handled above).
+        return False
 
     # Movies: a differing year is different content.
     if primary_year and candidate_year and primary_year != candidate_year:

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -1787,6 +1787,9 @@ def _attach_candidates_for_target(target, pool, max_candidates):
         seen_links.add(candidate_link)
         if candidate_digest:
             seen_article_digests.add(candidate_digest)
+    # Collapse same-post-date duplicates (same upload re-listed) before ranking
+    # so the _MAX_FALLBACKS clamp keeps the best DISTINCT posts, not dupes.
+    matched = _dedupe_candidates_by_pubdate(target, matched)
     # Exact-same-filename first (0 before 1), then tiered ranking: most-similar
     # first (lower tier), then smallest size delta. Sort is stable so equal keys
     # keep pool order.

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -586,6 +586,20 @@ def _titles_core_related(primary_title, candidate_title, corroborated=False):
                 return False
             return True
         return False
+    # Neither title's token set is a subset of the other, so each carries its
+    # own distinguishing tail. A MULTI-token distinguishing tail on either side
+    # looks like a different work in a franchise ("Mission Impossible Fallout"
+    # vs "...Dead Reckoning", "Star Wars The Force Awakens" vs "...The Last
+    # Jedi") rather than a repost, so require corroborating positive identity (a
+    # matching year, or a matching season+episode set) before accepting it -- a
+    # loose >=2-token prefix overlap is too weak on its own. A single-token
+    # difference on each side stays repost noise ("Movie mirror" vs "Movie
+    # repost") and keeps the existing token-overlap behavior, mirroring the
+    # <=1-trailing-token junk-suffix rule of the subset case above.
+    left_extra = left - right
+    right_extra = right - left
+    if (len(left_extra) >= 2 or len(right_extra) >= 2) and not corroborated:
+        return False
     return _title_token_sets_look_related(left, right)
 
 
@@ -670,7 +684,15 @@ def _same_content(primary, candidate):
     # the lone "season" as the phantom it is and collapse it away. The
     # matching-year gate is required: genuine TV is always season-tagged on both
     # sides (presence matches), so it never reaches this collapse and stays
-    # subject to season equality.
+    # subject to season equality. NOTE: extending this collapse to the
+    # both-years-ABSENT case was attempted and reverted -- a yearless phantom
+    # season and a yearless REAL season pack ("Show.S01"/"Show.Сезон.1") share an
+    # identical parsed identity, and no heuristic could tell them apart without
+    # re-implementing (and forever chasing) PTT's multilingual season vocabulary,
+    # so every loosening leaked a dangerous false-ACCEPT of different content. The
+    # yearless-phantom-movie false-reject is an accepted fail-safe limitation
+    # (never serves wrong content), per the "never loosen _same_content to win
+    # coverage" rule.
     same_year = bool(primary_year) and primary_year == candidate_year
     if (
         not primary_episodes

--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -210,6 +210,33 @@ def get_xml_text(element, tag):
     return ""
 
 
+def pubdate_to_epoch(pubdate_str):
+    """Return absolute UTC epoch seconds for an RFC-2822 pubdate, or None.
+
+    Unlike :func:`calculate_age` (a *relative*, drifting "N days ago"
+    label that changes every day for the same post), the epoch is a
+    stable identity key: one Usenet post always maps to the same value.
+    The picker uses it to tell apart same-name reposts that share a size
+    but were posted on different days. A pubdate without a timezone is
+    assumed UTC so the result is deterministic across hosts.
+    """
+    from datetime import timezone
+    from email.utils import parsedate_to_datetime
+
+    try:
+        pub = parsedate_to_datetime(pubdate_str)
+    except _PUBDATE_ERRORS:
+        return None
+    if pub is None:
+        return None
+    if pub.tzinfo is None:
+        pub = pub.replace(tzinfo=timezone.utc)
+    try:
+        return int(pub.timestamp())
+    except _PUBDATE_ERRORS:
+        return None
+
+
 def calculate_age(pubdate_str):
     """Return a human-readable age string computed from an RFC 2822 date.
 

--- a/repo/plugin.video.nzbdav/resources/lib/nzbdav_api.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzbdav_api.py
@@ -608,6 +608,11 @@ def _completed_job_from_slot(slot):
         "storage": slot.get("storage", ""),
         "name": slot.get("name", ""),
         "nzo_id": slot.get("nzo_id", ""),
+        # Downloaded byte size. nzbdav history is keyed by NAME, so the picker's
+        # DL/cache match disambiguates same-filename collisions (different
+        # release/resolution, or a repost at a different retention) by comparing
+        # this against the indexer result's advertised size (_tag_available).
+        "bytes": slot.get("bytes"),
         "fail_message": slot.get("fail_message", ""),
         # SABnzbd-compatible: epoch-seconds timestamp the job moved into
         # history. nzbdav-rs reports unix epoch directly. Used by the

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -17,6 +17,7 @@ import xbmcgui
 import xbmcplugin
 import xbmcvfs
 
+from resources.lib.download_ledger import record_download
 from resources.lib.fallback_streams import (
     FALLBACK_CANDIDATES_DISABLED,
     build_fallback_job_name,
@@ -3434,6 +3435,8 @@ def _poll_until_ready(
     settings_getter=None,
     selected_indexer=None,
     rejected_completed_ids=None,
+    download_pubdate=None,
+    download_size=None,
 ):
     """Submit NZB and poll until download completes.
 
@@ -3476,6 +3479,18 @@ def _poll_until_ready(
     )
     if not nzo_id:
         return None, None
+    # A fresh submit just happened (not a cache hit -- _existing_completed_stream
+    # returned above for those). Record the release's Usenet post-date keyed by
+    # title so the picker can later distinguish THIS download from a same-name
+    # repost posted on a different day. Fail-soft: never let bookkeeping break
+    # playback.
+    try:
+        record_download(title, download_pubdate, download_size)
+    except Exception as error:  # pylint: disable=broad-except
+        xbmc.log(
+            "NZB-DAV: download-ledger record failed (non-fatal): {}".format(error),
+            xbmc.LOGDEBUG,
+        )
     if on_primary_submitted is not None:
         try:
             on_primary_submitted(nzo_id)
@@ -3661,6 +3676,8 @@ def resolve(handle, params):
                 completed_job_lookup_done=picker_completed_lookup_done,
                 selected_indexer=selected_indexer,
                 rejected_completed_ids=rejected_completed_ids,
+                download_pubdate=params.get("_download_pubdate"),
+                download_size=params.get("_download_size"),
             )
         if stream_url:
             if fallback_state is None:
@@ -3811,6 +3828,8 @@ def resolve_and_play(nzb_url, title, params=None):
                 settings_getter=settings_getter,
                 selected_indexer=selected_indexer,
                 rejected_completed_ids=rejected_completed_ids,
+                download_pubdate=resolve_params.get("_download_pubdate"),
+                download_size=resolve_params.get("_download_size"),
             )
             _resolve_stage("poll until ready done stream={}".format(bool(stream_url)))
         if stream_url:

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -2872,6 +2872,52 @@ _FALLBACK_PREWARM_DELAY_SECONDS = 120
 # missed signal degrades to a late submit, never a permanently stranded backup).
 _FALLBACK_PLAYBACK_WAIT_POLL_SECONDS = 1.0
 _FALLBACK_PLAYBACK_WAIT_CAP_SECONDS = 300.0
+# Short interval the prewarm wait wakes on to re-check whether playback went
+# inactive cross-process. Small enough to abort promptly, big enough to avoid
+# busy-spinning. Module-level so tests can patch it to run fast.
+_FALLBACK_PREWARM_POLL_SECONDS = 1.0
+
+
+def _playback_still_active():
+    """Best-effort cross-process check that playback hasn't been stopped/ended.
+
+    The fallback submit worker's ``state["stop"]`` event is in-process and can
+    never be set by service.py's player callbacks (a different process). The
+    shared ``nzbdav.active`` window property IS observable across processes, so
+    a cleared/non-"true" value after playback has started signals the session
+    is dead. Guarded so a property-read failure never aborts submission (we
+    return True -- assume active -- on any error).
+    """
+    try:
+        return xbmcgui.Window(10000).getProperty("nzbdav.active") == "true"
+    except Exception:  # pylint: disable=broad-except
+        return True
+
+
+def _wait_prewarm_or_inactive(state, prewarm_delay, playback_signaled):
+    """Wait up to ``prewarm_delay`` seconds, aborting early on stop/inactive.
+
+    Returns True if the worker should ABORT (stop event set, or -- only once
+    ``playback_signaled`` is True -- the cross-process ``nzbdav.active`` flag is
+    no longer "true"). Returns False once the full delay elapses with playback
+    still active. Uses ``Event.wait`` for the polling sleep so a daemon worker
+    never blocks Kodi shutdown. Total wait equals ``prewarm_delay``.
+    """
+    stop = state.get("stop")
+    if not prewarm_delay:
+        return bool(stop is not None and stop.is_set())
+    interval = _FALLBACK_PREWARM_POLL_SECONDS
+    remaining = float(prewarm_delay)
+    while remaining > 0:
+        wait_for = interval if interval < remaining else remaining
+        if stop is not None and stop.wait(wait_for):
+            return True
+        remaining -= wait_for
+        # Only treat "inactive" as a stop AFTER playback was signaled, so we
+        # don't abort during the pre-playback window before active is ever set.
+        if playback_signaled and not _playback_still_active():
+            return True
+    return False
 
 
 def _get_fallback_submit_delay_seconds(settings_getter=None):
@@ -3009,7 +3055,10 @@ def _start_fallback_submit_worker(
             # primary). Both waits are cancellable: a stop aborts before submit.
             if wait_for_playback and not _await_playback_start(state):
                 return
-            if prewarm_delay and state["stop"].wait(prewarm_delay):
+            # ``wait_for_playback`` worker only reaches here once playback was
+            # signaled; a non-waiting worker never gets a cross-process active
+            # flag to honor, so only its stop event aborts the prewarm wait.
+            if _wait_prewarm_or_inactive(state, prewarm_delay, wait_for_playback):
                 return
             active_candidates = candidate_list
             candidate_lookup_disabled = False
@@ -3518,18 +3567,6 @@ def _poll_until_ready(
     )
     if not nzo_id:
         return None, None
-    # A fresh submit just happened (not a cache hit -- _existing_completed_stream
-    # returned above for those). Record the release's Usenet post-date keyed by
-    # title so the picker can later distinguish THIS download from a same-name
-    # repost posted on a different day. Fail-soft: never let bookkeeping break
-    # playback.
-    try:
-        record_download(title, download_pubdate, download_size)
-    except Exception as error:  # pylint: disable=broad-except
-        xbmc.log(
-            "NZB-DAV: download-ledger record failed (non-fatal): {}".format(error),
-            xbmc.LOGDEBUG,
-        )
     if on_primary_submitted is not None:
         try:
             on_primary_submitted(nzo_id)
@@ -3596,6 +3633,22 @@ def _poll_until_ready(
             )
         )
         if stream_url:
+            # The stream is confirmed playable (the only success path). Record
+            # the release's Usenet post-date keyed by title ONLY now -- never on
+            # a submit that later times out / fails / is cancelled -- so the
+            # picker can distinguish THIS completed download from a same-name
+            # repost posted on a different day, and a failed attempt can't make a
+            # different repost's same-name completed row look adopted here.
+            # Fail-soft: never let bookkeeping break playback.
+            try:
+                record_download(title, download_pubdate, download_size)
+            except Exception as error:  # pylint: disable=broad-except
+                xbmc.log(
+                    "NZB-DAV: download-ledger record failed (non-fatal): {}".format(
+                        error
+                    ),
+                    xbmc.LOGDEBUG,
+                )
             return stream_url, stream_headers
         if should_stop:
             if dead is not None and (history or {}).get("status") == "Failed":

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -17,6 +17,7 @@ import xbmcgui
 import xbmcplugin
 import xbmcvfs
 
+from resources.lib.dead_candidates import is_provably_dead_submit_error
 from resources.lib.download_ledger import record_download
 from resources.lib.fallback_streams import (
     FALLBACK_CANDIDATES_DISABLED,
@@ -2661,7 +2662,13 @@ def _submit_nzb_with_retries(
 
 
 def _submit_fallback_candidates(
-    candidates, monitor, stop_event=None, on_job=None, settings_getter=None
+    candidates,
+    monitor,
+    stop_event=None,
+    on_job=None,
+    settings_getter=None,
+    dead=None,
+    primary_nzb_url=None,
 ):
     """Submit duplicate fallback candidates as standby nzbdav jobs."""
     fallback_jobs = []
@@ -2674,6 +2681,23 @@ def _submit_fallback_candidates(
         nzb_url = candidate.get("link")
         title = candidate.get("title")
         if not nzb_url or not title:
+            continue
+        # Never re-admit a provably-dead candidate, and never offer the active
+        # primary as its own backup (the original primary only re-enters the
+        # pool after a live cutover demotes it -- handled in stream_proxy).
+        if dead is not None and dead.has_url(nzb_url):
+            xbmc.log(
+                "NZB-DAV: Skipping dead fallback candidate '{}'".format(title),
+                xbmc.LOGINFO,
+            )
+            continue
+        if primary_nzb_url and nzb_url == primary_nzb_url:
+            xbmc.log(
+                "NZB-DAV: Skipping primary's own release as a fallback '{}'".format(
+                    title
+                ),
+                xbmc.LOGINFO,
+            )
             continue
         job_name = build_fallback_job_name(title, nzb_url, index)
         candidate_jobs.append((candidate, nzb_url, title, job_name))
@@ -2737,6 +2761,8 @@ def _submit_fallback_candidates(
                     job_name, monitor, settings_getter=settings_getter
                 )
             if not nzo_id:
+                if dead is not None and is_provably_dead_submit_error(submit_error):
+                    dead.add(nzb_url=nzb_url)
                 xbmc.log(
                     "NZB-DAV: Fallback submit skipped for '{}' (status={}): {}".format(
                         job_name, status, submit_error.get("message", "")

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -2839,6 +2839,31 @@ _FALLBACK_PLAYBACK_WAIT_POLL_SECONDS = 1.0
 _FALLBACK_PLAYBACK_WAIT_CAP_SECONDS = 300.0
 
 
+def _get_fallback_submit_delay_seconds(settings_getter=None):
+    """Read the configurable fallback submit defer (seconds INTO playback).
+
+    Backup NZBs are submitted only this many seconds AFTER playback has actually
+    started (the burst is anchored to the playback-start signal, then held for
+    this delay). Exposed as the ``fallback_submit_delay`` user setting so the
+    defer is configurable; an empty/invalid/negative value funnels to the
+    documented ``_FALLBACK_PREWARM_DELAY_SECONDS`` default. ``0`` is valid and
+    means submit right at playback start.
+    """
+    try:
+        if settings_getter is None:
+            raw = xbmcaddon.Addon("plugin.video.nzbdav").getSetting(
+                "fallback_submit_delay"
+            )
+        else:
+            raw = settings_getter("fallback_submit_delay", "")
+        value = int(raw) if raw else _FALLBACK_PREWARM_DELAY_SECONDS
+        return value if value >= 0 else _FALLBACK_PREWARM_DELAY_SECONDS
+    except Exception:  # pylint: disable=broad-except
+        # xbmcaddon import failure, unexpected setting shapes, int() on a
+        # MagicMock in tests — all funnel to the documented default.
+        return _FALLBACK_PREWARM_DELAY_SECONDS
+
+
 def _await_playback_start(state):
     """Block until playback is signaled (return True) or the worker is stopped
     (return False).
@@ -3586,7 +3611,7 @@ def resolve(handle, params):
                 fallback_state = _start_fallback_submit_worker(
                     fallback_candidates,
                     candidate_loader=fallback_candidate_loader,
-                    prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
+                    prewarm_delay=_get_fallback_submit_delay_seconds(),
                     wait_for_playback=True,
                 )
 
@@ -3718,7 +3743,9 @@ def resolve_and_play(nzb_url, title, params=None):
             if fallback_state is None:
                 fallback_submit_kwargs = {
                     "candidate_loader": fallback_candidate_loader,
-                    "prewarm_delay": _FALLBACK_PREWARM_DELAY_SECONDS,
+                    "prewarm_delay": _get_fallback_submit_delay_seconds(
+                        settings_getter
+                    ),
                     "wait_for_playback": True,
                 }
                 fallback_submit_kwargs.update(_settings_getter_kwargs(settings_getter))

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -3437,6 +3437,7 @@ def _poll_until_ready(
     rejected_completed_ids=None,
     download_pubdate=None,
     download_size=None,
+    dead=None,
 ):
     """Submit NZB and poll until download completes.
 
@@ -3539,6 +3540,10 @@ def _poll_until_ready(
             job_status, nzo_id, dialog, last_status
         )
         if should_stop:
+            if dead is not None and str(
+                (job_status or {}).get("status", "")
+            ).lower() in ("failed", "deleted"):
+                dead.add(nzb_url=nzb_url, nzo_id=nzo_id)
             return None, None
 
         should_stop, stream_url, stream_headers, no_video_retries = (
@@ -3555,6 +3560,8 @@ def _poll_until_ready(
         if stream_url:
             return stream_url, stream_headers
         if should_stop:
+            if dead is not None and (history or {}).get("status") == "Failed":
+                dead.add(nzb_url=nzb_url, nzo_id=nzo_id)
             return None, None
 
         if _handle_webdav_error(nzo_id, webdav_error):

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -17,7 +17,7 @@ import xbmcgui
 import xbmcplugin
 import xbmcvfs
 
-from resources.lib.dead_candidates import is_provably_dead_submit_error
+from resources.lib.dead_candidates import DeadCandidates, is_provably_dead_submit_error
 from resources.lib.download_ledger import record_download
 from resources.lib.fallback_streams import (
     FALLBACK_CANDIDATES_DISABLED,
@@ -2932,6 +2932,8 @@ def _start_fallback_submit_worker(
     settings_getter=None,
     prewarm_delay=0,
     wait_for_playback=False,
+    dead=None,
+    primary_nzb_url=None,
 ):
     """Start background fallback submits and return shared state.
 
@@ -3034,6 +3036,8 @@ def _start_fallback_submit_worker(
                 stop_event=state["stop"],
                 on_job=_append_job,
                 settings_getter=settings_getter,
+                dead=dead,
+                primary_nzb_url=primary_nzb_url,
             )
         except Exception as error:  # pylint: disable=broad-except
             xbmc.log(
@@ -3661,11 +3665,14 @@ def resolve(handle, params):
                     candidate_loader=fallback_candidate_loader,
                     prewarm_delay=_get_fallback_submit_delay_seconds(),
                     wait_for_playback=True,
+                    dead=dead,
+                    primary_nzb_url=nzb_url,
                 )
 
         # One rejected-id set per resolve attempt, shared so a Completed row
         # the picker body probe rejects is honored by the submit/poll paths.
         rejected_completed_ids = set()
+        dead = DeadCandidates()
         completed_stream = _picker_completed_stream(
             title,
             params,
@@ -3711,6 +3718,7 @@ def resolve(handle, params):
                 rejected_completed_ids=rejected_completed_ids,
                 download_pubdate=params.get("_download_pubdate"),
                 download_size=params.get("_download_size"),
+                dead=dead,
             )
         if stream_url:
             if fallback_state is None:
@@ -3797,6 +3805,8 @@ def resolve_and_play(nzb_url, title, params=None):
                         settings_getter
                     ),
                     "wait_for_playback": True,
+                    "dead": dead,
+                    "primary_nzb_url": nzb_url,
                 }
                 fallback_submit_kwargs.update(_settings_getter_kwargs(settings_getter))
                 fallback_state = _start_fallback_submit_worker(
@@ -3807,6 +3817,7 @@ def resolve_and_play(nzb_url, title, params=None):
         # One rejected-id set per resolve attempt, shared so a Completed row
         # the picker body probe rejects is honored by the submit/poll paths.
         rejected_completed_ids = set()
+        dead = DeadCandidates()
         completed_stream = _picker_completed_stream(
             title,
             resolve_params,
@@ -3863,6 +3874,7 @@ def resolve_and_play(nzb_url, title, params=None):
                 rejected_completed_ids=rejected_completed_ids,
                 download_pubdate=resolve_params.get("_download_pubdate"),
                 download_size=resolve_params.get("_download_size"),
+                dead=dead,
             )
             _resolve_stage("poll until ready done stream={}".format(bool(stream_url)))
         if stream_url:

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -516,12 +516,18 @@ def _url_path(url):
     return urlsplit(url).path.lower()
 
 
-def _playback_fallback_sources_for_stream(stream_url, fallback_jobs):
+def _playback_fallback_sources_for_stream(stream_url, fallback_jobs, dead=None):
+    if dead is not None:
+        fallback_jobs = [
+            job
+            for job in fallback_jobs
+            if not (dead.has_nzo(job.get("nzo_id")) or dead.has_url(job.get("nzb_url")))
+        ]
     fallback_sources = build_prepare_fallback_payload(fallback_jobs)
     return fallback_sources
 
 
-def _arm_live_fallback_push(prepared, fallback_state, primary_stream_url):
+def _arm_live_fallback_push(prepared, fallback_state, primary_stream_url, dead=None):
     """Push fallbacks adopted AFTER /prepare into the live proxy session.
 
     The /prepare fallback snapshot is one-shot: when the primary resolves
@@ -551,7 +557,9 @@ def _arm_live_fallback_push(prepared, fallback_state, primary_stream_url):
 
     def _push():
         jobs = _fallback_submit_jobs_snapshot(fallback_state, wait_seconds=0)
-        sources = _playback_fallback_sources_for_stream(primary_stream_url, jobs)
+        sources = _playback_fallback_sources_for_stream(
+            primary_stream_url, jobs, dead=dead
+        )
         if not sources:
             return
         try:
@@ -3729,6 +3737,7 @@ def resolve(handle, params):
                     fallback_state,
                     wait_seconds=_PLAYBACK_PREPARE_HANDOFF_GRACE_SECONDS,
                 ),
+                dead=dead,
             )
             playback_prepare_state = _start_direct_playback_prepare(
                 stream_url,
@@ -3738,7 +3747,7 @@ def resolve(handle, params):
             )
             _wait_playback_state_cleanup(playback_cleanup_state)
             prepared = _wait_direct_playback_prepare(playback_prepare_state)
-            _arm_live_fallback_push(prepared, fallback_state, stream_url)
+            _arm_live_fallback_push(prepared, fallback_state, stream_url, dead=dead)
             _finish_direct_playback(handle, prepared)
             # Playback handed off to Kodi: start the fallback worker's "minutes
             # into playback" countdown now, not from the earlier primary submit.
@@ -3886,6 +3895,7 @@ def resolve_and_play(nzb_url, title, params=None):
                     fallback_state,
                     wait_seconds=_PLAYBACK_PREPARE_HANDOFF_GRACE_SECONDS,
                 ),
+                dead=dead,
             )
             _resolve_stage("prepare playback start")
             prepare_kwargs = {
@@ -3907,7 +3917,7 @@ def resolve_and_play(nzb_url, title, params=None):
                     prepared.get("service_port") if prepared else ""
                 )
             )
-            _arm_live_fallback_push(prepared, fallback_state, stream_url)
+            _arm_live_fallback_push(prepared, fallback_state, stream_url, dead=dead)
             _finish_player_playback(prepared)
             # Playback handed off to the player: start the fallback worker's
             # "minutes into playback" countdown now, not from the primary submit.

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -2878,45 +2878,64 @@ _FALLBACK_PLAYBACK_WAIT_CAP_SECONDS = 300.0
 _FALLBACK_PREWARM_POLL_SECONDS = 1.0
 
 
-def _playback_still_active():
-    """Best-effort cross-process check that playback hasn't been stopped/ended.
+def _playback_active_flag():
+    """Tri-state cross-process read of the live-playback liveness flag.
+
+    Returns True when service.py is currently monitoring playback, False when
+    that flag is absent/cleared, or None when the property can't be read.
 
     The fallback submit worker's ``state["stop"]`` event is in-process and can
-    never be set by service.py's player callbacks (a different process). The
-    shared ``nzbdav.active`` window property IS observable across processes, so
-    a cleared/non-"true" value after playback has started signals the session
-    is dead. Guarded so a property-read failure never aborts submission (we
-    return True -- assume active -- on any error).
+    never be set by service.py's player callbacks (a different process), so the
+    worker needs a cross-process signal to know playback ended. We use a
+    DEDICATED ``nzbdav.playing`` window property that service.py sets while
+    monitoring and clears only on stop/end -- NOT the ``nzbdav.active`` handoff
+    flag, which ``service._check_active()`` consumes (clears) on the first tick
+    after playback starts and so would read False mid-playback.
     """
     try:
-        return xbmcgui.Window(10000).getProperty("nzbdav.active") == "true"
+        return xbmcgui.Window(10000).getProperty("nzbdav.playing") == "true"
     except Exception:  # pylint: disable=broad-except
-        return True
+        return None
 
 
 def _wait_prewarm_or_inactive(state, prewarm_delay, playback_signaled):
     """Wait up to ``prewarm_delay`` seconds, aborting early on stop/inactive.
 
-    Returns True if the worker should ABORT (stop event set, or -- only once
-    ``playback_signaled`` is True -- the cross-process ``nzbdav.active`` flag is
-    no longer "true"). Returns False once the full delay elapses with playback
-    still active. Uses ``Event.wait`` for the polling sleep so a daemon worker
-    never blocks Kodi shutdown. Total wait equals ``prewarm_delay``.
+    Returns True if the worker should ABORT: the in-process stop event is set,
+    or -- only once ``playback_signaled`` is True AND we have positively
+    observed the cross-process ``nzbdav.playing`` flag as live at least once --
+    that flag is later cleared (playback stopped/ended during the standby
+    window). Returns False once the full delay elapses with playback still live.
+
+    The "seen live first" latch matters: if playback was never actually
+    signaled (the ``_await_playback_start`` cap path, or an unusual handoff
+    where service never set the flag), we never latch, so the worker degrades to
+    a late submit rather than a wrongly-stranded backup -- and a brief startup
+    race where the worker polls before service sets the flag can't abort it.
+
+    Uses ``Event.wait`` for the polling sleep so a daemon worker never blocks
+    Kodi shutdown. Total wait equals ``prewarm_delay``.
     """
     stop = state.get("stop")
     if not prewarm_delay:
         return bool(stop is not None and stop.is_set())
     interval = _FALLBACK_PREWARM_POLL_SECONDS
     remaining = float(prewarm_delay)
+    seen_live = False
     while remaining > 0:
         wait_for = interval if interval < remaining else remaining
         if stop is not None and stop.wait(wait_for):
             return True
         remaining -= wait_for
-        # Only treat "inactive" as a stop AFTER playback was signaled, so we
-        # don't abort during the pre-playback window before active is ever set.
-        if playback_signaled and not _playback_still_active():
-            return True
+        if playback_signaled:
+            flag = _playback_active_flag()
+            if flag is True:
+                seen_live = True
+            elif flag is False and seen_live:
+                # Was live, now cleared -> playback stopped/ended; abort the
+                # standby submit for this dead session. (flag is None -> read
+                # failed -> leave the latch unchanged and keep waiting.)
+                return True
     return False
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -1594,8 +1594,15 @@ def _start_existing_completed_cleanup(title, on_existing_completed):
         )
 
 
-def _find_video_stream_for_folder(webdav_folder, settings_getter=None):
-    """Return video path, URL, and headers for a completed WebDAV folder."""
+def _find_video_stream_for_folder(webdav_folder, settings_getter=None, title_hint=None):
+    """Return video path, URL, and headers for a completed WebDAV folder.
+
+    ``title_hint`` is the requested release/episode title (e.g. the submitted
+    scene name). It is threaded into webdav discovery so a multi-episode pack
+    returns the requested SxxExx episode rather than whichever sibling file is
+    largest. When ``None`` (movie / no identifiable episode) the historical
+    largest-video-wins behavior is preserved unchanged.
+    """
     try:
         from resources.lib import webdav as _webdav
 
@@ -1606,7 +1613,9 @@ def _find_video_stream_for_folder(webdav_folder, settings_getter=None):
         ):
             _resolve_stage("find_video_stream_for_folder_delegated")
             video_path, stream_url, stream_headers = find_video_stream_for_folder(
-                webdav_folder, **_settings_getter_kwargs(settings_getter)
+                webdav_folder,
+                title_hint=title_hint,
+                **_settings_getter_kwargs(settings_getter),
             )
             if video_path:
                 _remember_resolved_stream_content_length_hint(
@@ -1618,7 +1627,7 @@ def _find_video_stream_for_folder(webdav_folder, settings_getter=None):
 
     kwargs = _settings_getter_kwargs(settings_getter)
     _resolve_stage("find_video_file_start folder={}".format(webdav_folder))
-    video_path = find_video_file(webdav_folder, **kwargs)
+    video_path = find_video_file(webdav_folder, title_hint=title_hint, **kwargs)
     _resolve_stage("find_video_file_done path={}".format(bool(video_path)))
     if not video_path:
         return None, None, None
@@ -1667,7 +1676,7 @@ def _completed_job_stream(
     webdav_folder = _storage_to_webdav_path(storage)
     _start_existing_completed_cleanup(title, on_existing_completed)
     video_path, stream_url, stream_headers = _find_video_stream_for_folder(
-        webdav_folder, settings_getter=settings_getter
+        webdav_folder, settings_getter=settings_getter, title_hint=title
     )
     if not video_path:
         return None
@@ -3145,12 +3154,17 @@ def _handle_job_status(job_status, nzo_id, dialog, last_status):
 
 
 def _find_completed_video_stream_with_rechecks(
-    webdav_folder, monitor=None, settings_getter=None
+    webdav_folder, monitor=None, settings_getter=None, title_hint=None
 ):
-    """Return a completed WebDAV stream, briefly rechecking symlink visibility."""
+    """Return a completed WebDAV stream, briefly rechecking symlink visibility.
+
+    ``title_hint`` (the requested release/episode title) is threaded into
+    discovery so a multi-episode pack resolves to the requested episode; with
+    ``None`` the historical largest-video behavior is preserved.
+    """
     _resolve_stage("find_video_stream_start")
     video_path, stream_url, stream_headers = _find_video_stream_for_folder(
-        webdav_folder, settings_getter=settings_getter
+        webdav_folder, settings_getter=settings_getter, title_hint=title_hint
     )
     _resolve_stage("find_video_stream_done path={}".format(bool(video_path)))
     if video_path or monitor is None:
@@ -3161,7 +3175,7 @@ def _find_completed_video_stream_with_rechecks(
             return None, None, None
         _resolve_stage("find_video_stream_retry delay={}".format(delay_seconds))
         video_path, stream_url, stream_headers = _find_video_stream_for_folder(
-            webdav_folder, settings_getter=settings_getter
+            webdav_folder, settings_getter=settings_getter, title_hint=title_hint
         )
         _resolve_stage("find_video_stream_retry_done path={}".format(bool(video_path)))
         if video_path:
@@ -3219,7 +3233,10 @@ def _handle_history_result(
         return False, None, None, no_video_retries
     webdav_folder = _storage_to_webdav_path(storage)
     video_path, stream_url, stream_headers = _find_completed_video_stream_with_rechecks(
-        webdav_folder, monitor=monitor, settings_getter=settings_getter
+        webdav_folder,
+        monitor=monitor,
+        settings_getter=settings_getter,
+        title_hint=title,
     )
     if video_path and _completed_stream_body_available(stream_url, stream_headers):
         xbmc.log(

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -2825,26 +2825,75 @@ def _prefetch_fallback_candidate_loader(candidate_loader):
     return _load_prefetched_candidates
 
 
-# Seconds to hold the fallback prewarm burst after playback handoff so it does
-# not contend with the live stream for nzbdav connections while Kodi's read
-# cache is still filling. Long enough to cover the startup cache-fill window;
-# the cutover safety net is only briefly delayed, not removed.
-_FALLBACK_PREWARM_DELAY_SECONDS = 15
+# Seconds INTO playback to hold the fallback prewarm/submit burst. Anchored to
+# actual playback start (not primary submission, which can precede playback by a
+# whole download for a slow primary), so backups are only fetched well after the
+# video is established: a working playback that never needs them submits none,
+# and the burst never contends with the fragile startup cache-fill window. The
+# wait is cancellable -- a session stop aborts it with no submission.
+_FALLBACK_PREWARM_DELAY_SECONDS = 120
+# Poll granularity while waiting for the playback-start signal, plus a defensive
+# cap after which the worker proceeds even if the signal never arrived (so a
+# missed signal degrades to a late submit, never a permanently stranded backup).
+_FALLBACK_PLAYBACK_WAIT_POLL_SECONDS = 1.0
+_FALLBACK_PLAYBACK_WAIT_CAP_SECONDS = 300.0
+
+
+def _await_playback_start(state):
+    """Block until playback is signaled (return True) or the worker is stopped
+    (return False).
+
+    Anchors the fallback prewarm delay to actual playback start. Capped by
+    ``_FALLBACK_PLAYBACK_WAIT_CAP_SECONDS`` so a path that never signals (a bug
+    or an unusual handoff) degrades to a late submit rather than a permanently
+    stranded backup.
+    """
+    started = state.get("playback_started")
+    if started is None:
+        return True
+    stop = state.get("stop")
+    if stop is not None and stop.is_set():
+        return False
+    waited = 0.0
+    while not started.wait(_FALLBACK_PLAYBACK_WAIT_POLL_SECONDS):
+        if stop is not None and stop.is_set():
+            return False
+        waited += _FALLBACK_PLAYBACK_WAIT_POLL_SECONDS
+        if waited >= _FALLBACK_PLAYBACK_WAIT_CAP_SECONDS:
+            return True
+    return True
+
+
+def _signal_fallback_playback_started(state):
+    """Mark playback as started so a ``wait_for_playback`` fallback worker begins
+    its prewarm-delay countdown. Best-effort no-op when there is no worker."""
+    if not state:
+        return
+    event = state.get("playback_started")
+    if event is not None:
+        event.set()
 
 
 def _start_fallback_submit_worker(
-    candidates=None, candidate_loader=None, settings_getter=None, prewarm_delay=0
+    candidates=None,
+    candidate_loader=None,
+    settings_getter=None,
+    prewarm_delay=0,
+    wait_for_playback=False,
 ):
     """Start background fallback submits and return shared state.
 
-    ``prewarm_delay`` defers the submit/prevalidation burst by that many seconds
-    after playback hands off. The prewarm opens several concurrent connections to
-    nzbdav (one submit + one prevalidation probe per source); firing them during
-    the first seconds of playback — while Kodi's read cache is still filling —
-    competes for nzbdav's connection budget and can stall the live stream enough
-    to wedge the CoreELEC audio clock (black screen). Waiting until playback is
-    established keeps the cutover safety net while protecting startup. The wait is
-    cancellable: a session stop during the window aborts it with no submission.
+    When ``wait_for_playback`` is set, the burst is held until playback is
+    signaled (via ``_signal_fallback_playback_started``) and then for
+    ``prewarm_delay`` seconds, so backups are only fetched well INTO playback,
+    never during the pre-playback download. ``prewarm_delay`` then measures the
+    delay from playback start rather than from worker creation (primary submit).
+    The prewarm opens several concurrent connections to nzbdav (one submit + one
+    prevalidation probe per source); firing them during the fragile startup
+    cache-fill window competes for nzbdav's connection budget and can stall the
+    live stream enough to wedge the CoreELEC audio clock (black screen). Both the
+    playback wait and the delay are cancellable: a session stop aborts with no
+    submission.
     """
 
     def _cancel_job(nzo_id):
@@ -2857,6 +2906,7 @@ def _start_fallback_submit_worker(
         "jobs": [],
         "stop": threading.Event(),
         "finished": threading.Event(),
+        "playback_started": threading.Event(),
         "thread": None,
         "cancel_job": _cancel_job,
     }
@@ -2890,10 +2940,13 @@ def _start_fallback_submit_worker(
 
     def _worker():
         try:
-            # Defer the prewarm burst until playback is established so it does
-            # not compete with the live stream for nzbdav connections during the
-            # fragile cache-fill window. Cancellable: a stop set during the wait
-            # returns True and aborts before any submit.
+            # Hold the entire prewarm/submit burst until playback has actually
+            # started, then for ``prewarm_delay`` seconds, so backups are fetched
+            # well INTO playback and never during the pre-playback download
+            # (anchoring to primary submission could fire mid-download for a slow
+            # primary). Both waits are cancellable: a stop aborts before submit.
+            if wait_for_playback and not _await_playback_start(state):
+                return
             if prewarm_delay and state["stop"].wait(prewarm_delay):
                 return
             active_candidates = candidate_list
@@ -3534,6 +3587,7 @@ def resolve(handle, params):
                     fallback_candidates,
                     candidate_loader=fallback_candidate_loader,
                     prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
+                    wait_for_playback=True,
                 )
 
         # One rejected-id set per resolve attempt, shared so a Completed row
@@ -3603,6 +3657,9 @@ def resolve(handle, params):
             prepared = _wait_direct_playback_prepare(playback_prepare_state)
             _arm_live_fallback_push(prepared, fallback_state, stream_url)
             _finish_direct_playback(handle, prepared)
+            # Playback handed off to Kodi: start the fallback worker's "minutes
+            # into playback" countdown now, not from the earlier primary submit.
+            _signal_fallback_playback_started(fallback_state)
         else:
             _stop_fallback_submit_worker(fallback_state, cancel_submitted=True)
             xbmcplugin.setResolvedUrl(handle, False, xbmcgui.ListItem())
@@ -3662,6 +3719,7 @@ def resolve_and_play(nzb_url, title, params=None):
                 fallback_submit_kwargs = {
                     "candidate_loader": fallback_candidate_loader,
                     "prewarm_delay": _FALLBACK_PREWARM_DELAY_SECONDS,
+                    "wait_for_playback": True,
                 }
                 fallback_submit_kwargs.update(_settings_getter_kwargs(settings_getter))
                 fallback_state = _start_fallback_submit_worker(
@@ -3760,6 +3818,9 @@ def resolve_and_play(nzb_url, title, params=None):
             )
             _arm_live_fallback_push(prepared, fallback_state, stream_url)
             _finish_player_playback(prepared)
+            # Playback handed off to the player: start the fallback worker's
+            # "minutes into playback" countdown now, not from the primary submit.
+            _signal_fallback_playback_started(fallback_state)
             _resolve_stage("player playback started")
         else:
             _stop_fallback_submit_worker(fallback_state, cancel_submitted=True)

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -781,14 +781,69 @@ def _search_all_providers(
     return deduped, None
 
 
+# How close an indexer result's advertised size must be to a completed nzbdav
+# download's ``bytes`` for them to be treated as the SAME upload. nzbdav history
+# is keyed by NAME only, so a name match alone collapses distinct uploads that
+# merely share a filename (a different release/resolution, or a repost at a
+# different retention). The tolerance is generous enough to absorb the gap
+# between an indexer's advertised NZB size and the actually-downloaded bytes
+# (yEnc/par2/rar overhead) so a genuine cache hit is never hidden, while still
+# separating clearly-different files (e.g. a 1080p vs a 2160p sharing a generic
+# filename). True per-upload identity is the article list, but that is not
+# available at picker time without fetching every NZB.
+_COMPLETED_SIZE_MATCH_TOLERANCE = 0.15
+
+
+def _result_size_bytes(result):
+    """Best-effort parse of an indexer result's advertised size in bytes."""
+    value = result.get("size") if isinstance(result, dict) else None
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value) if value > 0 else 0
+    if isinstance(value, str):
+        value = value.strip().replace(",", "")
+        if not value:
+            return 0
+        try:
+            return max(0, int(float(value)))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def _completed_job_matches_result(result, completed_job):
+    """Return whether a name-matched completed job plausibly IS this result's
+    upload, disambiguating same-filename collisions by size.
+
+    Fails OPEN when either size is unknown (keep the prior name-only behavior
+    rather than hide a real cache hit). A clearly-different size means a
+    different file — do not mark it ``DL`` or reuse its cached stream.
+    """
+    result_size = _result_size_bytes(result)
+    try:
+        job_bytes = int(completed_job.get("bytes") or 0)
+    except (TypeError, ValueError):
+        job_bytes = 0
+    if result_size <= 0 or job_bytes <= 0:
+        return True
+    return (
+        abs(result_size - job_bytes)
+        <= max(result_size, job_bytes) * _COMPLETED_SIZE_MATCH_TOLERANCE
+    )
+
+
 def _tag_available(results, settings_getter=None):
     """
     Mark result entries that already exist in nzbdav by setting the `_available` flag.
 
     Parameters:
         results (list[dict]): Iterable of result dictionaries; entries whose
-            `"title"` matches a completed name in nzbdav will be modified
-            in-place with `result["_available"] = True`.
+            `"title"` matches a completed name in nzbdav AND whose size matches
+            that completed download (see ``_completed_job_matches_result``) are
+            modified in-place with `result["_available"] = True`. The size gate
+            stops distinct uploads that merely share a filename from being
+            collapsed onto one cached stream.
     """
     if not results:
         return {}
@@ -797,7 +852,7 @@ def _tag_available(results, settings_getter=None):
         return completed
     for result in results:
         completed_job = completed.get(result.get("title"))
-        if completed_job:
+        if completed_job and _completed_job_matches_result(result, completed_job):
             result["_available"] = True
             result["_completed_job"] = completed_job
     return completed

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -511,14 +511,23 @@ def _snapshot_settings_getter(settings_getter, defaults):
 
 
 def _script_completed_job_for_selection(selected):
-    """Look up completed-history metadata for a RunScript picker selection."""
+    """Look up completed-history metadata for a RunScript picker selection.
+
+    Gated by size the same way ``_tag_available`` is: nzbdav history is keyed by
+    NAME, so a name-only match would reuse the wrong cached stream for a distinct
+    same-filename upload. Only return the completed job when its size matches the
+    selection (fail-open on unknown size).
+    """
     title = selected.get("title", "") if isinstance(selected, dict) else ""
     if not title:
         return None
     try:
         from resources.lib.nzbdav_api import find_completed_by_name
 
-        return find_completed_by_name(title, settings_getter=_get_script_setting)
+        job = find_completed_by_name(title, settings_getter=_get_script_setting)
+        if job and _completed_job_matches_result(selected, job):
+            return job
+        return None
     except Exception as error:  # pylint: disable=broad-except
         xbmc.log(
             "NZB-DAV: Script completed lookup failed for '{}': {}".format(title, error),

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -20,6 +20,7 @@ import xbmcgui
 import xbmcplugin
 
 from resources.lib import telemetry
+from resources.lib.download_ledger import downloaded_pubdate_epochs
 from resources.lib.fallback_streams import (
     FALLBACK_CANDIDATES_DISABLED,
     attach_fallback_candidates_for_selection,
@@ -30,6 +31,7 @@ from resources.lib.fallback_streams import (
     selection_pool_may_have_fallback_peer,
 )
 from resources.lib.http_util import format_size as _format_size
+from resources.lib.http_util import pubdate_to_epoch
 from resources.lib.i18n import addon_name as _addon_name
 from resources.lib.i18n import fmt as _fmt
 from resources.lib.i18n import string as _string
@@ -427,12 +429,26 @@ def _fallback_candidate_loader_for_selection(selected, results, settings_getter=
     return _load_fallback_candidates
 
 
-def _attach_selected_indexer(resolver_params, selected):
+def _attach_selected_result_metadata(resolver_params, selected):
+    """Thread metadata from the chosen result into the resolver params.
+
+    Beyond the indexer label, this carries the release's ``pubdate`` and
+    ``size`` so that, on a fresh submit, the resolver can record the
+    download's Usenet post-date (see ``download_ledger``). That lets a later
+    picker render tell THIS download apart from a same-name repost posted on
+    a different day. Absent fields are left unset so the resolver fails open.
+    """
     if not isinstance(selected, dict):
         return
     indexer = str(selected.get("indexer", "") or "").strip()
     if indexer:
         resolver_params["_selected_indexer"] = indexer
+    pubdate = selected.get("pubdate")
+    if pubdate:
+        resolver_params["_download_pubdate"] = pubdate
+    size = selected.get("size")
+    if size:
+        resolver_params["_download_size"] = size
 
 
 def _selection_pool_with_peer_first(selected, results, first_peer):
@@ -513,10 +529,13 @@ def _snapshot_settings_getter(settings_getter, defaults):
 def _script_completed_job_for_selection(selected):
     """Look up completed-history metadata for a RunScript picker selection.
 
-    Gated by size the same way ``_tag_available`` is: nzbdav history is keyed by
-    NAME, so a name-only match would reuse the wrong cached stream for a distinct
-    same-filename upload. Only return the completed job when its size matches the
-    selection (fail-open on unknown size).
+    Gated by size AND pubdate the same way ``_tag_available`` is: nzbdav history
+    is keyed by NAME, so a name-only match would reuse the wrong cached stream
+    for a distinct same-filename upload. Only return the completed job when its
+    size matches the selection (fail-open on unknown size) and the selection's
+    pubdate is consistent with what we downloaded under that name (fail-open
+    when unknown), so a same-name same-size repost from a different day isn't
+    reused.
     """
     title = selected.get("title", "") if isinstance(selected, dict) else ""
     if not title:
@@ -525,7 +544,11 @@ def _script_completed_job_for_selection(selected):
         from resources.lib.nzbdav_api import find_completed_by_name
 
         job = find_completed_by_name(title, settings_getter=_get_script_setting)
-        if job and _completed_job_matches_result(selected, job):
+        if (
+            job
+            and _completed_job_matches_result(selected, job)
+            and _result_pubdate_consistent_with_downloads(selected)
+        ):
             return job
         return None
     except Exception as error:  # pylint: disable=broad-except
@@ -842,6 +865,40 @@ def _completed_job_matches_result(result, completed_job):
     )
 
 
+# A same-name release posted on a *different day* is a different upload, even
+# when the size matches (a repost / re-rip). nzbdav history records only the
+# download time, never the Usenet post date, so we compare the result's
+# pubdate against the post-dates we captured at submit time (download_ledger).
+# The tolerance absorbs sub-hour indexer/TZ formatting jitter for the SAME
+# post while still separating day-apart reposts cleanly.
+_PUBDATE_MATCH_TOLERANCE_SECONDS = 3600
+
+
+def _result_pubdate_consistent_with_downloads(result):
+    """Return whether a name+size-matched result's pubdate is consistent with
+    what we actually downloaded under that name.
+
+    Fails OPEN (returns True) when we have no recorded pubdate for the name
+    (e.g. downloaded before this feature, or via an external invocation) or
+    the result advertises no parseable pubdate -- we'd rather keep the prior
+    name+size behavior than hide a real cache hit. Returns False only when we
+    DO have recorded pubdates and the result's pubdate matches none of them,
+    i.e. it is a same-name repost posted at a different time.
+    """
+    if not isinstance(result, dict):
+        return True
+    recorded = downloaded_pubdate_epochs(result.get("title"))
+    if not recorded:
+        return True
+    result_epoch = pubdate_to_epoch(result.get("pubdate"))
+    if result_epoch is None:
+        return True
+    return any(
+        abs(result_epoch - epoch) <= _PUBDATE_MATCH_TOLERANCE_SECONDS
+        for epoch in recorded
+    )
+
+
 def _tag_available(results, settings_getter=None):
     """
     Mark result entries that already exist in nzbdav by setting the `_available` flag.
@@ -861,7 +918,11 @@ def _tag_available(results, settings_getter=None):
         return completed
     for result in results:
         completed_job = completed.get(result.get("title"))
-        if completed_job and _completed_job_matches_result(result, completed_job):
+        if (
+            completed_job
+            and _completed_job_matches_result(result, completed_job)
+            and _result_pubdate_consistent_with_downloads(result)
+        ):
             result["_available"] = True
             result["_completed_job"] = completed_job
     return completed
@@ -1308,7 +1369,7 @@ def _handle_play(handle, params):
                 best, filtered
             ),
         }
-        _attach_selected_indexer(resolver_params, best)
+        _attach_selected_result_metadata(resolver_params, best)
         resolve(
             handle,
             resolver_params,
@@ -1341,7 +1402,7 @@ def _handle_play(handle, params):
             resolver_params["_completed_job"] = completed_job
         elif _completed_lookup_was_done(completed_jobs):
             resolver_params["_completed_job_lookup_done"] = True
-        _attach_selected_indexer(resolver_params, selected)
+        _attach_selected_result_metadata(resolver_params, selected)
         resolve(
             handle,
             resolver_params,
@@ -1491,7 +1552,7 @@ def _handle_search(handle, params):
         resolver_params["_fallback_candidates"] = []
         fallback_loader = _fallback_candidate_loader_for_selection(best, filtered)
         resolver_params["_fallback_candidate_loader"] = fallback_loader
-        _attach_selected_indexer(resolver_params, best)
+        _attach_selected_result_metadata(resolver_params, best)
         resolve_and_play(best["link"], best["title"], params=resolver_params)
         # Same hang class as C1 (router.py): /search is a directory
         # route, so Kodi blocks until endOfDirectory fires. Without
@@ -1525,7 +1586,7 @@ def _handle_search(handle, params):
             resolver_params["_completed_job"] = completed_job
         elif _completed_lookup_was_done(completed_jobs):
             resolver_params["_completed_job_lookup_done"] = True
-        _attach_selected_indexer(resolver_params, selected)
+        _attach_selected_result_metadata(resolver_params, selected)
         resolve_and_play(selected["link"], selected["title"], params=resolver_params)
 
     # Must end the directory or Kodi hangs
@@ -1646,7 +1707,7 @@ def _handle_script_play(params):
         else:
             resolver_params["_completed_job_lookup_done"] = True
         resolver_params["_settings_getter"] = _get_script_setting
-        _attach_selected_indexer(resolver_params, best)
+        _attach_selected_result_metadata(resolver_params, best)
         _script_play_stage("resolve start '{}'".format(best.get("title", "")))
         resolve_and_play(best["link"], best["title"], params=resolver_params)
         _script_play_stage("resolve returned")
@@ -1690,7 +1751,7 @@ def _handle_script_play(params):
         resolver_params["_completed_job"] = completed_job
     elif _completed_lookup_was_done(completed_jobs):
         resolver_params["_completed_job_lookup_done"] = True
-    _attach_selected_indexer(resolver_params, selected)
+    _attach_selected_result_metadata(resolver_params, selected)
     _script_play_stage("resolve start '{}'".format(selected.get("title", "")))
     resolve_and_play(selected["link"], selected["title"], params=resolver_params)
     _script_play_stage("resolve returned")

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -511,7 +511,16 @@ class ReadAheadBuffer:
         bytes to consume), repoint ``base_offset`` to the served offset and drop
         any now-behind stale data. This advances ``next_fetch_offset`` so the
         prefetch daemon builds a FORWARD lead from the play head instead of
-        re-fetching from offset 0 behind it."""
+        re-fetching from offset 0 behind it.
+
+        For the IN-WINDOW case (``base_offset < offset < window_end``: a
+        read-ahead miss served directly upstream while the prefetch had already
+        filled bytes from the old ``base_offset``), trim the now-consumed prefix
+        ``[base_offset, offset)`` and advance ``base_offset`` to the served
+        offset. This keeps the forward lead instead of letting the consumed
+        prefix pin the window behind the play head and throttle the prefetch.
+        The trim is INLINED (not ``free_behind``) because ``self._lock`` is a
+        non-reentrant ``threading.Lock`` already held here."""
         try:
             offset = int(offset)
         except (TypeError, ValueError):
@@ -521,6 +530,9 @@ class ReadAheadBuffer:
             window_end = self.base_offset + len(self.data)
             if offset >= window_end:
                 self.data = bytearray()
+                self.base_offset = offset
+            elif offset > self.base_offset:
+                del self.data[: offset - self.base_offset]
                 self.base_offset = offset
 
     def note_seek(self, new_start):

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -1373,12 +1373,16 @@ def _storage_to_webdav_path(storage):
     if storage.startswith("/content/"):
         return storage.rstrip("/") + "/"
 
-    prefix = "/mnt/nzbdav/completed-symlinks/"
-    if storage.startswith(prefix):
-        relative = storage[len(prefix) :]
-    else:
-        parts = storage.rstrip("/").split("/")
-        relative = "/".join(parts[-2:]) if len(parts) >= 2 else parts[-1]
+    for prefix in (
+        "/mnt/nzbdav/completed-symlinks/",
+        "/mnt/data/completed-symlinks/",
+    ):
+        if storage.startswith(prefix):
+            relative = storage[len(prefix) :]
+            return "/content/{}/".format(relative)
+
+    parts = storage.rstrip("/").split("/")
+    relative = "/".join(parts[-2:]) if len(parts) >= 2 else parts[-1]
     return "/content/{}/".format(relative)
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -683,8 +683,9 @@ def _bool_from_snapshot(snapshot, setting_id, default=False):
 
 
 def _int_from_snapshot(snapshot, setting_id, default, lo, hi):
-    """Return a clamped int setting from a snapshot. Side-effect free: any parse
-    failure falls back to ``default`` (never calls Kodi)."""
+    """Return a clamped int setting from a snapshot. Does not read Kodi
+    settings: any parse failure falls back to ``default`` (an out-of-range value
+    is still clamped via ``_clamp_int_setting``, which logs a warning)."""
     raw = snapshot.get(setting_id) if isinstance(snapshot, dict) else None
     try:
         value = int(raw) if raw not in (None, "") else default

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -146,6 +146,26 @@ _MAX_RECOVERY_SECONDS = 30
 # Cap zero-filled bytes per response to prevent runaway silent playback when
 # an NZB is mostly corrupt. 64 MB ≈ several seconds of 4K REMUX video.
 _MAX_TOTAL_ZERO_FILL = 67108864
+# Patient forward-stall wait (pass-through). When an ESTABLISHED forward stream
+# (real upstream bytes already delivered this request) stalls on a RECOVERABLE
+# backend condition — a still-downloading high-water short read
+# (AWAITING_DOWNLOAD) or a transient 5xx/connection error (UPSTREAM_ERROR) — the
+# session breaker (upstream_down_notified) has short-circuited BOTH the retry
+# ladder and the skip-probe to instant give-up, so the loop would close in ms
+# and Kodi reads the premature Connection: close as demuxer EOF (the live 4K
+# REMUX mid-stream black screen). Instead, keep the CLIENT connection OPEN and
+# re-read with abortable backoff up to this budget so a recovering backend
+# resumes. A monotonic stall clock resets on ANY genuine forward byte, so a
+# healthy still-downloading stream is never condemned; only a TRULY-stuck stream
+# exhausts the budget and then falls through to the existing give-up paths. Bound
+# it at/under Kodi's network curllowspeedtime so Kodi buffers through the wait
+# rather than tearing down and stranding this handler as a zombie. 0 disables the
+# wait (restores the prior instant-close behavior). Does NOT apply to
+# SHORT_READ_RECOVERABLE (genuinely-missing articles must zero-fill past) nor to
+# a byte-0 first read / fresh seek that never streamed (issue #214 fast-fail).
+_DEFAULT_PASSTHROUGH_STALL_WAIT_SECONDS = 120
+_PASSTHROUGH_STALL_WAIT_MAX_SECONDS = 600
+_PASSTHROUGH_STALL_WAIT_BACKOFF_SECONDS = 2.0
 # Density breaker: abort if the recent recovery window becomes mostly synthetic
 # data instead of real upstream bytes.
 _DENSITY_BREAKER_WINDOW_BYTES = 16 * 1024 * 1024
@@ -662,6 +682,17 @@ def _bool_from_snapshot(snapshot, setting_id, default=False):
     return str(raw).strip().lower() in ("1", "true", "yes", "on")
 
 
+def _int_from_snapshot(snapshot, setting_id, default, lo, hi):
+    """Return a clamped int setting from a snapshot. Side-effect free: any parse
+    failure falls back to ``default`` (never calls Kodi)."""
+    raw = snapshot.get(setting_id) if isinstance(snapshot, dict) else None
+    try:
+        value = int(raw) if raw not in (None, "") else default
+    except (TypeError, ValueError):
+        value = default
+    return _clamp_int_setting(setting_id, value, lo, hi)
+
+
 def _strict_contract_mode_from_snapshot(snapshot):
     raw = snapshot.get("strict_contract_mode") if isinstance(snapshot, dict) else None
     key = str(raw).strip().lower() if raw is not None else ""
@@ -726,6 +757,13 @@ def _passthrough_runtime_settings_from_snapshot(snapshot):
         ),
         "send_200_no_range_enabled": _bool_from_snapshot(
             snapshot, "send_200_no_range", default=False
+        ),
+        "passthrough_stall_wait_seconds": _int_from_snapshot(
+            snapshot,
+            "passthrough_stall_wait",
+            _DEFAULT_PASSTHROUGH_STALL_WAIT_SECONDS,
+            0,
+            _PASSTHROUGH_STALL_WAIT_MAX_SECONDS,
         ),
     }
 
@@ -823,6 +861,22 @@ def _send_200_no_range_enabled():
     return _get_bool_setting("send_200_no_range", default=False)
 
 
+def _get_passthrough_stall_wait_seconds():
+    """Return the patient forward-stall budget in seconds, clamped [0, 600]."""
+    raw = _get_addon_setting("passthrough_stall_wait")
+    try:
+        secs = (
+            int(raw)
+            if raw not in (None, "")
+            else _DEFAULT_PASSTHROUGH_STALL_WAIT_SECONDS
+        )
+    except (TypeError, ValueError):
+        secs = _DEFAULT_PASSTHROUGH_STALL_WAIT_SECONDS
+    return _clamp_int_setting(
+        "passthrough_stall_wait", secs, 0, _PASSTHROUGH_STALL_WAIT_MAX_SECONDS
+    )
+
+
 def _read_passthrough_runtime_settings():
     """Read per-session pass-through recovery settings once."""
     contract_mode = _get_strict_contract_mode()
@@ -832,6 +886,7 @@ def _read_passthrough_runtime_settings():
         "zero_fill_budget_enabled": _zero_fill_budget_enabled(),
         "retry_ladder_enabled": _retry_ladder_enabled(),
         "send_200_no_range_enabled": _send_200_no_range_enabled(),
+        "passthrough_stall_wait_seconds": _get_passthrough_stall_wait_seconds(),
     }
 
 
@@ -4617,6 +4672,16 @@ class _StreamHandler(BaseHTTPRequestHandler):
             # first-byte retry schedule keys on this (not ``current``) to tell a
             # genuine first content read from a mid-stream rebuffer.
             streamed_real_upstream_bytes = False
+            # Patient forward-stall clock: monotonic time when an ESTABLISHED
+            # stream first stalled with NO forward progress (None while it is
+            # advancing; set on the first stalled pass and CLEARED on any genuine
+            # streamed byte below). The budget is consumed only by a truly-stuck
+            # stream, never by a slow-but-healthy one.
+            forward_stall_t0 = None
+            stall_wait_budget = runtime_settings.get(
+                "passthrough_stall_wait_seconds",
+                _DEFAULT_PASSTHROUGH_STALL_WAIT_SECONDS,
+            )
 
             while current <= end:
                 result, written = self._stream_upstream_range(
@@ -4802,6 +4867,10 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     # fruitless read starts from a fresh budget, not a stale count.
                     fallback_pending_fallthroughs = 0
                     last_fallthrough_streamed = -1
+                    # Genuine forward progress — drop the patient-stall clock so a
+                    # healthy still-downloading stream never consumes the wait
+                    # budget (only CONSECUTIVE no-progress time is counted).
+                    forward_stall_t0 = None
                 else:
                     awaiting_download_no_progress = self._bump_awaiting_no_progress(
                         ctx, result, awaiting_download_no_progress
@@ -4839,6 +4908,74 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     )
                     candidate_delivered = False
                     continue
+
+                # PATIENT FORWARD-STALL WAIT. An ESTABLISHED forward stream (real
+                # bytes already delivered) that stalls on a RECOVERABLE backend
+                # condition must NOT close on the spot: the session breaker
+                # (upstream_down_notified) short-circuited the retry ladder and
+                # skip-probe to instant give-up, so without this we hit the F4
+                # cap-fire or the recovery_exhausted close in ms and Kodi reads
+                # the premature Connection: close as demuxer EOF (the live 4K
+                # REMUX black screen). Hold the client connection open and re-read
+                # with abortable backoff until the budget elapses, then fall
+                # through to the existing give-up paths below. forward_stall_t0
+                # resets on genuine progress (above), so a healthy
+                # still-downloading stream never trips this; only a truly-stuck
+                # one exhausts the budget. Scope: established only
+                # (streamed_real_upstream_bytes) so a byte-0 first read / fresh
+                # never-streamed seek keep the issue-#214 fast-fail; and
+                # AWAITING_DOWNLOAD / UPSTREAM_ERROR only, so SHORT_READ_RECOVERABLE
+                # (genuinely-missing articles) still zero-fills past below. Runs
+                # AFTER the fallback cutover routes, so a validated alternate is
+                # always preferred over waiting.
+                if (
+                    stall_wait_budget > 0
+                    and streamed_real_upstream_bytes
+                    and current <= end
+                    and result
+                    in (
+                        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+                        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+                    )
+                ):
+                    now = time.monotonic()
+                    if forward_stall_t0 is None:
+                        forward_stall_t0 = now
+                    if now - forward_stall_t0 < stall_wait_budget:
+                        xbmc.log(
+                            "NZB-DAV: Established forward stream stalled at byte "
+                            "{} (result={}); holding client open and re-reading "
+                            "(elapsed={:.0f}s/{}s, reason=patient_forward_stall)".format(
+                                current,
+                                result,
+                                now - forward_stall_t0,
+                                stall_wait_budget,
+                            ),
+                            xbmc.LOGINFO,
+                        )
+                        # Abortable: a Kodi shutdown / session stop breaks the
+                        # wait immediately so the budget never blocks teardown.
+                        if xbmc.Monitor().waitForAbort(
+                            _PASSTHROUGH_STALL_WAIT_BACKOFF_SECONDS
+                        ):
+                            return
+                        # Reset the throughput watchdog window so the stale
+                        # pre-wait sample can't trip a spurious stall on the first
+                        # post-recovery read.
+                        ctx["passthrough_window_t0"] = time.monotonic()
+                        ctx["passthrough_window_bytes"] = 0
+                        continue
+                    # Budget exhausted: genuinely stuck. Fall through to the
+                    # existing F4 cap-fire / skip-probe give-up so the close is
+                    # reported through the established taxonomy (no new exit path).
+                    xbmc.log(
+                        "NZB-DAV: Patient forward-stall budget exhausted at byte "
+                        "{} after {}s with no progress (result={}); giving up "
+                        "(reason=patient_forward_stall_exhausted)".format(
+                            current, stall_wait_budget, result
+                        ),
+                        xbmc.LOGWARNING,
+                    )
 
                 # BOUNDED EXHAUSTION (F4) cap-fire: now that the retry ladder
                 # has run AND the progress-reset above has cleared the count on

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -3294,6 +3294,12 @@ class _StreamHandler(BaseHTTPRequestHandler):
         # session start; it only re-enters the pool here, after a real cutover to
         # a different source. It carries a resolved stream_url, so no nzo
         # re-resolution is needed; the byte-identity gate still guards serving.
+        #
+        # Mark it validated: this source was just actively serving these exact
+        # bytes, so it is content-identical by construction. Without the flag the
+        # prevalidation warmer would treat it as a fresh source and re-fingerprint
+        # it (an extra upstream open of a peer we already trust); validated=True
+        # skips that while leaving it selectable as a last resort.
         demoted_url = ctx.get("remote_url")
         if demoted_url and demoted_url != fallback.get("stream_url"):
             sources = ctx.setdefault("fallback_sources", [])
@@ -3310,6 +3316,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         ),
                         "content_length": ctx.get("content_length", 0) or 0,
                         "demoted": True,
+                        "validated": True,
                     }
                 )
         ctx["remote_url"] = fallback["stream_url"]

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -371,6 +371,35 @@ _TAIL_PREWARM_BYTES = 1048576
 # the defer cancels the prewarm cleanly (no wasted connection) instead of
 # blocking the daemon thread.
 _TAIL_PREWARM_DEFER_SECONDS = 1.5
+# Per-session forward read-ahead prefetch cache. A bounded contiguous in-memory
+# window is filled by a daemon thread that reads sequentially AHEAD of the
+# highest-served offset using the existing upstream-fetch primitive, throttling
+# when full and freeing consumed bytes behind the play head — so it keeps filling
+# WHILE Kodi is paused, letting a pause build a real lead. The serve path
+# consults the window FIRST; on a miss it falls through to today's untouched
+# upstream-read / retry-ladder / patient-forward-stall / fallback-cutover /
+# 404-awaiting path. Gated by readahead_buffer_mb (default 256, 0=off). When
+# disabled or on any miss, behavior is byte-for-byte identical to today.
+_READAHEAD_BUFFER_KEY = "_readahead_buffer"
+_READAHEAD_THREAD_KEY = "_readahead_thread"
+_DEFAULT_READAHEAD_BUFFER_MB = 256
+_READAHEAD_BUFFER_MB_MAX = 4096
+# Reuse the 64KB upstream chunk for heap-friendliness (the MemoryError class on
+# 32-bit/CoreELEC was fixed by small chunked reads).
+_READAHEAD_FETCH_CHUNK = _UPSTREAM_READ_CHUNK
+# Abortable wait when the window is full (keeps it filling while paused yet
+# bounded — resumes as the served offset advances and frees room).
+_READAHEAD_THROTTLE_BACKOFF_SECONDS = 0.25
+# Abortable wait after a best-effort upstream error (prefetch is best-effort and
+# the real serve path owns recovery — this never trips the user-facing taxonomy).
+_READAHEAD_ERROR_BACKOFF_SECONDS = 1.0
+# Hold the read-ahead's FIRST upstream read back a short, abortable beat so the
+# byte-0 prefetch and Kodi's initial range fetch win nzbdav's connection budget
+# first — the read-ahead must never widen the mid-startup stall window the byte-0
+# prefetch / tail prewarm exist to close (transient black-screen). The lead is
+# rebuilt steadily after startup. waitForAbort lets a Kodi shutdown / session
+# stop during the defer cancel the prefetch cleanly.
+_READAHEAD_START_DEFER_SECONDS = 1.5
 _PASSTHROUGH_RUNTIME_SETTINGS_KEY = "_passthrough_runtime_settings"
 _PASSTHROUGH_RUNTIME_SETTINGS_DONE_KEY = "_passthrough_runtime_settings_done"
 _PASSTHROUGH_RUNTIME_SETTINGS_ERROR_KEY = "_passthrough_runtime_settings_error"
@@ -384,7 +413,137 @@ _SETTINGS_SNAPSHOT_KEYS = (
     "retry_ladder_enabled",
     "send_200_no_range",
     "proxy_convert_subs",
+    "readahead_buffer_mb",
 )
+
+
+class ReadAheadBuffer:
+    """A per-session bounded contiguous forward read-ahead window.
+
+    Holds a single contiguous run of bytes ``data`` starting at
+    ``base_offset`` (the first buffered byte). A daemon prefetch thread
+    appends bytes strictly contiguous-forward; the serve path reads the
+    contiguous prefix starting exactly at the requested offset and frees
+    bytes behind the play head. The window never grows past ``cap_bytes``
+    nor past ``content_length``. A SEEK outside the window discards the
+    stale data and repoints ``base_offset`` so the prefetch thread refills
+    from the seek target. All mutation is guarded by a short lock so the
+    serve path never blocks on the prefetch thread for long.
+    """
+
+    def __init__(self, cap_bytes, content_length):
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        try:
+            self.cap_bytes = max(0, int(cap_bytes or 0))
+        except (TypeError, ValueError):
+            self.cap_bytes = 0
+        try:
+            self.content_length = max(0, int(content_length or 0))
+        except (TypeError, ValueError):
+            self.content_length = 0
+        self.base_offset = 0
+        self.data = bytearray()
+        self.served_high_water = 0
+
+    def read_prefix(self, start, end):
+        """Return the contiguous bytes the window holds starting exactly at
+        ``start`` (b'' on miss/gap/seek-mismatch), capped to ``end`` and to
+        what is present. The strict ``start == base_offset`` invariant means a
+        stale window can never feed wrong-offset bytes to Kodi after a seek."""
+        if not isinstance(start, int) or not isinstance(end, int):
+            return b""
+        if end < start:
+            return b""
+        with self._lock:
+            if not self.data or start != self.base_offset:
+                return b""
+            want = end - start + 1
+            return bytes(self.data[:want])
+
+    def append(self, offset, chunk):
+        """Add ``chunk`` only if it is strictly contiguous-forward (``offset``
+        == base_offset+len(data)). Truncates at ``cap_bytes`` and at
+        ``content_length``. Returns True when any bytes were stored."""
+        if not chunk:
+            return False
+        with self._lock:
+            expected = self.base_offset + len(self.data)
+            if offset != expected:
+                return False
+            room = self.cap_bytes - len(self.data)
+            if room <= 0:
+                return False
+            eof_room = self.content_length - expected
+            if eof_room <= 0:
+                return False
+            limit = min(room, eof_room, len(chunk))
+            if limit <= 0:
+                return False
+            self.data.extend(chunk[:limit])
+            return True
+
+    def free_behind(self, served_offset):
+        """Drop bytes before ``served_offset`` and advance ``base_offset``.
+        A no-op when ``served_offset`` is at or behind the current base."""
+        try:
+            served_offset = int(served_offset)
+        except (TypeError, ValueError):
+            return
+        with self._lock:
+            drop = served_offset - self.base_offset
+            if drop <= 0:
+                return
+            drop = min(drop, len(self.data))
+            del self.data[:drop]
+            self.base_offset += drop
+
+    def update_served_high_water(self, offset):
+        """Record the highest offset delivered to the client."""
+        try:
+            offset = int(offset)
+        except (TypeError, ValueError):
+            return
+        with self._lock:
+            self.served_high_water = max(self.served_high_water, offset)
+
+    def note_seek(self, new_start):
+        """Repoint the window on a seek OUTSIDE the buffered range.
+
+        In-window seeks leave the data intact (the read_prefix consult plus
+        free_behind naturally consume the now-behind bytes). An out-of-window
+        seek (forward past the lead or any backward seek) discards the data and
+        sets ``base_offset`` to the seek target so the prefetch thread refills
+        forward. Never blocks the seek — a cheap lock-protected pointer reset."""
+        if not isinstance(new_start, int) or new_start < 0:
+            return
+        with self._lock:
+            window_end = self.base_offset + len(self.data)
+            if self.base_offset <= new_start <= window_end:
+                return
+            self.data = bytearray()
+            self.base_offset = new_start
+            self.served_high_water = max(self.served_high_water, new_start)
+
+    def space_remaining(self):
+        with self._lock:
+            remaining = self.cap_bytes - len(self.data)
+        return remaining if remaining > 0 else 0
+
+    def next_fetch_offset(self):
+        with self._lock:
+            return self.base_offset + len(self.data)
+
+    def is_full(self):
+        with self._lock:
+            return len(self.data) >= self.cap_bytes
+
+    def stop(self):
+        self._stop.set()
+
+    def should_stop(self):
+        return self._stop.is_set()
+
 
 # Shared zero buffer reused across all pass-through responses.
 _ZERO_FILL_BUFFER = bytes(65536)
@@ -766,6 +925,13 @@ def _passthrough_runtime_settings_from_snapshot(snapshot):
             0,
             _PASSTHROUGH_STALL_WAIT_MAX_SECONDS,
         ),
+        "readahead_buffer_mb": _int_from_snapshot(
+            snapshot,
+            "readahead_buffer_mb",
+            _DEFAULT_READAHEAD_BUFFER_MB,
+            0,
+            _READAHEAD_BUFFER_MB_MAX,
+        ),
     }
 
 
@@ -878,6 +1044,20 @@ def _get_passthrough_stall_wait_seconds():
     )
 
 
+def _get_readahead_buffer_mb():
+    """Return the read-ahead prefetch buffer size in MB, clamped [0, MAX].
+
+    0 disables the read-ahead layer (no buffer, no thread) so behavior is
+    byte-for-byte identical to today.
+    """
+    raw = _get_addon_setting("readahead_buffer_mb")
+    try:
+        mb = int(raw) if raw not in (None, "") else _DEFAULT_READAHEAD_BUFFER_MB
+    except (TypeError, ValueError):
+        mb = _DEFAULT_READAHEAD_BUFFER_MB
+    return _clamp_int_setting("readahead_buffer_mb", mb, 0, _READAHEAD_BUFFER_MB_MAX)
+
+
 def _read_passthrough_runtime_settings():
     """Read per-session pass-through recovery settings once."""
     contract_mode = _get_strict_contract_mode()
@@ -888,6 +1068,7 @@ def _read_passthrough_runtime_settings():
         "retry_ladder_enabled": _retry_ladder_enabled(),
         "send_200_no_range_enabled": _send_200_no_range_enabled(),
         "passthrough_stall_wait_seconds": _get_passthrough_stall_wait_seconds(),
+        "readahead_buffer_mb": _get_readahead_buffer_mb(),
     }
 
 
@@ -4536,6 +4717,14 @@ class _StreamHandler(BaseHTTPRequestHandler):
         else:
             start, end = 0, content_length - 1
 
+        # Notify the read-ahead window of the requested start so a SEEK to a
+        # position outside the buffered window discards the stale window and
+        # repoints the prefetch base (does not block the seek). A no-op when the
+        # read-ahead layer is disabled (no buffer on ctx).
+        readahead_buffer = ctx.get(_READAHEAD_BUFFER_KEY)
+        if readahead_buffer is not None:
+            readahead_buffer.note_seek(start)
+
         total_bytes = end - start + 1
         runtime_settings = None
         no_range_status = False
@@ -5316,6 +5505,31 @@ class _StreamHandler(BaseHTTPRequestHandler):
 
         return last_result, total_written, current
 
+    def _serve_from_readahead(self, ctx, start, end):
+        """Write the contiguous read-ahead prefix at ``start`` to the client.
+
+        Returns the number of bytes written directly from the in-RAM window
+        (0 on miss / no buffer). On a hit the served bytes are freed behind the
+        play head and the served high-water is bumped (enabling free-behind so
+        the prefetch thread reclaims room and advances its base). On a miss the
+        caller falls through to today's untouched upstream-read path.
+
+        BrokenPipeError / ConnectionResetError from wfile.write propagate
+        exactly like the existing cached-prefix write so _serve_proxy's outer
+        except still classifies a client disconnect.
+        """
+        buf = ctx.get(_READAHEAD_BUFFER_KEY) if isinstance(ctx, dict) else None
+        if buf is None:
+            return 0
+        body = buf.read_prefix(start, end)
+        if not body:
+            return 0
+        self.wfile.write(body)
+        served_to = start + len(body)
+        buf.free_behind(served_to)
+        buf.update_served_high_water(served_to)
+        return len(body)
+
     def _stream_upstream_range(self, ctx, start, end, contract_mode=None):
         """Stream bytes from upstream to the client.
 
@@ -5335,6 +5549,21 @@ class _StreamHandler(BaseHTTPRequestHandler):
             return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0
         requested_start = start
         written = 0
+        # Read-ahead consult (additive, FIRST): serve the contiguous in-RAM
+        # prefix the prefetch daemon built ahead of the play head. On a hit,
+        # advance start/written; on a partial/empty result fall straight through
+        # to today's untouched upstream-read / retry-ladder / patient-stall /
+        # fallback-cutover / 404-awaiting path below. When the setting is 0 there
+        # is no buffer on ctx, so this returns 0 immediately (identical to
+        # today). The window only ever satisfies a contiguous-forward prefix, so
+        # every existing branch keyed on result/written sees identical inputs on
+        # the miss path.
+        prefix_from_window = self._serve_from_readahead(ctx, start, end)
+        if prefix_from_window:
+            written += prefix_from_window
+            start += prefix_from_window
+            if start > end:
+                return _UPSTREAM_RANGE_OK, written
         cached_prefix = self._pop_cached_fallback_range(ctx, start, end)
         wait_consumed = bool(ctx.pop("_initial_range_prefetch_wait_consumed", False))
         if not cached_prefix and not wait_consumed:
@@ -7013,6 +7242,15 @@ class StreamProxy:
     @staticmethod
     def _cleanup_session(ctx, wait_for_process=True):
         """Release resources associated with a stream session."""
+        # Signal the read-ahead prefetch daemon to stop (per-session close; the
+        # thread is daemon and also aborts on waitForAbort for global shutdown).
+        # This is the single sink reached by every close route, so all sessions
+        # are covered. Never block teardown on the thread — daemon is the
+        # backstop.
+        readahead_buffer = ctx.get(_READAHEAD_BUFFER_KEY)
+        if readahead_buffer is not None:
+            readahead_buffer.stop()
+
         active_ffmpeg = ctx.get("active_ffmpeg")
         if active_ffmpeg:
             try:
@@ -7440,6 +7678,115 @@ class StreamProxy:
             thread.start()
         except RuntimeError:
             ctx.pop("_initial_range_prefetch_thread", None)
+
+    def _run_readahead_prefetch(self, ctx):
+        """Daemon target: fill the read-ahead window forward of the play head.
+
+        Reads sequentially AHEAD of the highest-served offset in 64KB chunks
+        using the same upstream-fetch primitive the serve path uses, throttles
+        when the window is full (so it keeps filling WHILE PAUSED yet bounded),
+        and resumes as free-behind reclaims room. Best-effort: a prefetch
+        upstream error simply backs off and retries WITHOUT tearing down
+        playback or tripping the user-facing recovery taxonomy / notifications /
+        session counters. NEVER raises into anything.
+        """
+        buf = ctx.get(_READAHEAD_BUFFER_KEY) if isinstance(ctx, dict) else None
+        if buf is None:
+            return
+        monitor = xbmc.Monitor()
+        try:
+            content_length = int(ctx.get("content_length", 0) or 0)
+        except (TypeError, ValueError):
+            return
+        remote_url = ctx.get("remote_url")
+        auth_header = ctx.get("auth_header")
+        if not remote_url or content_length <= 0:
+            return
+        # Yield to startup: let the byte-0 prefetch and Kodi's first range fetch
+        # win nzbdav's connection budget before the read-ahead issues its first
+        # upstream read. Abortable so a shutdown during the defer exits cleanly.
+        if buf.should_stop() or monitor.waitForAbort(_READAHEAD_START_DEFER_SECONDS):
+            return
+        while not buf.should_stop() and not monitor.waitForAbort(0):
+            try:
+                fetch_offset = buf.next_fetch_offset()
+                if fetch_offset >= content_length:
+                    # Lead is fully built to EOF; nothing left to prefetch.
+                    return
+                if buf.is_full():
+                    # Throttle: wait (abortably) for free-behind to reclaim room
+                    # as the play head advances. This is what keeps the buffer
+                    # filling while paused yet strictly bounded.
+                    if monitor.waitForAbort(_READAHEAD_THROTTLE_BACKOFF_SECONDS):
+                        return
+                    continue
+                want = min(
+                    _READAHEAD_FETCH_CHUNK,
+                    buf.space_remaining(),
+                    content_length - fetch_offset,
+                )
+                if want <= 0:
+                    if monitor.waitForAbort(_READAHEAD_THROTTLE_BACKOFF_SECONDS):
+                        return
+                    continue
+                end = fetch_offset + want - 1
+                body = _StreamHandler._fetch_primary_range_bytes(
+                    remote_url, auth_header, fetch_offset, end, content_length
+                )
+                if not body:
+                    # Best-effort upstream error or awaiting-download: back off
+                    # and retry. The real serve path owns recovery; do not touch
+                    # the recovery taxonomy / notifications / counters here.
+                    if monitor.waitForAbort(_READAHEAD_ERROR_BACKOFF_SECONDS):
+                        return
+                    continue
+                buf.append(fetch_offset, body)
+            except Exception as exc:  # pylint: disable=broad-except
+                xbmc.log(
+                    "NZB-DAV: Read-ahead prefetch loop error: {}".format(exc),
+                    xbmc.LOGDEBUG,
+                )
+                if monitor.waitForAbort(_READAHEAD_ERROR_BACKOFF_SECONDS):
+                    return
+
+    def _start_readahead_prefetch(self, ctx):
+        """Spawn the per-session read-ahead prefetch daemon (gated + soft).
+
+        Gated on the same passthrough-only guard as the byte-0 prefetch AND on
+        readahead_buffer_mb>0 (read from the prefetched settings snapshot, never
+        a per-request getSetting). RuntimeError-tolerant start matching the
+        sibling prefetch spawns.
+        """
+        if not self._initial_range_prefetchable(ctx):
+            return
+        settings = _passthrough_runtime_settings(ctx)
+        try:
+            mb = int(settings.get("readahead_buffer_mb", 0) or 0)
+        except (TypeError, ValueError):
+            mb = 0
+        if mb <= 0:
+            return
+        try:
+            content_length = int(ctx.get("content_length", 0) or 0)
+        except (TypeError, ValueError):
+            return
+        if content_length <= 0:
+            return
+        cap_bytes = mb * 1024 * 1024
+        buf = ReadAheadBuffer(cap_bytes, content_length)
+        ctx[_READAHEAD_BUFFER_KEY] = buf
+        thread = threading.Thread(
+            target=self._run_readahead_prefetch,
+            args=(ctx,),
+            name="nzbdav-readahead",
+        )
+        thread.daemon = True
+        ctx[_READAHEAD_THREAD_KEY] = thread
+        try:
+            thread.start()
+        except RuntimeError:
+            ctx.pop(_READAHEAD_THREAD_KEY, None)
+            ctx.pop(_READAHEAD_BUFFER_KEY, None)
 
     def _prewarm_tail_range(self, ctx):
         """Warm nzbdav's FILE-TAIL article cache (MKV cues) for instant startup.
@@ -8001,6 +8348,7 @@ class StreamProxy:
             )
         self._start_passthrough_runtime_settings_prefetch(ctx)
         self._start_initial_range_prefetch(ctx)
+        self._start_readahead_prefetch(ctx)
         self._start_tail_prewarm(ctx)
         self._start_fallback_prevalidation(ctx)
 

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -4518,11 +4518,20 @@ class _StreamHandler(BaseHTTPRequestHandler):
             zero_fill_budget_enabled = runtime_settings["zero_fill_budget_enabled"]
             retry_ladder_enabled = runtime_settings["retry_ladder_enabled"]
 
+            # Whether any REAL upstream bytes have been delivered in this request
+            # yet. The byte-0 prefetch prefix is served instantly from cache and
+            # advances ``current`` WITHOUT counting as buffered playback, so the
+            # first-byte retry schedule keys on this (not ``current``) to tell a
+            # genuine first content read from a mid-stream rebuffer.
+            streamed_real_upstream_bytes = False
+
             while current <= end:
                 result, written = self._stream_upstream_range(
                     active_ctx, current, end, contract_mode=contract_mode
                 )
                 total_streamed += written
+                if written:
+                    streamed_real_upstream_bytes = True
                 _update_session_recovery_state(self.server, ctx, streamed=written)
                 _record_density_window(density_window, "progress", written)
                 current += written
@@ -4649,16 +4658,23 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         current,
                         end,
                         contract_mode,
-                        # Key on the ABSOLUTE file offset, not total_streamed:
-                        # Kodi forces Connection: close, so every mid-file seek
-                        # is a fresh request with total_streamed=0. Only a
-                        # genuine byte-0 open (where the player's first-read
-                        # patience is short) takes the short schedule; a
-                        # mid-file AWAITING_DOWNLOAD keeps the long
-                        # wait-on-primary ladder.
-                        first_byte=(current == 0),
+                        # The player's first content read takes the SHORT,
+                        # first-read-patient schedule; a mid-stream rebuffer keeps
+                        # the long wait-on-primary ladder (58f3d4f). "First read"
+                        # = a front-of-file open (start == 0) on which no REAL
+                        # upstream bytes have streamed yet. We must NOT key on
+                        # ``current`` alone: a byte-0 open serves its cached ~64KB
+                        # prefetch prefix first, advancing ``current`` to 65536
+                        # before this ladder runs, so ``current == 0`` wrongly
+                        # took the long ladder for the genuine first content read
+                        # (Interstellar 64KB-then-EOF). Nor on ``start`` alone:
+                        # once real bytes have streamed from byte 0, a later stall
+                        # is a mid-stream rebuffer and must keep the long ladder.
+                        first_byte=(start == 0 and not streamed_real_upstream_bytes),
                     )
                     total_streamed += retry_written
+                    if retry_written:
+                        streamed_real_upstream_bytes = True
                     _update_session_recovery_state(
                         self.server, ctx, streamed=retry_written
                     )

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -1160,6 +1160,11 @@ _STARVATION_TERMINAL_REASONS = (
     "fallback_exhausted",
     "session_zero_fill_budget_exceeded",
 )
+# How recently (seconds) an upstream outage must have occurred, relative to the
+# stream ending, for a client_disconnected end to count as backend starvation
+# rather than a healthy user stop. Catches the live incident (upstream blipped
+# back ~9s before Kodi gave up) without firing on a long-recovered early blip.
+_STARVATION_RECENT_OUTAGE_SECONDS = 60
 
 
 def _maybe_notify_stream_starvation(
@@ -1185,8 +1190,23 @@ def _maybe_notify_stream_starvation(
     """
     if terminal_reason == "complete":
         return False
-    upstream_trouble = int(ctx.get("upstream_unreachable_count", 0) or 0) > 0
-    if not (upstream_trouble or terminal_reason in _STARVATION_TERMINAL_REASONS):
+    # The backend (not a healthy stop) ended this stream when an explicit stall
+    # terminal reason fired, OR the upstream is still flagged down, OR an outage
+    # happened very recently. The RECENCY window matters because
+    # ``upstream_unreachable_count`` is a sticky running total and
+    # ``last_upstream_unreachable_at`` can predate a long healthy stretch the
+    # user then stopped — that must NOT fire. It also catches the live incident,
+    # where the upstream momentarily "recovered" a few seconds before Kodi gave
+    # up and disconnected (so a recovered-vs-unreachable ordering check alone
+    # would wrongly stay silent).
+    down_now = bool(ctx.get("upstream_down_notified"))
+    last_down = float(ctx.get("last_upstream_unreachable_at", 0) or 0)
+    recent_outage = (
+        last_down > 0 and (time.time() - last_down) <= _STARVATION_RECENT_OUTAGE_SECONDS
+    )
+    if not (
+        terminal_reason in _STARVATION_TERMINAL_REASONS or down_now or recent_outage
+    ):
         return False
     # Only when the stream was genuinely starved — it did NOT deliver the full
     # requested range. A fully-delivered stream the user happened to stop is

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -4732,7 +4732,18 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 # fallback_exhausted instead of looping — WITHOUT reintroducing
                 # e3a74a1's immediate hard-close. A recovering primary's count
                 # is 0 here (the SM-1 reset fired), so this won't condemn it.
-                if fallback_pending_fallthroughs >= _FALLBACK_PENDING_FALLTHROUGH_MAX:
+                # Guard: when the final ladder attempt returned a terminal
+                # 401/403/contract-mismatch, fall through to the
+                # CLIENT_ERROR/PROTOCOL_MISMATCH branch below so the real root
+                # cause is surfaced instead of being masked as fallback_exhausted.
+                if (
+                    fallback_pending_fallthroughs >= _FALLBACK_PENDING_FALLTHROUGH_MAX
+                    and result
+                    not in (
+                        _UPSTREAM_RANGE_CLIENT_ERROR,
+                        _UPSTREAM_RANGE_PROTOCOL_MISMATCH,
+                    )
+                ):
                     terminal_reason = "fallback_exhausted"
                     xbmc.log(
                         "NZB-DAV: Fallback chain exhausted at byte {} "

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -2925,15 +2925,17 @@ class _StreamHandler(BaseHTTPRequestHandler):
         """Advance the session-persistent no-progress AWAITING_DOWNLOAD count.
 
         Only a clean download-high-water short read (AWAITING_DOWNLOAD) that
-        delivered nothing advances the streak; any other result leaves it
-        unchanged. The count lives in ctx so it survives Kodi's
-        Connection: close reconnects (a dead region reads as a clean short
-        read on every fresh GET). See F-route.
+        delivered nothing advances the streak; any other result resets it to 0
+        (keeping the streak strictly consecutive AWAITING reads). The count
+        lives in ctx so it survives Kodi's Connection: close reconnects (a dead
+        region reads as a clean short read on every fresh GET). See F-route.
         """
         if result == _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD:
             current_count += 1
             ctx["_awaiting_download_no_progress"] = current_count
-        return current_count
+            return current_count
+        ctx["_awaiting_download_no_progress"] = 0
+        return 0
 
     def _activate_fallback_source(self, ctx, fallback, current, stuck_awaiting=False):
         """Point the session at a selected fallback source for live cutover.
@@ -4601,32 +4603,19 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         # (zero-fill "progress" is black frames, not recovery, so
                         # it must NOT reset the bound). Any genuine streamed byte
                         # since the last fall-through resets the count, so a
-                        # recovering primary is never penalised. Once the cap is
-                        # hit with still no validated candidate, close cleanly
-                        # with fallback_exhausted instead of looping — WITHOUT
-                        # reintroducing e3a74a1's immediate hard-close.
+                        # recovering primary is never penalised. The cap-fire
+                        # check itself now runs AFTER the retry ladder + the
+                        # progress-reset below, so the primary gets its FINAL
+                        # ladder attempt spent before fallback_exhausted is
+                        # declared (matching the no-fallback path, which always
+                        # runs the ladder); when it finally fires it closes
+                        # cleanly with fallback_exhausted instead of looping —
+                        # WITHOUT reintroducing e3a74a1's immediate hard-close.
                         if total_streamed == last_fallthrough_streamed:
                             fallback_pending_fallthroughs += 1
                         else:
                             fallback_pending_fallthroughs = 1
                             last_fallthrough_streamed = total_streamed
-                        if (
-                            fallback_pending_fallthroughs
-                            >= _FALLBACK_PENDING_FALLTHROUGH_MAX
-                        ):
-                            terminal_reason = "fallback_exhausted"
-                            xbmc.log(
-                                "NZB-DAV: Fallback chain exhausted at byte {} "
-                                "after {} fruitless cutover re-entries with no "
-                                "validated source and no primary progress; "
-                                "closing cleanly (reason={})".format(
-                                    current,
-                                    fallback_pending_fallthroughs,
-                                    terminal_reason,
-                                ),
-                                xbmc.LOGERROR,
-                            )
-                            return
                         xbmc.log(
                             "NZB-DAV: No validated fallback source available at "
                             "byte {}; re-entering retry ladder on the primary "
@@ -4706,7 +4695,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     and current <= end
                     and result == _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD
                     and awaiting_download_no_progress
-                    > _AWAITING_DOWNLOAD_NO_PROGRESS_MAX
+                    >= _AWAITING_DOWNLOAD_NO_PROGRESS_MAX
                     and ctx.get("fallback_sources")
                 )
                 awaiting_fallback = (
@@ -4734,6 +4723,29 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     )
                     candidate_delivered = False
                     continue
+
+                # BOUNDED EXHAUSTION (F4) cap-fire: now that the retry ladder
+                # has run AND the progress-reset above has cleared the count on
+                # any genuine byte, a still-positive fall-through count at the
+                # cap means the primary spent its final ladder attempt with no
+                # recovery and no validated candidate. Close cleanly with
+                # fallback_exhausted instead of looping — WITHOUT reintroducing
+                # e3a74a1's immediate hard-close. A recovering primary's count
+                # is 0 here (the SM-1 reset fired), so this won't condemn it.
+                if fallback_pending_fallthroughs >= _FALLBACK_PENDING_FALLTHROUGH_MAX:
+                    terminal_reason = "fallback_exhausted"
+                    xbmc.log(
+                        "NZB-DAV: Fallback chain exhausted at byte {} "
+                        "after {} fruitless cutover re-entries with no "
+                        "validated source and no primary progress; "
+                        "closing cleanly (reason={})".format(
+                            current,
+                            fallback_pending_fallthroughs,
+                            terminal_reason,
+                        ),
+                        xbmc.LOGERROR,
+                    )
+                    return
 
                 if result in (
                     _UPSTREAM_RANGE_CLIENT_ERROR,

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -7698,9 +7698,7 @@ class StreamProxy:
             content_length = int(ctx.get("content_length", 0) or 0)
         except (TypeError, ValueError):
             return
-        remote_url = ctx.get("remote_url")
-        auth_header = ctx.get("auth_header")
-        if not remote_url or content_length <= 0:
+        if not ctx.get("remote_url") or content_length <= 0:
             return
         # Yield to startup: let the byte-0 prefetch and Kodi's first range fetch
         # win nzbdav's connection budget before the read-ahead issues its first
@@ -7730,6 +7728,18 @@ class StreamProxy:
                         return
                     continue
                 end = fetch_offset + want - 1
+                # Re-read the source each iteration: a live fallback cutover
+                # mutates ctx["remote_url"]/["auth_header"] mid-stream, so a
+                # once-hoisted local would keep hammering the dead primary and
+                # the lead would stop growing from the live source. The buffer
+                # is offset-addressed, so bytes from either source are
+                # interchangeable for a given offset (no corruption either way).
+                remote_url = ctx.get("remote_url")
+                auth_header = ctx.get("auth_header")
+                if not remote_url:
+                    if monitor.waitForAbort(_READAHEAD_ERROR_BACKOFF_SECONDS):
+                        return
+                    continue
                 body = _StreamHandler._fetch_primary_range_bytes(
                     remote_url, auth_header, fetch_offset, end, content_length
                 )

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -414,6 +414,10 @@ _SETTINGS_SNAPSHOT_KEYS = (
     "send_200_no_range",
     "proxy_convert_subs",
     "readahead_buffer_mb",
+    # Serialized so _passthrough_runtime_settings_from_snapshot() honors a
+    # user-tuned (or 0-to-disable) patient stall wait on the service /prepare
+    # path; without it the snapshot consumer always fell back to the default.
+    "passthrough_stall_wait",
 )
 
 
@@ -520,18 +524,28 @@ class ReadAheadBuffer:
                 self.base_offset = offset
 
     def note_seek(self, new_start):
-        """Repoint the window on a seek OUTSIDE the buffered range.
+        """Repoint the window for a seek.
 
-        In-window seeks leave the data intact (the read_prefix consult plus
-        free_behind naturally consume the now-behind bytes). An out-of-window
-        seek (forward past the lead or any backward seek) discards the data and
+        ``read_prefix`` only serves when ``start == base_offset``, so an
+        in-window FORWARD seek must advance ``base_offset`` to the seek target
+        or the buffered lead is missed and refetched. We therefore TRIM the
+        now-behind prefix ``[base_offset, new_start)`` and keep the still-ahead
+        bytes ``[new_start, window_end)``, so a skip forward into the buffered
+        lead is served from memory. An out-of-window seek (forward past the
+        lead or any backward seek before ``base_offset``) discards the data and
         sets ``base_offset`` to the seek target so the prefetch thread refills
         forward. Never blocks the seek — a cheap lock-protected pointer reset."""
         if not isinstance(new_start, int) or new_start < 0:
             return
         with self._lock:
             window_end = self.base_offset + len(self.data)
-            if self.base_offset <= new_start <= window_end:
+            if new_start == self.base_offset:
+                return
+            if self.base_offset < new_start <= window_end:
+                # In-window forward seek: drop the consumed prefix, keep the lead.
+                del self.data[: new_start - self.base_offset]
+                self.base_offset = new_start
+                self.served_high_water = max(self.served_high_water, new_start)
                 return
             self.data = bytearray()
             self.base_offset = new_start

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -3304,7 +3304,10 @@ class _StreamHandler(BaseHTTPRequestHandler):
         storage = history.get("storage", "")
         if not storage:
             return False
-        video_path = find_video_file(_storage_to_webdav_path(storage))
+        video_path = find_video_file(
+            _storage_to_webdav_path(storage),
+            title_hint=source.get("title") or None,
+        )
         if not video_path:
             return False
         stream_url, stream_headers = get_webdav_stream_url_for_path(video_path)

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -242,6 +242,42 @@ _RANGE_RETRY_DELAYS = (2, 4, 8)
 # streamed yet, use a short schedule so byte 0 arrives promptly, or the
 # connection closes fast enough for Kodi's CCurlFile to reconnect and retry.
 _FIRST_BYTE_RANGE_RETRY_DELAYS = (0.25, 0.5, 1.0)
+# Bounded exhaustion cap for the fallback cutover fall-through (F4). When
+# fallback sources are attached but none validate and the primary makes no
+# forward progress, _serve_proxy re-enters the retry ladder so a TRANSIENT
+# trickle can recover (e3a74a1). But an indefinitely-dead primary with
+# never-validating fallbacks would otherwise spin the ladder / zero-fill until
+# the client gives up (looks like a hang). After this many CONSECUTIVE
+# fall-throughs that streamed no new REAL upstream bytes, close cleanly with
+# terminal_reason="fallback_exhausted" instead of looping. The transient
+# recovery path resets the counter on any genuine streamed progress, so a
+# healthy primary that briefly trickles is never penalised.
+_FALLBACK_PENDING_FALLTHROUGH_MAX = 3
+# F8-dropout: tri-state result for _fallback_source_matches. A definitive
+# MISMATCH (provably different file) permanently fails the source; a transient
+# INCONCLUSIVE (still-downloading region / probe 5xx / timeout / empty digest)
+# keeps the source eligible and is reconsidered on the next cutover. ``True``
+# (MATCH) means usable now. INCONCLUSIVE is a unique sentinel so it can never
+# be confused with the legacy truthy/falsy contract that callers still honour
+# (truthy -> select, falsy -> permanent fail).
+_FALLBACK_MATCH = True
+_FALLBACK_MISMATCH = False
+_FALLBACK_INCONCLUSIVE = object()
+# Bound on how many CONSECUTIVE transient (INCONCLUSIVE) misses a single
+# fallback source may accrue before it is abandoned (failed=True). Without this
+# bound a source that is permanently INCONCLUSIVE (e.g. an upstream that always
+# 5xxs the probe) would be reconsidered forever on every cutover. Reset to 0
+# whenever the source produces a definitive answer or validates.
+_FALLBACK_SOURCE_TRANSIENT_MISS_MAX = 4
+# F-route: a DEAD primary whose missing-article region reads as a CLEAN
+# download-high-water short read (AWAITING_DOWNLOAD) would otherwise spin the
+# retry ladder forever and never fail over (58f3d4f routed AWAITING_DOWNLOAD to
+# the ladder, not fallback, to avoid premature fallback_exhausted). After this
+# many CONSECUTIVE AWAITING_DOWNLOAD reads that make NO forward progress, allow
+# a failover to a validated fallback by routing into the live-cutover path. A
+# primary that IS still downloading and making progress resets the counter and
+# keeps using the ladder, preserving 58f3d4f's intent.
+_AWAITING_DOWNLOAD_NO_PROGRESS_MAX = 3
 _AUTH_HEADER_NOT_PROVIDED = object()
 _FALLBACK_SOURCE_STATE_NOT_PROVIDED = object()
 _FALLBACK_SOURCE_STREAM_URL_HINT_KEY = "_fallback_source_stream_url_hint"
@@ -305,6 +341,16 @@ _INITIAL_RANGE_PREFETCH_WAIT_SECONDS = 0.08
 # nzbdav's article cache so Kodi's real cues read is fast. 1 MiB comfortably
 # covers the cues/SeekHead region Kodi reads at startup.
 _TAIL_PREWARM_BYTES = 1048576
+# The tail prewarm warms the MKV cues, but firing its upstream read at prepare
+# time made it RACE Kodi's first-byte range request and the byte-0 prefetch for
+# nzbdav's connection budget — widening the same mid-startup stall window the
+# prewarm exists to close (transient black-screen). Hold the tail read back a
+# short, ABORTABLE beat so the byte-0 prefetch and Kodi's initial range fetch
+# win the budget first; Kodi's own cues read still arrives well after this. The
+# wait uses xbmc.Monitor.waitForAbort so a Kodi shutdown / session stop during
+# the defer cancels the prewarm cleanly (no wasted connection) instead of
+# blocking the daemon thread.
+_TAIL_PREWARM_DEFER_SECONDS = 1.5
 _PASSTHROUGH_RUNTIME_SETTINGS_KEY = "_passthrough_runtime_settings"
 _PASSTHROUGH_RUNTIME_SETTINGS_DONE_KEY = "_passthrough_runtime_settings_done"
 _PASSTHROUGH_RUNTIME_SETTINGS_ERROR_KEY = "_passthrough_runtime_settings_error"
@@ -2874,6 +2920,98 @@ class _StreamHandler(BaseHTTPRequestHandler):
         )
         return cmd
 
+    @staticmethod
+    def _bump_awaiting_no_progress(ctx, result, current_count):
+        """Advance the session-persistent no-progress AWAITING_DOWNLOAD count.
+
+        Only a clean download-high-water short read (AWAITING_DOWNLOAD) that
+        delivered nothing advances the streak; any other result leaves it
+        unchanged. The count lives in ctx so it survives Kodi's
+        Connection: close reconnects (a dead region reads as a clean short
+        read on every fresh GET). See F-route.
+        """
+        if result == _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD:
+            current_count += 1
+            ctx["_awaiting_download_no_progress"] = current_count
+        return current_count
+
+    def _activate_fallback_source(self, ctx, fallback, current, stuck_awaiting=False):
+        """Point the session at a selected fallback source for live cutover.
+
+        Shared by the recoverable cutover path and the F-route stuck-
+        AWAITING_DOWNLOAD failover so both perform identical bookkeeping
+        (URL/auth swap, watchdog window reset, switch counters, index).
+        """
+        ctx["remote_url"] = fallback["stream_url"]
+        ctx["auth_header"] = (fallback.get("stream_headers") or {}).get("Authorization")
+        ctx.pop("upstream_down_notified", None)
+        ctx.pop("upstream_unreachable_error", None)
+        # Reset throughput watchdog window so the new upstream gets a fresh
+        # stall window — otherwise the prior peer's wedge-induced low B/s would
+        # carry over and trip the watchdog mid-handshake against the healthy
+        # peer.
+        ctx["passthrough_window_t0"] = time.monotonic()
+        ctx["passthrough_window_bytes"] = 0
+        # The new source gets a fresh AWAITING_DOWNLOAD streak; the prior
+        # (dead) primary's stuck count must not carry over and prematurely
+        # escalate the healthy peer.
+        ctx["_awaiting_download_no_progress"] = 0
+        ctx["fallback_switch_count"] = int(ctx.get("fallback_switch_count", 0) or 0) + 1
+        try:
+            ctx["fallback_active_index"] = ctx.get("fallback_sources", []).index(
+                fallback
+            )
+        except ValueError:
+            ctx["fallback_active_index"] = -1
+        if stuck_awaiting:
+            message = (
+                "NZB-DAV: Primary stuck on no-progress AWAITING_DOWNLOAD at "
+                "byte {}; failing over to fallback nzo_id={} (switch_count={})"
+            )
+        else:
+            message = (
+                "NZB-DAV: Switched pass-through source at byte {} to fallback "
+                "nzo_id={} (switch_count={})"
+            )
+        xbmc.log(
+            message.format(
+                current,
+                fallback.get("nzo_id", ""),
+                ctx["fallback_switch_count"],
+            ),
+            xbmc.LOGWARNING,
+        )
+
+    @staticmethod
+    def _apply_fallback_match_result(source, match_result):
+        """Apply a tri-state match result to a candidate source (F8-dropout).
+
+        Returns True when the source is usable now (MATCH). On a definitive
+        MISMATCH the source is failed permanently. On a transient
+        INCONCLUSIVE the source is left eligible — its
+        ``transient_miss_count`` is bumped and only after exceeding
+        ``_FALLBACK_SOURCE_TRANSIENT_MISS_MAX`` is it abandoned, so a peer
+        that is briefly a few bytes short (or hiccups one probe) is
+        reconsidered on the next cutover instead of being killed for the
+        whole session. Any definitive answer resets the transient counter.
+        """
+        if match_result is _FALLBACK_INCONCLUSIVE:
+            misses = int(source.get("transient_miss_count", 0) or 0) + 1
+            source["transient_miss_count"] = misses
+            if misses > _FALLBACK_SOURCE_TRANSIENT_MISS_MAX:
+                # Stuck INCONCLUSIVE forever — abandon so the queue can't
+                # reconsider it on every cutover indefinitely.
+                source["failed"] = True
+            return False
+        # A definitive answer arrived; clear any prior transient streak.
+        if source.get("transient_miss_count"):
+            source["transient_miss_count"] = 0
+        if match_result:
+            return True
+        # Definitive MISMATCH (provably a different file).
+        source["failed"] = True
+        return False
+
     def _select_live_fallback_source(self, ctx, failed_byte, range_end):
         """Return a validated fallback source for the failed byte range."""
         fallback_sources = ctx.get("fallback_sources") or []
@@ -2966,10 +3104,10 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     known_failed=source_failed,
                 ):
                     continue
-                if not self._fallback_source_matches(
+                match_result = self._fallback_source_matches(
                     ctx, source, failed_byte, range_end
-                ):
-                    source["failed"] = True
+                )
+                if not self._apply_fallback_match_result(source, match_result):
                     continue
                 return source
             finally:
@@ -3112,8 +3250,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     ctx[primary_auth_hint_key] = previous_primary_auth_hint
                 else:
                     ctx.pop(primary_auth_hint_key, None)
-            if not matches:
-                source["failed"] = True
+            if not self._apply_fallback_match_result(source, matches):
                 continue
             return source
         return None
@@ -3224,7 +3361,24 @@ class _StreamHandler(BaseHTTPRequestHandler):
         return bool(stream_url)
 
     def _fallback_source_matches(self, ctx, source, failed_byte, range_end):
-        """Return True when a fallback looks like the same file and can resume."""
+        """Classify a fallback as MATCH / MISMATCH / INCONCLUSIVE (F8-dropout).
+
+        Returns one of:
+
+        - ``_FALLBACK_MATCH`` (``True``): same file, usable now.
+        - ``_FALLBACK_MISMATCH`` (``False``): provably a different file
+          (same URL+auth as primary, a definitively different content
+          length, or a fingerprint digest that is present and provably
+          differs). The caller fails the source permanently.
+        - ``_FALLBACK_INCONCLUSIVE``: a TRANSIENT condition — the needed
+          range/probe is not yet available (empty digest, probe 5xx /
+          timeout). The caller keeps the source eligible (bounded
+          reconsider) instead of killing it for the whole session.
+
+        The strict wrong-file safety is preserved: a definitively different
+        length or a provably different digest is still MISMATCH and can
+        never be selected.
+        """
         source_url = self._fallback_source_stream_url(ctx, source)
         source_auth = self._fallback_source_auth_hint(ctx, source)
         primary_auth = _AUTH_HEADER_NOT_PROVIDED
@@ -3238,16 +3392,23 @@ class _StreamHandler(BaseHTTPRequestHandler):
             if primary_auth is _AUTH_HEADER_NOT_PROVIDED:
                 primary_auth = ctx.get("auth_header")
             if source_auth == primary_auth:
-                return False
+                # The source IS the primary — it can never be its own
+                # recovery. A definitive, permanent MISMATCH.
+                return _FALLBACK_MISMATCH
         expected_length = self._fallback_expected_content_length(ctx)
         source_length = self._fallback_source_content_length(ctx, source)
         if expected_length <= 0 or source_length != expected_length:
-            return False
+            # A different WebDAV-reported final content length is a
+            # different release — definitive wrong-file rejection.
+            return _FALLBACK_MISMATCH
         if source_auth is _AUTH_HEADER_NOT_PROVIDED:
             source_auth = self._fallback_source_auth(source)
         probe_bases = self._fallback_probe_bases(ctx)
         if source.get("validated"):
-            return self._probe_fallback_current_range(
+            # Already fingerprint-proven this session. A failing
+            # current-range probe now is transient (the peer just hasn't
+            # downloaded THIS offset yet), not a wrong-file mismatch.
+            if self._probe_fallback_current_range(
                 source,
                 failed_byte,
                 range_end,
@@ -3256,7 +3417,9 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 auth_header=source_auth,
                 stream_url=source_url,
                 cache_ctx=ctx,
-            )
+            ):
+                return _FALLBACK_MATCH
+            return _FALLBACK_INCONCLUSIVE
         current_digest = self._fetch_fallback_current_range_digest(
             source,
             failed_byte,
@@ -3268,7 +3431,9 @@ class _StreamHandler(BaseHTTPRequestHandler):
             cache_ctx=ctx,
         )
         if not current_digest:
-            return False
+            # Range not yet available on the peer (still downloading) or a
+            # probe hiccup — transient, do not condemn the source.
+            return _FALLBACK_INCONCLUSIVE
         # Bug 4: only reuse the current_range digest in fingerprint
         # validation when its (start, end) covers the WHOLE 4096-byte
         # fingerprint range. When ``range_end`` is shorter than
@@ -3284,7 +3449,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
             current_range = None
         else:
             current_range = (failed_byte, natural_end, current_digest)
-        if not self._validate_fallback_fingerprint(
+        classification = self._classify_fallback_fingerprint(
             ctx,
             source,
             expected_length,
@@ -3294,10 +3459,16 @@ class _StreamHandler(BaseHTTPRequestHandler):
             fallback_url=source_url,
             fallback_auth=source_auth,
             primary_auth=primary_auth,
-        ):
-            return False
+        )
+        if classification is _FALLBACK_INCONCLUSIVE:
+            # A probe couldn't be completed (5xx / timeout / empty body) so
+            # we can't PROVE same-or-different yet. Stay eligible.
+            return _FALLBACK_INCONCLUSIVE
+        if classification is _FALLBACK_MISMATCH:
+            # Digests present and provably differ — a different file.
+            return _FALLBACK_MISMATCH
         source["validated"] = True
-        return True
+        return _FALLBACK_MATCH
 
     def _prevalidate_ready_fallback_sources(self, ctx):
         """Fingerprint ready fallback URLs before an upstream failure happens."""
@@ -3523,7 +3694,50 @@ class _StreamHandler(BaseHTTPRequestHandler):
         primary_auth=_AUTH_HEADER_NOT_PROVIDED,
         cache_fallback_range_bytes=False,
     ):
-        """Verify sampled bytes match before splicing in a fallback stream."""
+        """Return True only when every sampled range provably matches.
+
+        Bool wrapper over :meth:`_classify_fallback_fingerprint`. A
+        transient INCONCLUSIVE probe is treated as a non-match here — the
+        prevalidation caller only wants to mark a source ``validated`` when
+        it is byte-proven, and a transient miss simply stays unvalidated to
+        be retried later.
+        """
+        return (
+            self._classify_fallback_fingerprint(
+                ctx,
+                source,
+                content_length,
+                probe_bases,
+                current_range,
+                primary_url,
+                fallback_url,
+                fallback_auth,
+                primary_auth,
+                cache_fallback_range_bytes,
+            )
+            is _FALLBACK_MATCH
+        )
+
+    def _classify_fallback_fingerprint(
+        self,
+        ctx,
+        source,
+        content_length,
+        probe_bases,
+        current_range=None,
+        primary_url=None,
+        fallback_url=None,
+        fallback_auth=_AUTH_HEADER_NOT_PROVIDED,
+        primary_auth=_AUTH_HEADER_NOT_PROVIDED,
+        cache_fallback_range_bytes=False,
+    ):
+        """Classify sampled bytes as MATCH / MISMATCH / INCONCLUSIVE.
+
+        A digest that is PRESENT on both sides and differs is a definitive
+        MISMATCH (wrong file). A digest that cannot be fetched (empty body,
+        probe 5xx / timeout) is INCONCLUSIVE — we can't prove same-or-
+        different yet, so the caller keeps the source eligible.
+        """
         if primary_auth is _AUTH_HEADER_NOT_PROVIDED:
             primary_auth = ctx.get("auth_header")
         if fallback_url is None:
@@ -3532,7 +3746,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
             fallback_auth = self._fallback_source_auth(source)
         ranges = tuple(self._fallback_fingerprint_ranges(ctx, content_length))
         if len(ranges) > 1 and _FALLBACK_FINGERPRINT_WORKERS > 1:
-            return self._validate_fallback_fingerprint_parallel(
+            return self._classify_fallback_fingerprint_parallel(
                 ctx,
                 ranges,
                 content_length,
@@ -3556,7 +3770,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 cache_range_bytes=cache_fallback_range_bytes,
             )
             if not fallback_digest:
-                return False
+                return _FALLBACK_INCONCLUSIVE
             primary_digest = self._fetch_primary_fallback_range_digest(
                 ctx,
                 primary_auth,
@@ -3566,9 +3780,11 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 probe_bases,
                 primary_url,
             )
-            if not primary_digest or primary_digest != fallback_digest:
-                return False
-        return True
+            if not primary_digest:
+                return _FALLBACK_INCONCLUSIVE
+            if primary_digest != fallback_digest:
+                return _FALLBACK_MISMATCH
+        return _FALLBACK_MATCH
 
     def _fetch_fallback_fingerprint_digest(
         self,
@@ -3719,7 +3935,40 @@ class _StreamHandler(BaseHTTPRequestHandler):
         primary_auth,
         cache_fallback_range_bytes=False,
     ):
-        """Verify fingerprint ranges with bounded parallel range probes."""
+        """Return True only when every parallel-probed range provably matches.
+
+        Bool wrapper over :meth:`_classify_fallback_fingerprint_parallel`.
+        """
+        return (
+            self._classify_fallback_fingerprint_parallel(
+                ctx,
+                ranges,
+                content_length,
+                probe_bases,
+                current_range,
+                primary_url,
+                fallback_url,
+                fallback_auth,
+                primary_auth,
+                cache_fallback_range_bytes,
+            )
+            is _FALLBACK_MATCH
+        )
+
+    def _classify_fallback_fingerprint_parallel(
+        self,
+        ctx,
+        ranges,
+        content_length,
+        probe_bases,
+        current_range,
+        primary_url,
+        fallback_url,
+        fallback_auth,
+        primary_auth,
+        cache_fallback_range_bytes=False,
+    ):
+        """Classify fingerprint ranges with bounded parallel range probes."""
         workers = min(_FALLBACK_FINGERPRINT_WORKERS, len(ranges))
         fallback_digests = {}
         # Shared lock for the primary-digest cache: parallel workers
@@ -3756,7 +4005,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 start, end = fallback_futures[future]
                 digest = future.result()
                 if not digest:
-                    return False
+                    return _FALLBACK_INCONCLUSIVE
                 fallback_digests[(start, end)] = digest
 
             for start, end in ranges:
@@ -3776,11 +4025,11 @@ class _StreamHandler(BaseHTTPRequestHandler):
             for future in as_completed(primary_futures):
                 start, end = primary_futures[future]
                 primary_digest = future.result()
-                if not primary_digest or primary_digest != fallback_digests.get(
-                    (start, end)
-                ):
-                    return False
-            return True
+                if not primary_digest:
+                    return _FALLBACK_INCONCLUSIVE
+                if primary_digest != fallback_digests.get((start, end)):
+                    return _FALLBACK_MISMATCH
+            return _FALLBACK_MATCH
         finally:
             # `cancel_futures` requires Python 3.9+. Cancel explicitly first
             # so Python 3.8 stops any queued probes before nonblocking shutdown.
@@ -4167,7 +4416,39 @@ class _StreamHandler(BaseHTTPRequestHandler):
         total_streamed = 0
         total_skipped = 0
         recovery_count = 0
-        terminal_reason = "complete"
+        # Default to a DISTINCT sentinel, NOT "complete". Only the genuine
+        # success paths (full range delivered) set terminal_reason="complete"
+        # explicitly; any early return/raise that leaves it unset must read as
+        # a non-benign exit so the finally block still reports a still-pending
+        # fallback candidate as failed instead of silently swallowing it.
+        terminal_reason = "unknown"
+        # Bounded exhaustion guard: count consecutive cutover fall-throughs
+        # where fallback sources are attached but none validated AND the
+        # primary made no forward progress since the prior fall-through. A
+        # transient trickle re-enters the retry ladder and recovers (resetting
+        # this), but a genuinely-dead primary with never-validating fallbacks
+        # is stopped after the cap instead of spinning the ladder / zero-fill
+        # forever (the indefinite-hang regression). See e3a74a1 + F4.
+        fallback_pending_fallthroughs = 0
+        last_fallthrough_streamed = -1
+        # F-route: count CONSECUTIVE clean download-high-water short reads
+        # (AWAITING_DOWNLOAD) that make NO forward progress. 58f3d4f routes a
+        # still-downloading short read to the retry ladder (wait on the
+        # primary) rather than failing over, which is correct while the
+        # primary is genuinely advancing. But a DEAD primary whose missing
+        # region reads as a clean short read would spin the ladder forever and
+        # never fail over. Once this many no-progress AWAITING_DOWNLOAD reads
+        # accrue, allow a failover into the live-cutover path. Any genuine
+        # forward progress resets the counter, so a primary that IS still
+        # downloading keeps using the ladder (preserving 58f3d4f's intent).
+        #
+        # Kept in ctx (not a local) so it survives Kodi's Connection: close
+        # reconnects: a dead region reads as a clean short read on every fresh
+        # GET, and a per-request local would reset to 0 each time and never
+        # escalate. Genuine progress (this request or any prior one) clears it.
+        awaiting_download_no_progress = int(
+            ctx.get("_awaiting_download_no_progress", 0) or 0
+        )
         density_window = deque()
         # Reset the throughput watchdog window per request. ctx may be reused
         # across requests for the same session, so explicit re-init avoids
@@ -4182,6 +4463,17 @@ class _StreamHandler(BaseHTTPRequestHandler):
         # toast: success when bytes flow, failure when we switch away or
         # exhaust the queue before it delivers anything.
         fallback_pending_candidate = None
+        # Whether the currently-pending candidate has PROVABLY delivered real
+        # bytes yet. Set True only at the sites that emit the success toast
+        # (where written/retry_written > 0), and reset to False on every fresh
+        # switch. The finally block reports a still-pending candidate that never
+        # delivered as a failure regardless of terminal_reason — closing the
+        # F11/F12 hole where a benign exit (zero-fill "complete" or a client
+        # disconnect AFTER the switch but BEFORE any byte) silently swallowed a
+        # dead/wrong fallback. A candidate that DID deliver already cleared
+        # fallback_pending_candidate to None at the success site, so it is never
+        # re-toasted here.
+        candidate_delivered = False
         # A failed candidate number whose toast is deferred until after the
         # NEXT candidate's read has started, so a slow Kodi notification can
         # never stall the cutover between a dead candidate and its successor
@@ -4204,6 +4496,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     _update_session_recovery_state(self.server, ctx, streamed=written)
                     _record_density_window(density_window, "progress", written)
                     if current > end:
+                        terminal_reason = "complete"
                         return
 
             if waited_for_initial_prefetch:
@@ -4233,10 +4526,20 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 if fallback_pending_candidate is not None and written:
                     # The candidate we switched to just delivered playable
                     # bytes — the cutover worked.
+                    candidate_delivered = True
                     _notify_fallback_outcome(fallback_pending_candidate, True)
                     fallback_pending_candidate = None
                 if current > end:
+                    terminal_reason = "complete"
                     return
+
+                # F-route: track consecutive AWAITING_DOWNLOAD iterations that
+                # made NO forward progress. The reset happens here for the main
+                # read; the retry ladder below feeds back into this counter via
+                # ``awaiting_download_stuck`` so a primary that the ladder can
+                # still coax forward (genuinely downloading, per 58f3d4f) keeps
+                # waiting, while a stuck/dead primary escalates to failover.
+                progressed_this_iter = bool(written)
 
                 if current <= end and result in (
                     _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE,
@@ -4244,38 +4547,17 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 ):
                     fallback = self._select_live_fallback_source(ctx, current, end)
                     if fallback:
-                        ctx["remote_url"] = fallback["stream_url"]
-                        ctx["auth_header"] = (fallback.get("stream_headers") or {}).get(
-                            "Authorization"
-                        )
-                        ctx.pop("upstream_down_notified", None)
-                        ctx.pop("upstream_unreachable_error", None)
-                        # Reset throughput watchdog window so the new
-                        # upstream gets a fresh stall window — otherwise
-                        # the prior peer's wedge-induced low B/s would
-                        # carry over and trip the watchdog mid-handshake
-                        # against the healthy peer.
-                        ctx["passthrough_window_t0"] = time.monotonic()
-                        ctx["passthrough_window_bytes"] = 0
+                        self._activate_fallback_source(ctx, fallback, current)
+                        awaiting_download_no_progress = 0
+                        # SM-1 (F4): a successful cutover is genuine progress on
+                        # the fallback chain — reset the bounded-exhaustion
+                        # counters so a freshly-switched source gets its FULL
+                        # fruitless-read budget instead of inheriting the stale
+                        # primary-driven count (which could trip
+                        # fallback_exhausted after ~one fruitless read).
+                        fallback_pending_fallthroughs = 0
+                        last_fallthrough_streamed = -1
                         active_ctx = ctx
-                        ctx["fallback_switch_count"] = (
-                            int(ctx.get("fallback_switch_count", 0) or 0) + 1
-                        )
-                        try:
-                            ctx["fallback_active_index"] = ctx.get(
-                                "fallback_sources", []
-                            ).index(fallback)
-                        except ValueError:
-                            ctx["fallback_active_index"] = -1
-                        xbmc.log(
-                            "NZB-DAV: Switched pass-through source at byte {} "
-                            "to fallback nzo_id={} (switch_count={})".format(
-                                current,
-                                fallback.get("nzo_id", ""),
-                                ctx["fallback_switch_count"],
-                            ),
-                            xbmc.LOGWARNING,
-                        )
                         if fallback_pending_candidate is not None:
                             # Switching away from a candidate that never
                             # delivered a byte — it failed. Defer the toast to
@@ -4288,6 +4570,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                             if ctx["fallback_active_index"] >= 0
                             else int(ctx.get("fallback_switch_count", 0) or 0)
                         )
+                        candidate_delivered = False
                         continue
                     if ctx.get("fallback_sources"):
                         # Fallback sources are attached but none validated yet
@@ -4308,11 +4591,51 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         # still emitted by the finally block (the single sink for
                         # every terminal exit) whenever the stream does end, so
                         # falling through here doesn't drop the notification.
+                        #
+                        # BOUNDED EXHAUSTION (F4): re-entering the retry ladder
+                        # is correct for a TRANSIENT trickle, but a primary that
+                        # never recovers while its fallbacks never validate would
+                        # otherwise spin the ladder / zero-fill indefinitely
+                        # (looks like a hang/dropout). Count consecutive
+                        # fall-throughs that streamed NO new REAL upstream bytes
+                        # (zero-fill "progress" is black frames, not recovery, so
+                        # it must NOT reset the bound). Any genuine streamed byte
+                        # since the last fall-through resets the count, so a
+                        # recovering primary is never penalised. Once the cap is
+                        # hit with still no validated candidate, close cleanly
+                        # with fallback_exhausted instead of looping — WITHOUT
+                        # reintroducing e3a74a1's immediate hard-close.
+                        if total_streamed == last_fallthrough_streamed:
+                            fallback_pending_fallthroughs += 1
+                        else:
+                            fallback_pending_fallthroughs = 1
+                            last_fallthrough_streamed = total_streamed
+                        if (
+                            fallback_pending_fallthroughs
+                            >= _FALLBACK_PENDING_FALLTHROUGH_MAX
+                        ):
+                            terminal_reason = "fallback_exhausted"
+                            xbmc.log(
+                                "NZB-DAV: Fallback chain exhausted at byte {} "
+                                "after {} fruitless cutover re-entries with no "
+                                "validated source and no primary progress; "
+                                "closing cleanly (reason={})".format(
+                                    current,
+                                    fallback_pending_fallthroughs,
+                                    terminal_reason,
+                                ),
+                                xbmc.LOGERROR,
+                            )
+                            return
                         xbmc.log(
                             "NZB-DAV: No validated fallback source available at "
                             "byte {}; re-entering retry ladder on the primary "
-                            "instead of closing "
-                            "(reason=fallback_pending_retry_primary)".format(current),
+                            "instead of closing (attempt {}/{}) "
+                            "(reason=fallback_pending_retry_primary)".format(
+                                current,
+                                fallback_pending_fallthroughs,
+                                _FALLBACK_PENDING_FALLTHROUGH_MAX,
+                            ),
                             xbmc.LOGWARNING,
                         )
 
@@ -4348,10 +4671,69 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         # The candidate delivered its first bytes via the retry
                         # ladder (its initial read was a download-high-water
                         # short read) — the cutover worked.
+                        candidate_delivered = True
                         _notify_fallback_outcome(fallback_pending_candidate, True)
                         fallback_pending_candidate = None
+                    if retry_written:
+                        progressed_this_iter = True
                     if current > end:
+                        terminal_reason = "complete"
                         return
+
+                # F-route: the retry ladder has now had its chance to coax the
+                # primary forward. If this whole iteration delivered bytes, the
+                # primary IS still downloading — reset the streak and keep
+                # waiting on it (58f3d4f's intent). If the result is STILL a
+                # clean AWAITING_DOWNLOAD short read with no progress, the
+                # primary's needed region is stuck/dead; after a bounded number
+                # of such no-progress passes, fail over to a validated fallback
+                # (the same live-cutover path the recoverable cases use) rather
+                # than spinning the ladder / zero-filling toward EOF forever.
+                if progressed_this_iter:
+                    awaiting_download_no_progress = 0
+                    ctx["_awaiting_download_no_progress"] = 0
+                    # SM-1 (F4): genuine streamed progress means the chain is
+                    # alive — reset the bounded-exhaustion counters so a later
+                    # fruitless read starts from a fresh budget, not a stale count.
+                    fallback_pending_fallthroughs = 0
+                    last_fallthrough_streamed = -1
+                else:
+                    awaiting_download_no_progress = self._bump_awaiting_no_progress(
+                        ctx, result, awaiting_download_no_progress
+                    )
+                awaiting_stuck = (
+                    not progressed_this_iter
+                    and current <= end
+                    and result == _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD
+                    and awaiting_download_no_progress
+                    > _AWAITING_DOWNLOAD_NO_PROGRESS_MAX
+                    and ctx.get("fallback_sources")
+                )
+                awaiting_fallback = (
+                    self._select_live_fallback_source(ctx, current, end)
+                    if awaiting_stuck
+                    else None
+                )
+                if awaiting_fallback:
+                    self._activate_fallback_source(
+                        ctx, awaiting_fallback, current, stuck_awaiting=True
+                    )
+                    awaiting_download_no_progress = 0
+                    # SM-1 (F4): see the live-cutover reset above — a successful
+                    # awaiting-stuck cutover likewise resets the bounded-
+                    # exhaustion counters so the new source gets a fresh budget.
+                    fallback_pending_fallthroughs = 0
+                    last_fallthrough_streamed = -1
+                    active_ctx = ctx
+                    if fallback_pending_candidate is not None:
+                        fallback_failed_to_notify = fallback_pending_candidate
+                    fallback_pending_candidate = (
+                        ctx["fallback_active_index"] + 1
+                        if ctx["fallback_active_index"] >= 0
+                        else int(ctx.get("fallback_switch_count", 0) or 0)
+                    )
+                    candidate_delivered = False
+                    continue
 
                 if result in (
                     _UPSTREAM_RANGE_CLIENT_ERROR,
@@ -4466,6 +4848,11 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     ),
                     xbmc.LOGWARNING,
                 )
+            # The while loop only exits normally when ``current > end`` — every
+            # requested byte was delivered (streamed and/or zero-filled). That
+            # is a genuine completion, so mark it explicitly rather than leaning
+            # on the default sentinel.
+            terminal_reason = "complete"
         except (BrokenPipeError, ConnectionResetError, _socket.timeout):
             # socket.timeout has TWO causes here:
             #   1. Kodi stopped reading from us for longer than
@@ -4519,17 +4906,32 @@ class _StreamHandler(BaseHTTPRequestHandler):
             if fallback_failed_to_notify is not None:
                 _notify_fallback_outcome(fallback_failed_to_notify, False)
                 fallback_failed_to_notify = None
-            # The candidate still awaiting its first byte only "failed" if the
-            # stream ended on a genuine upstream/recovery failure. A benign exit
-            # is NOT its fault: on full completion a delivering candidate already
-            # cleared itself on success, and on client_disconnected the CLIENT
-            # write aborted — which means the candidate WAS serving bytes — so a
-            # failure toast here would falsely blame a working candidate. Clear
-            # it silently in that case; report it on every genuine failure exit.
-            if fallback_pending_candidate is not None:
-                if not _benign_summary:
-                    _notify_fallback_outcome(fallback_pending_candidate, False)
-                fallback_pending_candidate = None
+            # A candidate that PROVABLY delivered real bytes cleared
+            # fallback_pending_candidate to None at its success site, so reaching
+            # here with it still set means the candidate switched in but
+            # candidate_delivered never flipped True. That covers the F11 hole —
+            # a full zero-fill to EOF (reason="complete") where the candidate
+            # genuinely never wrote a real byte — which the candidate_delivered
+            # catch correctly reports as a failure.
+            #
+            # But 4decdd4's invariant exempts terminal_reason="client_disconnected":
+            # a BrokenPipeError yielding that reason can ONLY originate at the
+            # client body write (self.wfile.write(chunk)), reached only AFTER
+            # resp.read() returned a non-empty chunk — so the candidate's
+            # upstream WAS serving bytes and the CLIENT went away (a Kodi demuxer
+            # probe/seek abandoning the range, or a user stop). candidate_delivered
+            # stays False because the BrokenPipeError raises before
+            # _stream_upstream_range returns (written>0), so without this exempt a
+            # live/working candidate (including one disconnected mid multi-chunk
+            # delivery) would be falsely toasted as failed. Suppress the toast on
+            # that genuinely-benign exit; every genuine failure exit still blames it.
+            if (
+                fallback_pending_candidate is not None
+                and not candidate_delivered
+                and terminal_reason != "client_disconnected"
+            ):
+                _notify_fallback_outcome(fallback_pending_candidate, False)
+            fallback_pending_candidate = None
             xbmc.log(
                 "NZB-DAV: Pass-through summary reason={} range={}-{} "
                 "streamed={} zero_fill={} recoveries={} "
@@ -6725,6 +7127,15 @@ class StreamProxy:
         # Only warm a tail that is distinct from the byte-0 prefetch window;
         # tiny files are already fully covered by _prefetch_initial_range.
         if content_length <= _TAIL_PREWARM_BYTES + _UPSTREAM_READ_CHUNK:
+            return
+        # Yield to startup playback: hold the tail read back a short, abortable
+        # beat so the byte-0 prefetch and Kodi's first-byte range request win
+        # nzbdav's connection budget first. Without this the tail read RACED
+        # them at prepare time and widened the very mid-startup stall window the
+        # prewarm exists to close (transient black-screen). waitForAbort lets a
+        # Kodi shutdown / session stop cancel the prewarm cleanly during the
+        # defer instead of blocking the daemon thread or wasting a connection.
+        if xbmc.Monitor().waitForAbort(_TAIL_PREWARM_DEFER_SECONDS):
             return
         tail_start = content_length - _TAIL_PREWARM_BYTES
         try:

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -1278,7 +1278,7 @@ def _maybe_notify_stream_starvation(
     # Only when the stream was genuinely starved — it did NOT deliver the full
     # requested range. A fully-delivered stream the user happened to stop is
     # not starvation.
-    if requested_bytes > 0 and total_streamed >= requested_bytes:
+    if 0 < requested_bytes <= total_streamed:
         return False
 
     context_lock = _get_server_context_lock(server)
@@ -4955,9 +4955,12 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         forward_stall_t0 = now
                     if now - forward_stall_t0 < stall_wait_budget:
                         xbmc.log(
-                            "NZB-DAV: Established forward stream stalled at byte "
-                            "{} (result={}); holding client open and re-reading "
-                            "(elapsed={:.0f}s/{}s, reason=patient_forward_stall)".format(
+                            (
+                                "NZB-DAV: Established forward stream stalled at "
+                                "byte {} (result={}); holding client open and "
+                                "re-reading (elapsed={:.0f}s/{}s, "
+                                "reason=patient_forward_stall)"
+                            ).format(
                                 current,
                                 result,
                                 now - forward_stall_t0,
@@ -5359,6 +5362,30 @@ class _StreamHandler(BaseHTTPRequestHandler):
         except (OSError, ValueError) as e:
             if _is_terminal_http_client_error(e):
                 code = getattr(e, "code", "?")
+                # A 404 on an ESTABLISHED read (start > 0) is nzbdav reporting
+                # "I have not downloaded this byte range yet" — it 404s for
+                # ranges past its download high-water — NOT a permanent path
+                # error. Treat it as a still-downloading short read so the
+                # retry ladder + patient forward-stall wait + fallback cutover
+                # engage, instead of a hard CLIENT_ERROR abort that kills
+                # playback the instant playback catches the download
+                # high-water (the "Dune died on a 404" incident). A 404 on the
+                # INITIAL open (start == 0 — byte 0 must exist if the path is
+                # valid) is a genuine missing path and stays terminal; 401/403
+                # (auth) are always terminal because waiting cannot fix bad
+                # credentials. A cached/verified prefix already written is real
+                # progress, so report it as a recoverable short read.
+                if code == 404 and start > 0:
+                    xbmc.log(
+                        "NZB-DAV: Upstream 404 at byte {} on an established "
+                        "stream; treating as awaiting-download (nzbdav past "
+                        "its download high-water) "
+                        "(reason=client_error_awaiting_download)".format(start),
+                        xbmc.LOGWARNING,
+                    )
+                    if written:
+                        return _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE, written
+                    return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0
                 xbmc.log(
                     "NZB-DAV: Proxy upstream client error at byte {}: HTTP {} "
                     "(reason=upstream_client_error)".format(start, code),

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -1151,6 +1151,79 @@ def _record_upstream_unreachable(server, ctx, error):
         pass
 
 
+# Pass-through terminal reasons that mean the BACKEND could not deliver the
+# stream (a throughput stall, fallback exhaustion, or a zero-fill blowout) — as
+# opposed to a clean finish ("complete") or a healthy user stop. Used to surface
+# a clear "nzbdav can't keep up" notification instead of a silent black screen.
+_STARVATION_TERMINAL_REASONS = (
+    "passthrough_stall",
+    "fallback_exhausted",
+    "session_zero_fill_budget_exceeded",
+)
+
+
+def _maybe_notify_stream_starvation(
+    server, ctx, terminal_reason, total_streamed, requested_bytes
+):
+    """Fire ONE clear notification when a pass-through stream ends because the
+    backend could not keep up, so the user gets an explanation instead of a
+    silent black screen.
+
+    This is the graceful-starvation guard for the live failure mode where
+    nzbdav delivers far below the release's bitrate and/or returns HTTP 5xx for
+    a sustained period: playback exhausts the downloaded head-start, the demuxer
+    EOFs, and Kodi stops with no on-screen reason. No proxy change can stream
+    bytes that were never downloaded, but the user should at least learn WHY.
+
+    Distinct from the early one-shot ``_record_upstream_unreachable`` toast
+    (which warns when an outage STARTS): this explains why playback STOPPED. It
+    fires only for an abnormal end (not ``complete``) that shows evidence of
+    backend trouble — a recorded upstream outage this session, or an explicit
+    stall terminal reason — and never for a clean finish or a healthy user stop
+    of a stream that delivered its full range. Debounced once per session via
+    ``starvation_notified``. Returns whether the notification fired.
+    """
+    if terminal_reason == "complete":
+        return False
+    upstream_trouble = int(ctx.get("upstream_unreachable_count", 0) or 0) > 0
+    if not (upstream_trouble or terminal_reason in _STARVATION_TERMINAL_REASONS):
+        return False
+    # Only when the stream was genuinely starved — it did NOT deliver the full
+    # requested range. A fully-delivered stream the user happened to stop is
+    # not starvation.
+    if requested_bytes > 0 and total_streamed >= requested_bytes:
+        return False
+
+    context_lock = _get_server_context_lock(server)
+
+    def _update():
+        if ctx.get("starvation_notified"):
+            return False
+        ctx["starvation_notified"] = True
+        return True
+
+    if context_lock is None:
+        fire = _update()
+    else:
+        with context_lock:
+            fire = _update()
+    if not fire:
+        return False
+
+    xbmc.log(
+        "NZB-DAV: Stream stalled — backend could not keep up "
+        "(terminal={} streamed={} requested={} reason=stream_starvation)".format(
+            terminal_reason, total_streamed, requested_bytes
+        ),
+        xbmc.LOGWARNING,
+    )
+    try:
+        _notify("NZB-DAV", "nzbdav can't keep up — playback stalled")
+    except (RuntimeError, OSError):
+        pass
+    return True
+
+
 def _read_session_recovery_state(ctx):
     return {
         "streamed": int(ctx.get("session_streamed_bytes", 0) or 0),
@@ -4995,6 +5068,13 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     ctx.get("session_zero_fill_bytes", 0),
                 ),
                 xbmc.LOGINFO if _benign_summary else xbmc.LOGWARNING,
+            )
+            # Graceful-starvation guard: if this stream ended because the
+            # backend could not keep up (a sustained outage or a throughput
+            # stall), tell the user once instead of leaving a silent black
+            # screen. No-op on a clean finish or a healthy user stop.
+            _maybe_notify_stream_starvation(
+                self.server, ctx, terminal_reason, total_streamed, end - start + 1
             )
 
     def _retry_original_range(self, ctx, start, end, contract_mode, first_byte=False):

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -3289,6 +3289,29 @@ class _StreamHandler(BaseHTTPRequestHandler):
         AWAITING_DOWNLOAD failover so both perform identical bookkeeping
         (URL/auth swap, watchdog window reset, switch counters, index).
         """
+        # Demote the currently-active source to a last-resort fallback BEFORE we
+        # repoint at the new one. The original primary is never its own backup at
+        # session start; it only re-enters the pool here, after a real cutover to
+        # a different source. It carries a resolved stream_url, so no nzo
+        # re-resolution is needed; the byte-identity gate still guards serving.
+        demoted_url = ctx.get("remote_url")
+        if demoted_url and demoted_url != fallback.get("stream_url"):
+            sources = ctx.setdefault("fallback_sources", [])
+            already_present = any(
+                src.get("stream_url") == demoted_url for src in sources
+            )
+            if not already_present:
+                demoted_auth = ctx.get("auth_header")
+                sources.append(
+                    {
+                        "stream_url": demoted_url,
+                        "stream_headers": (
+                            {"Authorization": demoted_auth} if demoted_auth else {}
+                        ),
+                        "content_length": ctx.get("content_length", 0) or 0,
+                        "demoted": True,
+                    }
+                )
         ctx["remote_url"] = fallback["stream_url"]
         ctx["auth_header"] = (fallback.get("stream_headers") or {}).get("Authorization")
         ctx.pop("upstream_down_notified", None)

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -499,13 +499,25 @@ class ReadAheadBuffer:
             self.base_offset += drop
 
     def update_served_high_water(self, offset):
-        """Record the highest offset delivered to the client."""
+        """Record the highest offset delivered to the client.
+
+        When the play head has been served PAST the end of the buffered window
+        (the common startup case: an initial read MISSES the read-ahead window
+        and is served directly from upstream, so ``free_behind`` has no buffered
+        bytes to consume), repoint ``base_offset`` to the served offset and drop
+        any now-behind stale data. This advances ``next_fetch_offset`` so the
+        prefetch daemon builds a FORWARD lead from the play head instead of
+        re-fetching from offset 0 behind it."""
         try:
             offset = int(offset)
         except (TypeError, ValueError):
             return
         with self._lock:
             self.served_high_water = max(self.served_high_water, offset)
+            window_end = self.base_offset + len(self.data)
+            if offset >= window_end:
+                self.data = bytearray()
+                self.base_offset = offset
 
     def note_seek(self, new_start):
         """Repoint the window on a seek OUTSIDE the buffered range.
@@ -3848,6 +3860,14 @@ class _StreamHandler(BaseHTTPRequestHandler):
             # Digests present and provably differ — a different file.
             return _FALLBACK_MISMATCH
         source["validated"] = True
+        # A source that prevalidates after a few INCONCLUSIVE probes (it was
+        # still downloading when first probed) must not carry a stale transient
+        # streak that would later abandon it once it crosses
+        # _FALLBACK_SOURCE_TRANSIENT_MISS_MAX. Reaching validated proves it is
+        # readable, so clear the streak. The "stuck forever" bound still applies
+        # to sources that never validate.
+        if source.get("transient_miss_count"):
+            source["transient_miss_count"] = 0
         return _FALLBACK_MATCH
 
     def _prevalidate_ready_fallback_sources(self, ctx):
@@ -3915,6 +3935,11 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     cache_fallback_range_bytes=True,
                 ):
                     source["validated"] = True
+                    # Prevalidation succeeded after earlier INCONCLUSIVE probes
+                    # (still-downloading at first contact): clear any transient
+                    # streak so it is not later abandoned at the miss bound.
+                    if source.get("transient_miss_count"):
+                        source["transient_miss_count"] = 0
                     validated += 1
             finally:
                 if had_hint:
@@ -5812,6 +5837,17 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         )
                 self.wfile.write(chunk)
                 written += len(chunk)
+                # Tell the read-ahead buffer how far the play head has now been
+                # served directly from upstream. On the common startup MISS the
+                # buffer was never told the served position, so its base stayed
+                # at 0 and the prefetch daemon kept re-fetching bytes already
+                # behind the play head instead of building a forward lead. The
+                # hit path updates the high-water inside _serve_from_readahead;
+                # this covers the bytes served straight from upstream. Idempotent
+                # (max-based) so no double-count with the prefix on a hit.
+                readahead_buf = ctx.get(_READAHEAD_BUFFER_KEY)
+                if readahead_buf is not None:
+                    readahead_buf.update_served_high_water(requested_start + written)
                 # Env-gated fault injection: a single long-lived connection
                 # opened below the threshold can stream past it, so the
                 # entry-only check misses it — re-check the absolute position

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -4973,6 +4973,14 @@ class _StreamHandler(BaseHTTPRequestHandler):
                         if xbmc.Monitor().waitForAbort(
                             _PASSTHROUGH_STALL_WAIT_BACKOFF_SECONDS
                         ):
+                            # waitForAbort True == Kodi closing the session: a
+                            # client-side teardown, never an upstream error. Mark
+                            # it benign (matches the byte-write client-disconnect
+                            # at the bottom of the loop) so the finally block logs
+                            # at INFO and never blames a pending fallback candidate
+                            # for a clean shutdown. Without this it stays "unknown"
+                            # and a clean teardown reads as a genuine failure.
+                            terminal_reason = "client_disconnected"
                             return
                         # Reset the throughput watchdog window so the stale
                         # pre-wait sample can't trip a spurious stall on the first

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -1246,22 +1246,33 @@ def _maybe_notify_stream_starvation(
     """
     if terminal_reason == "complete":
         return False
+    # The density breaker emits its own toast at its terminal branch, so suppress
+    # the redundant starvation toast for that reason (avoid a double notification).
+    if terminal_reason == "density_breaker_tripped":
+        return False
     # The backend (not a healthy stop) ended this stream when an explicit stall
     # terminal reason fired, OR the upstream is still flagged down, OR an outage
-    # happened very recently. The RECENCY window matters because
-    # ``upstream_unreachable_count`` is a sticky running total and
-    # ``last_upstream_unreachable_at`` can predate a long healthy stretch the
-    # user then stopped — that must NOT fire. It also catches the live incident,
-    # where the upstream momentarily "recovered" a few seconds before Kodi gave
-    # up and disconnected (so a recovered-vs-unreachable ordering check alone
-    # would wrongly stay silent).
+    # happened very recently, OR the patient forward-stall wait exhausted. The
+    # forward-stall signal covers the pure-SLOW case (a still-downloading region
+    # that never caught up: AWAITING with no 5xx, so no outage is recorded) —
+    # without it that give-up would be silent, the exact thing this guard exists
+    # to prevent. The RECENCY window matters because ``upstream_unreachable_count``
+    # is a sticky running total and ``last_upstream_unreachable_at`` can predate a
+    # long healthy stretch the user then stopped — that must NOT fire. It also
+    # catches the live incident, where the upstream momentarily "recovered" a few
+    # seconds before Kodi gave up and disconnected (so a recovered-vs-unreachable
+    # ordering check alone would wrongly stay silent).
     down_now = bool(ctx.get("upstream_down_notified"))
     last_down = float(ctx.get("last_upstream_unreachable_at", 0) or 0)
     recent_outage = (
         last_down > 0 and (time.time() - last_down) <= _STARVATION_RECENT_OUTAGE_SECONDS
     )
+    forward_stall_exhausted = bool(ctx.get("forward_stall_exhausted"))
     if not (
-        terminal_reason in _STARVATION_TERMINAL_REASONS or down_now or recent_outage
+        terminal_reason in _STARVATION_TERMINAL_REASONS
+        or down_now
+        or recent_outage
+        or forward_stall_exhausted
     ):
         return False
     # Only when the stream was genuinely starved — it did NOT deliver the full
@@ -4969,6 +4980,10 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     # Budget exhausted: genuinely stuck. Fall through to the
                     # existing F4 cap-fire / skip-probe give-up so the close is
                     # reported through the established taxonomy (no new exit path).
+                    # Mark the session so the terminal starvation guard fires even
+                    # on a pure slow-backend give-up (AWAITING with no 5xx outage
+                    # recorded) — otherwise that give-up would be silent.
+                    ctx["forward_stall_exhausted"] = True
                     xbmc.log(
                         "NZB-DAV: Patient forward-stall budget exhausted at byte "
                         "{} after {}s with no progress (result={}); giving up "

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -44,6 +44,20 @@ _EPISODE_RANGE_MAX_SPAN = 64
 # x264/x265 from registering as episodes. Accepts the Cyrillic 'х' the PTT
 # handler also allows.
 _EPISODE_NXN_RE = re.compile(r"(?<!\d)(\d{1,2})[xх](\d{1,3})(?!\d)", re.IGNORECASE)
+# NxN RANGE notation "1x01-03" / "1x01-1x03" -- the NxN sibling of
+# _EPISODE_RANGE_RE (SxxEaa-Ebb). The standalone _EPISODE_NXN_RE above only
+# records the literal endpoints (1x01 and 1x03) and drops a bare "-03" half
+# entirely, so a request for a covered middle episode (1x02) would mis-score
+# and a larger non-covering sibling could win. We expand the inclusive span
+# below, capped by _EPISODE_RANGE_MAX_SPAN. The `\d{1,2}` season cap and the
+# trailing `(?!\d)` are the resolution/codec guard (1920x1080, 1280x720,
+# 3840x2160, 1920x1080-1920x1200 and 1x01-1080 all register nothing). The
+# optional `(?:\d{1,2}[xх])?` handles both "1x01-03" and "1x01-1x03"; the
+# literal '-' means dot-separated adjacent tags ("2x05.2x06") never collapse.
+_EPISODE_NXN_RANGE_RE = re.compile(
+    r"(?<!\d)(\d{1,2})[xх](\d{1,3})[. _-]*-[. _-]*(?:\d{1,2}[xх])?(\d{1,3})(?!\d)",
+    re.IGNORECASE,
+)
 
 
 def _hint_tokens(value):
@@ -75,6 +89,18 @@ def _episode_tags(value):
         if start <= end <= start + _EPISODE_RANGE_MAX_SPAN:
             for episode in range(start, end + 1):
                 tags.add((season, episode))
+    for match in _EPISODE_NXN_RANGE_RE.finditer(value):
+        season = int(match.group(1))
+        start = int(match.group(2))
+        end = int(match.group(3))
+        if start <= end <= start + _EPISODE_RANGE_MAX_SPAN:
+            for episode in range(start, end + 1):
+                tags.add((season, episode))
+    # Keep the standalone NxN loop AFTER the range expansion: it preserves the
+    # literal endpoints when the range guard rejects a span (reversed 1x05-1x02
+    # or cross-season 1x10-2x02, where start<=end is False, or beyond the cap),
+    # so behavior is a strict superset and never regresses. tags is a set, so
+    # there is no double-count.
     for match in _EPISODE_NXN_RE.finditer(value):
         tags.add((int(match.group(1)), int(match.group(2))))
     return frozenset(tags)
@@ -102,21 +128,30 @@ def _title_hint_match_score(file_path, hint_tokens, hint_episode_tags):
     name = unquote(file_path.rsplit("/", 1)[-1]) if file_path else ""
     if not name:
         return (0, 0)
-    parent = (
-        unquote(file_path.rsplit("/", 1)[0]) if file_path and "/" in file_path else ""
-    )
+    parent_path = file_path.rsplit("/", 1)[0] if file_path and "/" in file_path else ""
     episode_score = 0
     if hint_episode_tags:
         # Basename FIRST: the file's own episode tag is authoritative. Only
         # when the basename carries no episode tag (a generically-named file
-        # like "video.mkv") do we fall back to the parent directory's tag --
-        # this is a LAYERED fallback, NOT a union: a matching dir tag must
-        # never mask a wrong-episode FILENAME, or the wrong-episode gate
-        # would regress. A season-complete parent ("Show.S01.Complete")
-        # yields no tag, so largest-wins is preserved there.
+        # like "video.mkv") do we fall back to the directory -- this is a
+        # LAYERED fallback, NOT a union: a matching dir tag must never mask a
+        # wrong-episode FILENAME, or the wrong-episode gate would regress.
+        #
+        # The fallback scores the NEAREST parent SEGMENT and treats it as
+        # authoritative when it carries its OWN episode tag (most-specific
+        # identity), so a wrong nearer dir like "Show.S01E03" is correctly
+        # wrong and is NOT rescued by an ancestor pack folder
+        # ("Show.S01E02.Pack"). It widens to scan the FULL ancestor path only
+        # when the nearest dir is generic (e.g. "1080p"), so a grandparent's
+        # tag ("Show.S01E02/1080p/video.mkv") still supplies the match. A
+        # season-complete parent ("Show.S01.Complete") yields no tag, so
+        # largest-wins is preserved there.
         file_tags = _episode_tags(name)
-        if not file_tags and parent:
-            file_tags = _episode_tags(parent)
+        if not file_tags and parent_path:
+            nearest_tags = _episode_tags(unquote(parent_path.rsplit("/", 1)[-1]))
+            file_tags = (
+                nearest_tags if nearest_tags else _episode_tags(unquote(parent_path))
+            )
         if file_tags:
             if hint_episode_tags & file_tags:
                 # Strong match: same episode requested and present.

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -22,6 +22,13 @@ _VIDEO_FILE_SIZE_HINTS = {}
 # between consecutive episode numbers within the same Sxx tag.
 _EPISODE_TAG_RE = re.compile(r"s(\d{1,3})[. _-]*((?:e\d{1,4}[. _-]*)+)", re.IGNORECASE)
 _EPISODE_NUM_RE = re.compile(r"e(\d{1,4})", re.IGNORECASE)
+# Older/scene-alternate "NxNN" / "NNxNN" episode notation (e.g. 2x05,
+# 02x05) that PTT's parse_title recognizes (ptt/handlers.py:1444 season
+# handler) but the SxxExx regex above does not. The (?:\D|^) left boundary
+# and 2-digit season cap keep resolutions like 1920x1080 / 1280x720 /
+# 3840x2160 and codec tokens like x264/x265 from registering as episodes.
+# Accepts the Cyrillic 'х' the PTT handler also allows.
+_EPISODE_NXN_RE = re.compile(r"(?:\D|^)(\d{1,2})[xх](\d{1,3})(?:\D|$)", re.IGNORECASE)
 
 
 def _hint_tokens(value):
@@ -46,6 +53,8 @@ def _episode_tags(value):
         season = int(match.group(1))
         for episode in _EPISODE_NUM_RE.findall(match.group(2)):
             tags.add((season, int(episode)))
+    for match in _EPISODE_NXN_RE.finditer(value):
+        tags.add((int(match.group(1)), int(match.group(2))))
     return frozenset(tags)
 
 
@@ -645,10 +654,15 @@ def find_video_file(
             # sibling when it is at least as good a hint match; otherwise the
             # mismatched current-level file is no worse and stays the fallback.
             if best_file and have_hint:
-                result_ep_score, _ = _title_hint_match_score(
+                result_ep_score, result_tok_score = _title_hint_match_score(
                     result, hint_tokens, hint_episode_tags
                 )
-                if result_ep_score < best_match_score:
+                result_key = (
+                    result_ep_score,
+                    get_video_file_size_hint(result),
+                    result_tok_score,
+                )
+                if result_key < best_file_key:
                     result = None
             if result:
                 return result

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -29,8 +29,14 @@ _EPISODE_NUM_RE = re.compile(r"e(\d{1,4})", re.IGNORECASE)
 # expand the inclusive span below. _EPISODE_RANGE_MAX_SPAN caps expansion so
 # a malformed/absurd range (e.g. S01E01-E999) can't balloon the tag set --
 # beyond the cap we leave the literal endpoints from _EPISODE_TAG_RE intact.
+# The optional `(?:s\1[. _-]*)?` before the final episode number accepts the
+# repeated full-season form "S01E01-S01E03" in addition to "S01E01-E03" /
+# "S01E01-03". The `\1` backreference forces the SAME season, so a cross-season
+# range like "S01E10-S02E02" does NOT satisfy the repeated-season branch and
+# only the literal endpoints (E10, E02) survive via _EPISODE_TAG_RE.
 _EPISODE_RANGE_RE = re.compile(
-    r"s(\d{1,3})[. _-]*e(\d{1,4})[. _-]*-[. _-]*e?(\d{1,4})", re.IGNORECASE
+    r"s(\d{1,3})[. _-]*e(\d{1,4})[. _-]*-[. _-]*(?:s\1[. _-]*)?e?(\d{1,4})",
+    re.IGNORECASE,
 )
 _EPISODE_RANGE_MAX_SPAN = 64
 # Older/scene-alternate "NxNN" / "NNxNN" episode notation (e.g. 2x05,
@@ -44,6 +50,29 @@ _EPISODE_RANGE_MAX_SPAN = 64
 # x264/x265 from registering as episodes. Accepts the Cyrillic 'х' the PTT
 # handler also allows.
 _EPISODE_NXN_RE = re.compile(r"(?<!\d)(\d{1,2})[xх](\d{1,3})(?!\d)", re.IGNORECASE)
+# Well-known display aspect ratios that share the NxN shape (16x9, 4x3, ...)
+# but are NOT episodes. The season cap on _EPISODE_NXN_RE already rejects
+# resolutions (1920x1080) and codecs (x264), but these small ratios slip
+# through and would mis-parse as episode (16, 9) / (4, 3). We FILTER these
+# exact pairs out of the NxN extraction rather than tightening the regex, so
+# real un-padded single-digit episodes like 2x3 or 1x9 still register.
+_ASPECT_RATIO_PAIRS = frozenset(
+    {
+        (16, 9),
+        (4, 3),
+        (21, 9),
+        (16, 10),
+        (2, 35),
+        (2, 39),
+        (2, 40),
+        (1, 85),
+        (1, 78),
+        (1, 33),
+        (2, 20),
+        (1, 90),
+        (2, 76),
+    }
+)
 # NxN RANGE notation "1x01-03" / "1x01-1x03" -- the NxN sibling of
 # _EPISODE_RANGE_RE (SxxEaa-Ebb). The standalone _EPISODE_NXN_RE above only
 # records the literal endpoints (1x01 and 1x03) and drops a bare "-03" half
@@ -93,6 +122,14 @@ def _episode_tags(value):
         season = int(match.group(1))
         start = int(match.group(2))
         end = int(match.group(3))
+        # An aspect ratio (16x9) never forms a valid range start/end, so a
+        # span anchored on one is spurious -- skip it (the standalone NxN loop
+        # below also filters the literal endpoints).
+        if (season, start) in _ASPECT_RATIO_PAIRS or (
+            season,
+            end,
+        ) in _ASPECT_RATIO_PAIRS:
+            continue
         if start <= end <= start + _EPISODE_RANGE_MAX_SPAN:
             for episode in range(start, end + 1):
                 tags.add((season, episode))
@@ -102,7 +139,13 @@ def _episode_tags(value):
     # so behavior is a strict superset and never regresses. tags is a set, so
     # there is no double-count.
     for match in _EPISODE_NXN_RE.finditer(value):
-        tags.add((int(match.group(1)), int(match.group(2))))
+        pair = (int(match.group(1)), int(match.group(2)))
+        # Skip well-known display aspect ratios (16x9, 4x3, ...) that share the
+        # NxN shape but are not episodes. Real un-padded episodes (2x3, 1x9)
+        # are not in the set, so they still register.
+        if pair in _ASPECT_RATIO_PAIRS:
+            continue
+        tags.add(pair)
     return frozenset(tags)
 
 
@@ -678,7 +721,13 @@ def find_video_file(
             # video missing getcontentlength is skipped so recursion can find
             # the real feature in a subfolder rather than returning a
             # placeholder/teaser.
-            has_signal = size > 0 or ep_score > 0 or tok_score > 0
+            # Token overlap alone must NOT establish a signal: per the
+            # docstring, raw token overlap ranks BELOW size, so a zero-size
+            # placeholder/teaser that merely shares title tokens must not be
+            # adopted and pre-empt recursion into the subfolder holding the
+            # real feature. Only a real size or a positive episode match
+            # establishes a selectable signal.
+            has_signal = size > 0 or ep_score > 0
             if has_signal and (best_file_key is None or file_key > best_file_key):
                 best_file_key = file_key
                 best_size = size

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -669,7 +669,17 @@ def find_video_file(
             else:
                 ep_score, tok_score = 0, 0
             file_key = (ep_score, size, tok_score)
-            if best_file_key is None or file_key > best_file_key:
+            # A current-level video only displaces "nothing yet" when it
+            # carries a positive selection signal: a real (non-zero) size --
+            # the historical largest-wins rule, under which main never adopted
+            # a size-0 file but recursed past it -- or, with a hint, a positive
+            # episode/token score. This keeps the no-hint movie path
+            # byte-identical to main (deliberate decision f12b3c3): a top-level
+            # video missing getcontentlength is skipped so recursion can find
+            # the real feature in a subfolder rather than returning a
+            # placeholder/teaser.
+            has_signal = size > 0 or ep_score > 0 or tok_score > 0
+            if has_signal and (best_file_key is None or file_key > best_file_key):
                 best_file_key = file_key
                 best_size = size
                 best_file = href_path

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -35,11 +35,15 @@ _EPISODE_RANGE_RE = re.compile(
 _EPISODE_RANGE_MAX_SPAN = 64
 # Older/scene-alternate "NxNN" / "NNxNN" episode notation (e.g. 2x05,
 # 02x05) that PTT's parse_title recognizes (ptt/handlers.py:1444 season
-# handler) but the SxxExx regex above does not. The (?:\D|^) left boundary
-# and 2-digit season cap keep resolutions like 1920x1080 / 1280x720 /
-# 3840x2160 and codec tokens like x264/x265 from registering as episodes.
-# Accepts the Cyrillic 'х' the PTT handler also allows.
-_EPISODE_NXN_RE = re.compile(r"(?:\D|^)(\d{1,2})[xх](\d{1,3})(?:\D|$)", re.IGNORECASE)
+# handler) but the SxxExx regex above does not. Zero-width `(?<!\d)` /
+# `(?!\d)` digit-lookarounds anchor the tag without CONSUMING the
+# surrounding separator, so adjacent tags ("2x05.2x06") both register
+# instead of the boundary eating the gap and dropping the second (and the
+# middle of a 3-pack). The `\d{1,2}` season cap (unchanged) is what keeps
+# resolutions like 1920x1080 / 1280x720 / 3840x2160 and codec tokens like
+# x264/x265 from registering as episodes. Accepts the Cyrillic 'х' the PTT
+# handler also allows.
+_EPISODE_NXN_RE = re.compile(r"(?<!\d)(\d{1,2})[xх](\d{1,3})(?!\d)", re.IGNORECASE)
 
 
 def _hint_tokens(value):
@@ -98,9 +102,21 @@ def _title_hint_match_score(file_path, hint_tokens, hint_episode_tags):
     name = unquote(file_path.rsplit("/", 1)[-1]) if file_path else ""
     if not name:
         return (0, 0)
+    parent = (
+        unquote(file_path.rsplit("/", 1)[0]) if file_path and "/" in file_path else ""
+    )
     episode_score = 0
     if hint_episode_tags:
+        # Basename FIRST: the file's own episode tag is authoritative. Only
+        # when the basename carries no episode tag (a generically-named file
+        # like "video.mkv") do we fall back to the parent directory's tag --
+        # this is a LAYERED fallback, NOT a union: a matching dir tag must
+        # never mask a wrong-episode FILENAME, or the wrong-episode gate
+        # would regress. A season-complete parent ("Show.S01.Complete")
+        # yields no tag, so largest-wins is preserved there.
         file_tags = _episode_tags(name)
+        if not file_tags and parent:
+            file_tags = _episode_tags(parent)
         if file_tags:
             if hint_episode_tags & file_tags:
                 # Strong match: same episode requested and present.

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -4,10 +4,11 @@
 """WebDAV availability checker for nzbdav streams."""
 
 import base64
+import re
 import threading
 from queue import Queue
 from urllib.error import HTTPError
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 from urllib.request import Request, urlopen
 
 import xbmc
@@ -15,6 +16,66 @@ import xbmc
 _WEBDAV_SUBDIR_SCAN_WORKERS = 4
 _VIDEO_FILE_SIZE_HINTS_MAX = 64
 _VIDEO_FILE_SIZE_HINTS = {}
+# Capture a season followed by one or more episode numbers so a multi-episode
+# file like "S01E01E02E03" yields every episode it contains, not just the
+# first. The episode run allows light separators (e.g. "E01-E02", "E01.E02")
+# between consecutive episode numbers within the same Sxx tag.
+_EPISODE_TAG_RE = re.compile(r"s(\d{1,3})[. _-]*((?:e\d{1,4}[. _-]*)+)", re.IGNORECASE)
+_EPISODE_NUM_RE = re.compile(r"e(\d{1,4})", re.IGNORECASE)
+
+
+def _hint_tokens(value):
+    """Return lowercased alphanumeric tokens for loose name matching."""
+    if not isinstance(value, str) or not value:
+        return frozenset()
+    cleaned = re.sub(r"[\W_]+", " ", value.lower())
+    return frozenset(token for token in cleaned.split() if token)
+
+
+def _episode_tags(value):
+    """Return the set of (season, episode) tags found in a release name.
+
+    A multi-episode tag such as "S01E01E02E03" expands to every episode it
+    spans -- {(1, 1), (1, 2), (1, 3)} -- so a request for a middle episode
+    (E02) still matches the combined file rather than only its first episode.
+    """
+    if not isinstance(value, str) or not value:
+        return frozenset()
+    tags = set()
+    for match in _EPISODE_TAG_RE.finditer(value):
+        season = int(match.group(1))
+        for episode in _EPISODE_NUM_RE.findall(match.group(2)):
+            tags.add((season, int(episode)))
+    return frozenset(tags)
+
+
+def _title_hint_match_score(file_path, hint_tokens, hint_episode_tags):
+    """Return how strongly a video file name matches the requested title hint.
+
+    A shared SxxExx episode tag is the strongest signal (an episode pack must
+    pick the requested episode, not the largest file). Otherwise fall back to
+    raw token overlap. Returns 0 when there is no usable hint or no overlap.
+    """
+    if not hint_tokens and not hint_episode_tags:
+        return 0
+    name = unquote(file_path.rsplit("/", 1)[-1]) if file_path else ""
+    if not name:
+        return 0
+    score = 0
+    if hint_episode_tags:
+        file_tags = _episode_tags(name)
+        if file_tags:
+            if hint_episode_tags & file_tags:
+                # Strong match: same episode requested and present.
+                score += 1000
+            else:
+                # The file names a different episode than requested; never
+                # prefer it over a true match (but token overlap may still
+                # rank it among non-episode candidates).
+                score -= 1000
+    if hint_tokens:
+        score += len(hint_tokens & _hint_tokens(name))
+    return score
 
 
 def _get_settings(settings_getter=None):
@@ -170,19 +231,26 @@ def probe_webdav_reachable(
     return False, "connection_error"
 
 
-def _find_video_file_in_subdirs(subdirs, depth, visited, settings):
-    """Probe sibling WebDAV subfolders and return the LARGEST video found.
+def _find_video_file_in_subdirs(
+    subdirs, depth, visited, settings, hint_tokens=None, hint_episode_tags=None
+):
+    """Probe sibling WebDAV subfolders and return the best video found.
+
+    When a requested title/episode hint is available, a sibling whose video
+    name matches the hint (especially the requested SxxExx episode) is preferred
+    over the largest video — so a multi-episode pack returns the requested
+    episode instead of whichever sibling happens to be biggest. With no hint
+    (or no hint match) the historical "largest video wins" behavior is kept.
 
     Every sibling is scanned (no early-exit on the first match) so a polluted
-    release folder can't win by ordering — e.g. a smaller junk release listed
-    before the real, larger release must not hijack playback. Ties break toward
-    the earliest sibling so behavior stays stable. Sizes come from the
-    PROPFIND ``getcontentlength`` hint each recursive call records; a found
-    video whose size is unknown still beats "no video" so we never drop a
-    playable file just because the server omitted its length.
+    release folder can't win by ordering. Among equally-scored hint matches, or
+    when no hint matches, ties break toward the larger then earlier-listed
+    sibling so behavior stays stable.
     """
     if not subdirs:
         return None
+    hint_tokens = hint_tokens or frozenset()
+    hint_episode_tags = hint_episode_tags or frozenset()
 
     pending = list(subdirs)
     workers = max(1, min(_WEBDAV_SUBDIR_SCAN_WORKERS, len(pending)))
@@ -205,7 +273,15 @@ def _find_video_file_in_subdirs(subdirs, depth, visited, settings):
                 xbmc.LOGDEBUG,
             )
             try:
-                result = find_video_file(subdir, depth + 1, visited, True, settings)
+                result = find_video_file(
+                    subdir,
+                    depth + 1,
+                    visited,
+                    True,
+                    settings,
+                    title_hint_tokens=hint_tokens,
+                    title_hint_episode_tags=hint_episode_tags,
+                )
             except Exception as e:  # pylint: disable=broad-except
                 xbmc.log(
                     "NZB-DAV: Error scanning WebDAV subfolder in parallel: "
@@ -220,18 +296,25 @@ def _find_video_file_in_subdirs(subdirs, depth, visited, settings):
         thread.start()
 
     best_path = None
-    best_size = -1
-    best_index = None
+    best_key = None
+    have_hint = bool(hint_tokens or hint_episode_tags)
     for _ in range(len(pending)):
         index, result = result_queue.get()
         if not result:
             continue
         size = get_video_file_size_hint(result)
-        # Strictly-larger wins; on a tie keep the earlier-listed sibling.
-        if size > best_size or (size == best_size and index < best_index):
+        match_score = (
+            _title_hint_match_score(result, hint_tokens, hint_episode_tags)
+            if have_hint
+            else 0
+        )
+        # Rank by (hint score, size) and break ties toward the earlier sibling
+        # (negative index sorts a smaller index higher). Without a hint the
+        # score stays 0, so this reduces to the historical largest-wins rule.
+        key = (match_score, size, -index)
+        if best_key is None or key > best_key:
             best_path = result
-            best_size = size
-            best_index = index
+            best_key = key
     return best_path
 
 
@@ -262,8 +345,11 @@ def find_video_file(
     _already_encoded=False,
     _settings=None,
     settings_getter=None,
+    title_hint=None,
+    title_hint_tokens=None,
+    title_hint_episode_tags=None,
 ):
-    """Browse a WebDAV folder and find the largest video file.
+    """Browse a WebDAV folder and find the requested (or largest) video file.
 
     Args:
         folder_path: WebDAV folder path to scan (may be absolute or relative).
@@ -276,6 +362,14 @@ def find_video_file(
             the server already URL-encoded for us). Without this, recursive
             descents double-encode ``%20`` → ``%2520`` and every subdirectory
             lookup 404s.
+        title_hint: Optional requested release name (e.g. the selected scene
+            title). When supplied and a folder/pack holds several candidate
+            videos, the one whose name matches the hint — especially the
+            requested SxxExx episode — is preferred over the largest video.
+            When omitted, the historical largest-video behavior is preserved.
+        title_hint_tokens / title_hint_episode_tags: Internal pre-parsed forms
+            of ``title_hint`` threaded through recursion so the hint is parsed
+            once per discovery rather than once per folder level.
 
     Returns:
         The WebDAV href path of the largest video file found, typically an
@@ -293,6 +387,16 @@ def find_video_file(
 
     if _depth > 2:
         return None
+
+    # Parse the title hint once at the top of a discovery; recursive calls
+    # receive the already-parsed token/episode-tag sets so the cost is paid
+    # once, not per folder level.
+    if title_hint_tokens is None and title_hint_episode_tags is None:
+        hint_tokens = _hint_tokens(title_hint)
+        hint_episode_tags = _episode_tags(title_hint)
+    else:
+        hint_tokens = title_hint_tokens or frozenset()
+        hint_episode_tags = title_hint_episode_tags or frozenset()
 
     if _visited is None:
         _visited = set()
@@ -355,6 +459,9 @@ def find_video_file(
 
         best_file = None
         best_size = 0
+        best_file_key = None
+        best_match_score = 0
+        have_hint = bool(hint_tokens or hint_episode_tags)
         subdirs = []
 
         from urllib.parse import urlparse
@@ -459,11 +566,31 @@ def find_video_file(
                         xbmc.LOGWARNING,
                     )
 
-            if size > best_size:
+            # Rank candidate videos by (hint match score, size). Without a hint
+            # the score is always 0, so this stays the historical largest-wins
+            # rule. With a hint, the name-matching video (especially the
+            # requested SxxExx episode) outranks a larger non-matching sibling.
+            match_score = (
+                _title_hint_match_score(href_path, hint_tokens, hint_episode_tags)
+                if have_hint
+                else 0
+            )
+            file_key = (match_score, size)
+            if best_file_key is None or file_key > best_file_key:
+                best_file_key = file_key
                 best_size = size
                 best_file = href_path
+                best_match_score = match_score
 
-        if best_file:
+        # When the best current-level candidate is an explicit episode MISMATCH
+        # (negative hint score) and a hint was given, the requested episode may
+        # still live in a sibling subdir (e.g. a season pack with per-episode
+        # subfolders plus a stray wrong-episode file at the top). Prefer
+        # recursing first so we don't return the wrong episode before even
+        # looking; fall back to the mismatched current-level file only if the
+        # descent finds nothing. The no-hint path keeps the historical
+        # largest-wins/return-immediately behavior untouched.
+        if best_file and not (have_hint and best_match_score < 0 and subdirs):
             file_path = best_file
             _remember_video_file_size_hint(file_path, best_size)
             xbmc.log(
@@ -472,12 +599,51 @@ def find_video_file(
             )
             return file_path
 
-        # No video found at this level, recurse into subdirectories. Subdirs
-        # came from PROPFIND hrefs and are already URL-encoded, so recursive
-        # calls skip top-level quote() to avoid `%20` -> `%2520`.
-        result = _find_video_file_in_subdirs(subdirs, _depth, _visited, settings)
+        if best_file:
+            xbmc.log(
+                "NZB-DAV: Current-level video '{}' is a wrong-episode match for "
+                "the requested title; checking sibling subfolders first".format(
+                    best_file
+                ),
+                xbmc.LOGDEBUG,
+            )
+
+        # No (usable) video found at this level, recurse into subdirectories.
+        # Subdirs came from PROPFIND hrefs and are already URL-encoded, so
+        # recursive calls skip top-level quote() to avoid `%20` -> `%2520`.
+        result = _find_video_file_in_subdirs(
+            subdirs,
+            _depth,
+            _visited,
+            settings,
+            hint_tokens=hint_tokens,
+            hint_episode_tags=hint_episode_tags,
+        )
         if result:
-            return result
+            # If we deferred a wrong-episode current-level file, only adopt the
+            # sibling when it is at least as good a hint match; otherwise the
+            # mismatched current-level file is no worse and stays the fallback.
+            if best_file and have_hint:
+                result_score = _title_hint_match_score(
+                    result, hint_tokens, hint_episode_tags
+                )
+                if result_score < best_match_score:
+                    result = None
+            if result:
+                return result
+
+        # Recursion found nothing better; fall back to the wrong-episode
+        # current-level file rather than returning nothing at all.
+        if best_file:
+            _remember_video_file_size_hint(best_file, best_size)
+            xbmc.log(
+                "NZB-DAV: No matching episode in sibling subfolders; falling "
+                "back to current-level video: {} ({} bytes)".format(
+                    best_file, best_size
+                ),
+                xbmc.LOGINFO,
+            )
+            return best_file
 
         return None
     except Exception as e:
@@ -523,10 +689,15 @@ def get_webdav_stream_url_for_path(file_path, settings_getter=None):
     )
 
 
-def find_video_stream_for_folder(folder_path, settings_getter=None):
-    """Find a folder's playable video path and stream URL with one settings read."""
+def find_video_stream_for_folder(folder_path, settings_getter=None, title_hint=None):
+    """Find a folder's playable video path and stream URL with one settings read.
+
+    ``title_hint`` is the optional requested release name; when supplied it
+    steers multi-episode/multi-video folders toward the requested episode
+    instead of the largest file (see ``find_video_file``).
+    """
     settings = _read_settings(settings_getter)
-    video_path = find_video_file(folder_path, _settings=settings)
+    video_path = find_video_file(folder_path, _settings=settings, title_hint=title_hint)
     if not video_path:
         return None, None, None
     stream_url, stream_headers = _get_webdav_stream_url_for_path_with_settings(

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -22,6 +22,17 @@ _VIDEO_FILE_SIZE_HINTS = {}
 # between consecutive episode numbers within the same Sxx tag.
 _EPISODE_TAG_RE = re.compile(r"s(\d{1,3})[. _-]*((?:e\d{1,4}[. _-]*)+)", re.IGNORECASE)
 _EPISODE_NUM_RE = re.compile(r"e(\d{1,4})", re.IGNORECASE)
+# Episode RANGE notation "SxxEaa-Ebb" / "SxxEaa-bb" (e.g. S01E01-E03,
+# S01E01-03). The base _EPISODE_TAG_RE only records the literal endpoints
+# (E01 and E03) and drops a bare "-03" half entirely, so a request for a
+# covered middle episode (E02) would be scored as a different episode. We
+# expand the inclusive span below. _EPISODE_RANGE_MAX_SPAN caps expansion so
+# a malformed/absurd range (e.g. S01E01-E999) can't balloon the tag set --
+# beyond the cap we leave the literal endpoints from _EPISODE_TAG_RE intact.
+_EPISODE_RANGE_RE = re.compile(
+    r"s(\d{1,3})[. _-]*e(\d{1,4})[. _-]*-[. _-]*e?(\d{1,4})", re.IGNORECASE
+)
+_EPISODE_RANGE_MAX_SPAN = 64
 # Older/scene-alternate "NxNN" / "NNxNN" episode notation (e.g. 2x05,
 # 02x05) that PTT's parse_title recognizes (ptt/handlers.py:1444 season
 # handler) but the SxxExx regex above does not. The (?:\D|^) left boundary
@@ -53,6 +64,13 @@ def _episode_tags(value):
         season = int(match.group(1))
         for episode in _EPISODE_NUM_RE.findall(match.group(2)):
             tags.add((season, int(episode)))
+    for match in _EPISODE_RANGE_RE.finditer(value):
+        season = int(match.group(1))
+        start = int(match.group(2))
+        end = int(match.group(3))
+        if start <= end <= start + _EPISODE_RANGE_MAX_SPAN:
+            for episode in range(start, end + 1):
+                tags.add((season, episode))
     for match in _EPISODE_NXN_RE.finditer(value):
         tags.add((int(match.group(1)), int(match.group(2))))
     return frozenset(tags)

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -52,30 +52,39 @@ def _episode_tags(value):
 def _title_hint_match_score(file_path, hint_tokens, hint_episode_tags):
     """Return how strongly a video file name matches the requested title hint.
 
-    A shared SxxExx episode tag is the strongest signal (an episode pack must
-    pick the requested episode, not the largest file). Otherwise fall back to
-    raw token overlap. Returns 0 when there is no usable hint or no overlap.
+    Returns a 2-tuple ``(episode_score, token_score)`` so callers can rank
+    episode identity ABOVE size but raw token overlap BELOW it:
+
+    * ``episode_score`` is the strongest signal -- ``1000`` when the requested
+      SxxExx episode is present, ``-1000`` when the file names a different
+      episode, ``0`` when no episode comparison applies. An episode pack must
+      pick the requested episode, not the largest file.
+    * ``token_score`` is the raw token-overlap count (``0`` when there is no
+      token hint). For a movie hint (no episode tag) this must NOT outrank
+      size, or a small token-rich extra/trailer would hijack the feature; the
+      folder/sibling sort keys therefore place size between the two scores.
+
+    Returns ``(0, 0)`` when there is no usable hint or the name is empty.
     """
     if not hint_tokens and not hint_episode_tags:
-        return 0
+        return (0, 0)
     name = unquote(file_path.rsplit("/", 1)[-1]) if file_path else ""
     if not name:
-        return 0
-    score = 0
+        return (0, 0)
+    episode_score = 0
     if hint_episode_tags:
         file_tags = _episode_tags(name)
         if file_tags:
             if hint_episode_tags & file_tags:
                 # Strong match: same episode requested and present.
-                score += 1000
+                episode_score = 1000
             else:
                 # The file names a different episode than requested; never
                 # prefer it over a true match (but token overlap may still
                 # rank it among non-episode candidates).
-                score -= 1000
-    if hint_tokens:
-        score += len(hint_tokens & _hint_tokens(name))
-    return score
+                episode_score = -1000
+    token_score = len(hint_tokens & _hint_tokens(name)) if hint_tokens else 0
+    return (episode_score, token_score)
 
 
 def _get_settings(settings_getter=None):
@@ -303,15 +312,19 @@ def _find_video_file_in_subdirs(
         if not result:
             continue
         size = get_video_file_size_hint(result)
-        match_score = (
-            _title_hint_match_score(result, hint_tokens, hint_episode_tags)
-            if have_hint
-            else 0
-        )
-        # Rank by (hint score, size) and break ties toward the earlier sibling
-        # (negative index sorts a smaller index higher). Without a hint the
-        # score stays 0, so this reduces to the historical largest-wins rule.
-        key = (match_score, size, -index)
+        if have_hint:
+            ep_score, tok_score = _title_hint_match_score(
+                result, hint_tokens, hint_episode_tags
+            )
+        else:
+            ep_score, tok_score = 0, 0
+        # Rank by (episode identity, size, token overlap) and break ties toward
+        # the earlier sibling (negative index sorts a smaller index higher).
+        # Episode match is primary so the requested SxxExx still wins; size
+        # outranks loose token overlap so a small token-rich extra can't beat
+        # the feature. Without a hint both scores stay 0, so this reduces to the
+        # historical largest-wins rule.
+        key = (ep_score, size, tok_score, -index)
         if best_key is None or key > best_key:
             best_path = result
             best_key = key
@@ -566,31 +579,39 @@ def find_video_file(
                         xbmc.LOGWARNING,
                     )
 
-            # Rank candidate videos by (hint match score, size). Without a hint
-            # the score is always 0, so this stays the historical largest-wins
-            # rule. With a hint, the name-matching video (especially the
-            # requested SxxExx episode) outranks a larger non-matching sibling.
-            match_score = (
-                _title_hint_match_score(href_path, hint_tokens, hint_episode_tags)
-                if have_hint
-                else 0
-            )
-            file_key = (match_score, size)
+            # Rank candidate videos by (episode identity, size, token overlap).
+            # Without a hint both scores are 0, so this stays the historical
+            # largest-wins rule. With a hint, the requested SxxExx episode
+            # outranks a larger non-matching sibling, while size outranks loose
+            # token overlap so a small token-rich extra can't beat the feature.
+            if have_hint:
+                ep_score, tok_score = _title_hint_match_score(
+                    href_path, hint_tokens, hint_episode_tags
+                )
+            else:
+                ep_score, tok_score = 0, 0
+            file_key = (ep_score, size, tok_score)
             if best_file_key is None or file_key > best_file_key:
                 best_file_key = file_key
                 best_size = size
                 best_file = href_path
-                best_match_score = match_score
+                # Keep the episode score as the recurse/adoption signal so the
+                # wrong-episode gate compares episode identity, not token noise.
+                best_match_score = ep_score
 
-        # When the best current-level candidate is an explicit episode MISMATCH
-        # (negative hint score) and a hint was given, the requested episode may
-        # still live in a sibling subdir (e.g. a season pack with per-episode
-        # subfolders plus a stray wrong-episode file at the top). Prefer
-        # recursing first so we don't return the wrong episode before even
-        # looking; fall back to the mismatched current-level file only if the
-        # descent finds nothing. The no-hint path keeps the historical
-        # largest-wins/return-immediately behavior untouched.
-        if best_file and not (have_hint and best_match_score < 0 and subdirs):
+        # When an episode was requested but the current-level best is NOT a
+        # confirmed episode match (score below the confirmed-match threshold of
+        # 1000), the requested episode may still live in a sibling subdir. This
+        # covers both an explicit wrong-episode file (score -1000) AND a generic
+        # current-level video that merely shares show tokens but carries no
+        # SxxExx tag (score 0) -- either would otherwise be returned before we
+        # ever scan the subdir holding the exact requested episode. Recurse
+        # first; fall back to the current-level file only if the descent finds
+        # nothing better. A movie/token-only hint has empty hint_episode_tags so
+        # it keeps the historical short-circuit, as does the no-hint path.
+        if best_file and not (
+            hint_episode_tags and best_match_score < 1000 and subdirs
+        ):
             file_path = best_file
             _remember_video_file_size_hint(file_path, best_size)
             xbmc.log(
@@ -624,10 +645,10 @@ def find_video_file(
             # sibling when it is at least as good a hint match; otherwise the
             # mismatched current-level file is no worse and stays the fallback.
             if best_file and have_hint:
-                result_score = _title_hint_match_score(
+                result_ep_score, _ = _title_hint_match_score(
                     result, hint_tokens, hint_episode_tags
                 )
-                if result_score < best_match_score:
+                if result_ep_score < best_match_score:
                     result = None
             if result:
                 return result

--- a/repo/plugin.video.nzbdav/resources/settings.xml
+++ b/repo/plugin.video.nzbdav/resources/settings.xml
@@ -150,6 +150,7 @@
 		<setting id="density_breaker_enabled" label="30148" type="bool" default="false" />
 		<setting id="zero_fill_budget_enabled" label="30149" type="bool" default="true" />
 		<setting id="retry_ladder_enabled" label="30150" type="bool" default="true" />
+		<setting id="passthrough_stall_wait" label="30206" type="number" default="120" />
 		<setting id="send_200_no_range" label="30151" type="bool" default="false" />
 		<setting id="cache_warning_shown" type="bool" default="false" visible="false" />
 		<setting id="cache_dialog_dismissed" type="bool" default="false" visible="false" />

--- a/repo/plugin.video.nzbdav/resources/settings.xml
+++ b/repo/plugin.video.nzbdav/resources/settings.xml
@@ -139,6 +139,7 @@
 		<setting label="30183" type="lsep" />
 		<setting id="fallback_streams_enabled" label="30184" type="bool" default="true" />
 		<setting id="fallback_streams_max" label="30185" type="number" default="5" />
+		<setting id="fallback_submit_delay" label="30205" type="number" default="120" />
 		<setting label="30118" type="lsep" />
 		<setting id="proxy_convert_subs" label="30119" type="bool" default="true" />
 		<setting id="force_remux_threshold_mb" label="30123" type="number" default="15000" />

--- a/repo/plugin.video.nzbdav/resources/settings.xml
+++ b/repo/plugin.video.nzbdav/resources/settings.xml
@@ -151,6 +151,7 @@
 		<setting id="zero_fill_budget_enabled" label="30149" type="bool" default="true" />
 		<setting id="retry_ladder_enabled" label="30150" type="bool" default="true" />
 		<setting id="passthrough_stall_wait" label="30206" type="number" default="120" />
+		<setting id="readahead_buffer_mb" label="30207" type="number" default="256" />
 		<setting id="send_200_no_range" label="30151" type="bool" default="false" />
 		<setting id="cache_warning_shown" type="bool" default="false" visible="false" />
 		<setting id="cache_dialog_dismissed" type="bool" default="false" visible="false" />

--- a/repo/plugin.video.nzbdav/service.py
+++ b/repo/plugin.video.nzbdav/service.py
@@ -33,6 +33,11 @@ from resources.lib.stream_proxy import StreamProxy  # noqa: E402
 _PROP_STREAM_URL = "nzbdav.stream_url"
 _PROP_STREAM_TITLE = "nzbdav.stream_title"
 _PROP_ACTIVE = "nzbdav.active"
+# Persistent live-playback liveness flag (distinct from the consume-once
+# ``_PROP_ACTIVE`` handoff signal): set while the service monitors a stream and
+# cleared only on stop/end, so the plugin-process fallback submit worker can
+# observe cross-process whether playback is still live during its standby wait.
+_PROP_PLAYING = "nzbdav.playing"
 _PROP_PROXY_PORT = "nzbdav.proxy_port"
 _PROP_PROXY_TOKEN = "nzbdav.proxy_token"  # nosec B105 — settings key, not a secret
 
@@ -214,6 +219,14 @@ class NzbdavPlayer(xbmc.Player):
                 _HOME_WINDOW.clearProperty(prop)
             except _PLAYER_RUNTIME_ERRORS:
                 pass
+        # Raise the persistent liveness flag now that we are monitoring this
+        # stream. Unlike ``_PROP_ACTIVE`` (consumed above), this stays set until
+        # onPlayBackStopped/Ended clears it, giving the plugin-process fallback
+        # submit worker a reliable cross-process "still playing" signal.
+        try:
+            _HOME_WINDOW.setProperty(_PROP_PLAYING, "true")
+        except _PLAYER_RUNTIME_ERRORS:
+            pass
         xbmc.log(
             "NZB-DAV: Service monitoring stream '{}'".format(title),
             xbmc.LOGINFO,
@@ -242,18 +255,40 @@ class NzbdavPlayer(xbmc.Player):
         up the previous session's URL/title if ``nzbdav.active="true"``
         is ever re-set by a stale/racing writer.
 
-        ``nzbdav.active`` is cleared here too so that "playback inactive"
-        is observable cross-process: the in-process ``state["stop"]`` event
-        the fallback submit worker waits on lives in the resolver/plugin
-        process and can't be set from this service process. Clearing the
-        shared window property lets that worker abort its prewarm wait when
-        the user stops/ends playback during the standby-submit window.
+        ``nzbdav.playing`` (the persistent liveness flag) is cleared here too,
+        on stop/end, so that "playback inactive" is observable cross-process:
+        the in-process ``state["stop"]`` event the fallback submit worker waits
+        on lives in the resolver/plugin process and can't be set from this
+        service process. Clearing this shared window property lets that worker
+        abort its prewarm wait when the user stops/ends playback during the
+        standby-submit window. ``nzbdav.active`` is cleared as a belt-and-braces
+        measure (it is normally already consumed by ``_check_active``).
         """
-        for prop in (_PROP_ACTIVE, _PROP_STREAM_URL, _PROP_STREAM_TITLE):
+        for prop in (
+            _PROP_PLAYING,
+            _PROP_ACTIVE,
+            _PROP_STREAM_URL,
+            _PROP_STREAM_TITLE,
+        ):
             try:
                 _HOME_WINDOW.clearProperty(prop)
             except _PLAYER_RUNTIME_ERRORS:
                 pass
+
+    def _enter_idle_and_clear(self):
+        """Transition to IDLE and clear the IPC properties (incl. liveness).
+
+        Used by tick()'s terminal failure paths (never-started, retries
+        disabled, max retries reached, retry relaunch failed). Like the
+        onPlayBackStopped/Ended callbacks, this clears ``nzbdav.playing`` so the
+        plugin-process fallback submit worker observes the session as dead and
+        aborts its standby wait. ERROR is NOT terminal -- a retry that recovers
+        keeps the flag set so backups still arrive into the recovered playback;
+        only these end-of-the-line transitions clear it.
+        """
+        with self._state_lock:
+            self._state = PlaybackState.IDLE
+        self._clear_stream_properties()
 
     def onPlayBackStopped(self):
         """Mark stream inactive when user stops playback."""
@@ -460,8 +495,7 @@ class NzbdavPlayer(xbmc.Player):
                 _notify(_addon_name(), _s(30121), 8000)
                 xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
                 self._cleanup_proxy_session()
-                with self._state_lock:
-                    self._state = PlaybackState.IDLE
+                self._enter_idle_and_clear()
                 return
 
         self._save_position()
@@ -479,8 +513,7 @@ class NzbdavPlayer(xbmc.Player):
             from resources.lib.i18n import string as _s
 
             _notify(_addon_name(), _s(30115), 8000)
-            with self._state_lock:
-                self._state = PlaybackState.IDLE
+            self._enter_idle_and_clear()
             return
 
         if retry_count >= max_retries:
@@ -492,13 +525,11 @@ class NzbdavPlayer(xbmc.Player):
             from resources.lib.i18n import fmt as _f
 
             _notify(_addon_name(), _f(30116, max_retries), 8000)
-            with self._state_lock:
-                self._state = PlaybackState.IDLE
+            self._enter_idle_and_clear()
             return
 
         if not self._retry_playback(max_retries, retry_delay):
-            with self._state_lock:
-                self._state = PlaybackState.IDLE
+            self._enter_idle_and_clear()
 
 
 def check_cache_warning(state):
@@ -525,6 +556,7 @@ def main():
     # service starts from a clean slate. TODO.md §H.2-M34.
     for stale_prop in (
         _PROP_ACTIVE,
+        _PROP_PLAYING,
         _PROP_STREAM_URL,
         _PROP_STREAM_TITLE,
         _PROP_PROXY_TOKEN,

--- a/repo/plugin.video.nzbdav/service.py
+++ b/repo/plugin.video.nzbdav/service.py
@@ -241,8 +241,15 @@ class NzbdavPlayer(xbmc.Player):
         before writing fresh properties would cause the service to pick
         up the previous session's URL/title if ``nzbdav.active="true"``
         is ever re-set by a stale/racing writer.
+
+        ``nzbdav.active`` is cleared here too so that "playback inactive"
+        is observable cross-process: the in-process ``state["stop"]`` event
+        the fallback submit worker waits on lives in the resolver/plugin
+        process and can't be set from this service process. Clearing the
+        shared window property lets that worker abort its prewarm wait when
+        the user stops/ends playback during the standby-submit window.
         """
-        for prop in (_PROP_STREAM_URL, _PROP_STREAM_TITLE):
+        for prop in (_PROP_ACTIVE, _PROP_STREAM_URL, _PROP_STREAM_TITLE):
             try:
                 _HOME_WINDOW.clearProperty(prop)
             except _PLAYER_RUNTIME_ERRORS:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,42 @@ sys.path.insert(
 )
 
 
+@pytest.fixture(autouse=True)
+def _reap_readahead_threads():
+    """Stop any read-ahead prefetch daemon a test left running.
+
+    ``prepare_stream()`` spawns a per-session ``nzbdav-readahead`` daemon
+    thread (default on via ``readahead_buffer_mb``). In production
+    ``_cleanup_session`` stops it and ``waitForAbort`` really blocks; in the
+    test harness neither happens, so without this reaper one such daemon
+    leaks per ``prepare_stream`` test and they accumulate across the suite,
+    adding timer/GIL load that flakes timing-sensitive tests (e.g. the
+    byte-0 prefetch 0.08s deadline). After each test, signal abort (so the
+    loop's ``waitForAbort`` returns True and it exits) and join briefly,
+    then restore the monitor defaults. Cheap no-op when none were spawned.
+    """
+    yield
+    import threading
+
+    leftover = [
+        t
+        for t in threading.enumerate()
+        if t.name == "nzbdav-readahead" and t.is_alive()
+    ]
+    if not leftover:
+        return
+    monitor = sys.modules["xbmc"].Monitor.return_value
+    saved_side = monitor.waitForAbort.side_effect
+    saved_ret = monitor.waitForAbort.return_value
+    monitor.waitForAbort.side_effect = lambda timeout=0.0: True
+    try:
+        for thread in leftover:
+            thread.join(timeout=2)
+    finally:
+        monitor.waitForAbort.side_effect = saved_side
+        monitor.waitForAbort.return_value = saved_ret
+
+
 @pytest.fixture
 def resolver_mocks():
     """Patch the dependencies that nearly every resolver test needs.

--- a/tests/test_dead_candidates.py
+++ b/tests/test_dead_candidates.py
@@ -40,6 +40,16 @@ def test_timeout_status_is_not_provably_dead():
     assert not is_provably_dead_submit_error({"status": "timeout", "message": "x"})
 
 
+def test_transient_http_status_is_not_provably_dead():
+    for status in (408, 502, 503, 504):
+        assert not is_provably_dead_submit_error({"status": status, "message": "x"})
+
+
+def test_non_transient_http_status_is_provably_dead():
+    for status in (500, 501, 400, 429):
+        assert is_provably_dead_submit_error({"status": status, "message": "x"})
+
+
 def test_none_or_non_dict_is_not_provably_dead():
     assert not is_provably_dead_submit_error(None)
     assert not is_provably_dead_submit_error("oops")

--- a/tests/test_dead_candidates.py
+++ b/tests/test_dead_candidates.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Unit tests for the per-session dead-candidate tracker."""
+
+from resources.lib.dead_candidates import (
+    DeadCandidates,
+    is_provably_dead_submit_error,
+)
+
+
+def test_add_and_query_by_url():
+    dead = DeadCandidates()
+    assert not dead.has_url("http://x/a.nzb")
+    dead.add(nzb_url="http://x/a.nzb")
+    assert dead.has_url("http://x/a.nzb")
+    assert not dead.has_url("http://x/b.nzb")
+
+
+def test_add_and_query_by_nzo_id():
+    dead = DeadCandidates()
+    dead.add(nzo_id="SABnzbd_nzo_123")
+    assert dead.has_nzo("SABnzbd_nzo_123")
+    assert not dead.has_nzo("SABnzbd_nzo_999")
+
+
+def test_add_ignores_empty_keys():
+    dead = DeadCandidates()
+    dead.add(nzb_url="", nzo_id=None)
+    assert not dead.has_url("")
+    assert not dead.has_nzo(None)
+
+
+def test_http_error_status_is_provably_dead():
+    assert is_provably_dead_submit_error({"status": 500, "message": "x"})
+    assert is_provably_dead_submit_error({"status": "rejected", "message": "x"})
+
+
+def test_timeout_status_is_not_provably_dead():
+    assert not is_provably_dead_submit_error({"status": "timeout", "message": "x"})
+
+
+def test_none_or_non_dict_is_not_provably_dead():
+    assert not is_provably_dead_submit_error(None)
+    assert not is_provably_dead_submit_error("oops")

--- a/tests/test_download_ledger.py
+++ b/tests/test_download_ledger.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Tests for the download pubdate ledger.
+
+The ledger records the Usenet post-date (pubdate) of NZBs we actually
+download, keyed by name, so the picker can tell apart same-name reposts
+that share a size but were posted on different days.
+"""
+
+import pytest
+from resources.lib import download_ledger
+
+
+@pytest.fixture(autouse=True)
+def _tmp_ledger(tmp_path, monkeypatch):
+    monkeypatch.setattr(download_ledger, "_ledger_dir", lambda: str(tmp_path))
+    return tmp_path
+
+
+_DEC15 = "Wed, 15 Dec 2021 12:00:00 +0000"  # epoch 1639569600
+_DEC16 = "Thu, 16 Dec 2021 12:00:00 +0000"  # epoch 1639656000
+
+
+def test_record_then_retrieve_round_trips_the_epoch():
+    download_ledger.record_download("Movie X", _DEC15, size=1000)
+    assert download_ledger.downloaded_pubdate_epochs("Movie X") == [1639569600]
+
+
+def test_unknown_name_returns_empty_list():
+    download_ledger.record_download("Movie X", _DEC15)
+    assert not download_ledger.downloaded_pubdate_epochs("Other Movie")
+
+
+def test_unparseable_pubdate_is_not_recorded():
+    download_ledger.record_download("Movie X", "not a date")
+    download_ledger.record_download("Movie X", "")
+    download_ledger.record_download("Movie X", None)
+    assert not download_ledger.downloaded_pubdate_epochs("Movie X")
+
+
+def test_duplicate_pubdate_recorded_once():
+    download_ledger.record_download("Movie X", _DEC15)
+    download_ledger.record_download("Movie X", _DEC15)
+    assert download_ledger.downloaded_pubdate_epochs("Movie X") == [1639569600]
+
+
+def test_distinct_pubdates_accumulate_under_same_name():
+    download_ledger.record_download("Movie X", _DEC15)
+    download_ledger.record_download("Movie X", _DEC16)
+    assert sorted(download_ledger.downloaded_pubdate_epochs("Movie X")) == [
+        1639569600,
+        1639656000,
+    ]
+
+
+def test_per_name_epoch_list_is_capped_keeping_newest():
+    base = 1_600_000_000
+    for i in range(download_ledger._MAX_EPOCHS_PER_NAME + 5):
+        # Synthesize distinct pubdates one day apart.
+        epoch = base + i * 86400
+        pubdate = _epoch_to_rfc2822(epoch)
+        download_ledger.record_download("Spammy Name", pubdate)
+    recorded = download_ledger.downloaded_pubdate_epochs("Spammy Name")
+    assert len(recorded) == download_ledger._MAX_EPOCHS_PER_NAME
+    # The most recently recorded entry is retained; the oldest is dropped.
+    newest = base + (download_ledger._MAX_EPOCHS_PER_NAME + 4) * 86400
+    assert newest in recorded
+    assert base not in recorded
+
+
+def test_corrupt_ledger_file_is_tolerated(tmp_path):
+    (tmp_path / download_ledger._LEDGER_FILENAME).write_text("{ not json", "utf-8")
+    assert not download_ledger.downloaded_pubdate_epochs("Movie X")
+    # A subsequent record still works (corrupt file is overwritten).
+    download_ledger.record_download("Movie X", _DEC15)
+    assert download_ledger.downloaded_pubdate_epochs("Movie X") == [1639569600]
+
+
+def _epoch_to_rfc2822(epoch):
+    from datetime import datetime, timezone
+    from email.utils import format_datetime
+
+    return format_datetime(datetime.fromtimestamp(epoch, tz=timezone.utc))

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -3041,33 +3041,6 @@ def test_fingerprint_ranges_uses_100_deterministic_4096_byte_samples_for_large_f
     assert all((end - start + 1) == 4096 for start, end in ranges)
 
 
-@pytest.mark.skip(
-    reason=(
-        "LRU cache removed to fix Kodi crash; cache is an optimization, "
-        "not core functionality"
-    )
-)
-def test_fingerprint_ranges_reuses_large_file_sample_offsets_between_calls():
-    from resources.lib import fallback_streams
-
-    content_length = 11 * 1024 * 1024 * 1024 + 12345
-    original_sha256 = fallback_streams.hashlib.sha256
-    sha256_calls = []
-
-    def counted_sha256(*args, **kwargs):
-        sha256_calls.append(args)
-        return original_sha256(*args, **kwargs)
-
-    with patch(
-        "resources.lib.fallback_streams.hashlib.sha256", side_effect=counted_sha256
-    ):
-        first = fingerprint_ranges(content_length)
-        second = fingerprint_ranges(content_length)
-
-    assert second == first
-    assert len(sha256_calls) == len(first) - 2
-
-
 def test_fingerprint_ranges_handles_small_files():
     assert fingerprint_ranges(1024) == [(0, 1023)]
 
@@ -3166,12 +3139,6 @@ def test_fetch_content_length_accepts_configured_stream_url(mock_urlopen):
     assert mock_urlopen.call_args.kwargs["timeout"] == 10
 
 
-@pytest.mark.skip(
-    reason=(
-        "LRU cache removed to fix Kodi crash; cache is an optimization, "
-        "not core functionality"
-    )
-)
 def test_fetch_content_length_reuses_validated_probe_url_for_precomputed_bases():
     from resources.lib import fallback_streams
 
@@ -4247,6 +4214,54 @@ def test_same_content_keeps_distinct_seasons_apart_despite_phantom_collapse():
     assert fs._release_identity(s01)[1] == fs._release_identity(s02)[1] == 2014
     assert fs._same_content(s01, s02) is False
     assert fs._same_content(s02, s01) is False
+
+
+def test_titles_core_related_rejects_disjoint_tail_without_corroboration():
+    """FB-1: two titles that share a >=2-token prefix but diverge into DIFFERENT
+    tails on both sides (neither a subset of the other) are typically distinct
+    works in a franchise. A loose >=2-token overlap is not enough to call them
+    the same content -- require corroborating positive identity (matching year,
+    or matching season+episode). Without corroboration the disjoint-tail overlap
+    must be rejected; with it, the loose overlap is allowed.
+    """
+    from resources.lib import fallback_streams as fs
+
+    left = "mission impossible fallout"
+    right = "mission impossible dead reckoning"
+    # Sanity: neither token set is a subset of the other (this is the
+    # disjoint-tail branch, not the junk-suffix subset branch).
+    assert not frozenset(left.split()).issubset(frozenset(right.split()))
+    assert not frozenset(right.split()).issubset(frozenset(left.split()))
+    assert fs._titles_core_related(left, right, corroborated=False) is False
+    assert fs._titles_core_related(right, left, corroborated=False) is False
+    assert fs._titles_core_related(left, right, corroborated=True) is True
+    assert fs._titles_core_related(right, left, corroborated=True) is True
+
+
+def test_same_content_rejects_disjoint_tail_franchise_without_year():
+    """FB-1: different films in a franchise that share a >=2-token prefix but
+    diverge in their tails, with no year on either side, must NOT be treated as
+    the same content (no corroborating year/episode to back the loose overlap).
+    """
+    from resources.lib import fallback_streams as fs
+
+    fallout = _result(
+        "Mission.Impossible.Fallout.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/fallout.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    reckoning = _result(
+        "Mission.Impossible.Dead.Reckoning.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/reckoning.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    # Sanity: PTT leaves the distinguishing tail in the title and parses no year.
+    assert fs._release_identity(fallout)[1] == 0
+    assert fs._release_identity(reckoning)[1] == 0
+    assert fs._same_content(fallout, reckoning) is False
+    assert fs._same_content(reckoning, fallout) is False
 
 
 @patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -3976,6 +3976,111 @@ def test_same_content_keeps_junk_suffix_repost_peering():
     assert fs._same_content(mirror, primary) is True
 
 
+def test_same_content_rejects_numeric_sequel_suffix_without_year():
+    """FS: a lone numeric sequel tail ("Avatar 2") is a content discriminator,
+    not a junk suffix, even when neither side parses a year (PTT keeps the
+    sequel number in the title and _part_number_from_title only covers labeled
+    parts)."""
+    from resources.lib import fallback_streams as fs
+
+    sequel = _result(
+        "Avatar.2.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/avatar2.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    original = _result(
+        "Avatar.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/avatar.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    # Sanity: PTT keeps the sequel number in the title, parses no year.
+    assert fs._release_identity(sequel)[0] == "avatar 2"
+    assert fs._release_identity(sequel)[1] == 0
+    assert fs._release_identity(original)[0] == "avatar"
+    assert fs._same_content(sequel, original) is False
+    assert fs._same_content(original, sequel) is False
+    rocky2 = _result(
+        "Rocky.2.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/rocky2.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    rocky = _result(
+        "Rocky.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/rocky.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(rocky2, rocky) is False
+    assert fs._same_content(rocky, rocky2) is False
+
+
+def test_same_content_ignores_phantom_season_for_movie_peer():
+    """FS: a movie whose release-group suffix mis-parses as a season (e.g.
+    REMUX-ALT01 -> seasons=[1]) must still peer with the same movie posted by a
+    normal group (seasons=[]) when both carry the same parsed year.
+
+    Without the guarded collapse the phantom season makes one side look
+    episodic, and the season-presence parity check then rejects the same
+    movie from a normal group.
+    """
+    from resources.lib import fallback_streams as fs
+
+    phantom = _result(
+        "The.Matrix.1999.2160p.UHD.BluRay.REMUX.DV.HEVC-REMUX-ALT01",
+        "https://idx/matrix-alt01.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    normal = _result(
+        "The.Matrix.1999.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/matrix-group.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    # Sanity: the suffix injects a phantom season on one side only, no episode,
+    # and both sides parse the same year.
+    phantom_identity = fs._release_identity(phantom)
+    normal_identity = fs._release_identity(normal)
+    assert phantom_identity[2] == (1,)
+    assert phantom_identity[3] == ()
+    assert normal_identity[2] == ()
+    assert normal_identity[3] == ()
+    assert phantom_identity[1] == normal_identity[1] == 1999
+    assert fs._same_content(phantom, normal) is True
+    assert fs._same_content(normal, phantom) is True
+
+
+def test_same_content_keeps_distinct_seasons_apart_despite_phantom_collapse():
+    """REGRESSION GUARD: the phantom-season collapse must NOT relax genuinely
+    different seasons. Fargo S01 and S02 both carry a season AND the same year,
+    so the season-presence parity holds and they stay subject to season
+    equality — they must remain different content.
+    """
+    from resources.lib import fallback_streams as fs
+
+    s01 = _result(
+        "Fargo.2014.S01.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/fargo-s01.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    s02 = _result(
+        "Fargo.2014.S02.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/fargo-s02.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    # Sanity: both sides carry a season and the same year (presence matches).
+    assert fs._release_identity(s01)[2] == (1,)
+    assert fs._release_identity(s02)[2] == (2,)
+    assert fs._release_identity(s01)[1] == fs._release_identity(s02)[1] == 2014
+    assert fs._same_content(s01, s02) is False
+    assert fs._same_content(s02, s01) is False
+
+
 @patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
 @patch("resources.lib.fallback_streams._fallback_settings")
 def test_same_episode_different_group_is_allowed_fallback(mock_settings, mock_fetch):

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -3904,6 +3904,45 @@ def test_same_content_rejects_different_part_same_episode():
     assert fs._same_content(part_two, part_one) is False
 
 
+def test_same_content_rejects_episode_with_conflicting_years():
+    """REGRESSION GUARD: a same-SxxExx episode whose differing parsed year marks
+    a distinct production (a reboot/remake) is DIFFERENT content. The original
+    Doctor Who (2005) S01E01 must never peer with the reboot (2023) S01E01."""
+    from resources.lib import fallback_streams as fs
+
+    classic = _result(
+        "Doctor.Who.2005.S01E01.1080p.WEB-DL.x265-GROUP",
+        "https://idx/dw-2005.nzb",
+        2000000000,
+    )
+    reboot = _result(
+        "Doctor.Who.2023.S01E01.1080p.WEB-DL.x265-GROUP",
+        "https://idx/dw-2023.nzb",
+        2000000000,
+    )
+    assert fs._same_content(classic, reboot) is False
+    assert fs._same_content(reboot, classic) is False
+
+    # A same-year same-episode repost still peers.
+    same_year = _result(
+        "Doctor.Who.2005.S01E01.1080p.WEB-DL.x265-ALT",
+        "https://idx/dw-2005-alt.nzb",
+        2000000000,
+    )
+    assert fs._same_content(classic, same_year) is True
+    assert fs._same_content(same_year, classic) is True
+
+    # One side omitting the year must NOT reject (only both-parsed-and-differ
+    # rejects), so a yearless repost of the same episode still peers.
+    yearless = _result(
+        "Doctor.Who.S01E01.1080p.WEB-DL.x265-ALT",
+        "https://idx/dw-yearless.nzb",
+        2000000000,
+    )
+    assert fs._same_content(classic, yearless) is True
+    assert fs._same_content(yearless, classic) is True
+
+
 def test_titles_core_related_fails_closed_on_empty_token_set():
     """FS-2: an empty core-title token set must not fail open.
 

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -3855,6 +3855,64 @@ def test_same_content_rejects_part_one_vs_part_two():
     assert fs._same_content(part_two, part_one) is False
 
 
+def test_same_episode_with_part_token_matches_bare_repost():
+    """An episode that carries an episode-title Part/Chapter token must still
+    peer with the same SxxExx posted without that token.
+
+    PTT leaves words like "Chapter One" inside an episode title, so the
+    part-vs-bare xor (the 'Dune Part Two' vs 'Dune' movie discriminator) must
+    NOT fire for episodes — both sides are the same episode, one just spelled
+    out its episode title.
+    """
+    from resources.lib import fallback_streams as fs
+
+    titled = _result(
+        "Show.Name.S01E01.Chapter.1.1080p.WEB-DL.x265-GROUP",
+        "https://idx/titled.nzb",
+        2000000000,
+    )
+    bare = _result(
+        "Show.Name.S01E01.1080p.WEB-DL.x265-GROUP",
+        "https://idx/bare.nzb",
+        2000000000,
+    )
+    assert fs._same_content(titled, bare) is True
+    assert fs._same_content(bare, titled) is True
+
+    real_titled = _result(
+        "Stranger.Things.S04E01.Chapter.One.The.Hellfire.Club.1080p.NF.WEB-DL.x265-GROUP",
+        "https://idx/stranger-titled.nzb",
+        2000000000,
+    )
+    real_bare = _result(
+        "Stranger.Things.S04E01.1080p.NF.WEB-DL.x265-GROUP",
+        "https://idx/stranger-bare.nzb",
+        2000000000,
+    )
+    assert fs._same_content(real_titled, real_bare) is True
+    assert fs._same_content(real_bare, real_titled) is True
+
+
+def test_same_content_rejects_different_part_same_episode():
+    """REGRESSION GUARD: same SxxExx but a differing explicit part is different
+    content, so the global differing-explicit-part reject must still apply to
+    episodes (the broad CodeRabbit fix would false-accept this)."""
+    from resources.lib import fallback_streams as fs
+
+    part_one = _result(
+        "Some.Show.S01E01.Part.1.1080p.WEB-DL.x265-GROUP",
+        "https://idx/ep-part-one.nzb",
+        2000000000,
+    )
+    part_two = _result(
+        "Some.Show.S01E01.Part.2.1080p.WEB-DL.x265-GROUP",
+        "https://idx/ep-part-two.nzb",
+        2000000000,
+    )
+    assert fs._same_content(part_one, part_two) is False
+    assert fs._same_content(part_two, part_one) is False
+
+
 def test_titles_core_related_fails_closed_on_empty_token_set():
     """FS-2: an empty core-title token set must not fail open.
 

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -4597,3 +4597,80 @@ def test_rank_fallback_candidates_prefers_exact_same_filename():
 
     assert ranked[0] is exact
     assert ranked[1] is closer
+
+
+def _dated(tier, pubdate, link, exact_name=1, size_delta=0):
+    """Build a (exact_name, tier, size_delta, candidate) ranking tuple."""
+    return (exact_name, tier, size_delta, {"link": link, "pubdate": pubdate})
+
+
+def test_dedupe_pubdate_collapses_same_hour_keeping_best_tier():
+    from resources.lib import fallback_streams
+
+    target = {"pubdate": ""}  # undated primary -> no primary suppression
+    worse = _dated(2, "Mon, 01 Jan 2024 00:10:00 +0000", "https://a/nzb")
+    better = _dated(0, "Mon, 01 Jan 2024 00:50:00 +0000", "https://b/nzb")
+
+    result = fallback_streams._dedupe_candidates_by_pubdate(target, [worse, better])
+
+    assert [item[3]["link"] for item in result] == ["https://b/nzb"]
+
+
+def test_dedupe_pubdate_keeps_candidates_more_than_an_hour_apart():
+    from resources.lib import fallback_streams
+
+    target = {"pubdate": ""}
+    first = _dated(1, "Mon, 01 Jan 2024 00:00:00 +0000", "https://a/nzb")
+    second = _dated(1, "Mon, 01 Jan 2024 02:00:00 +0000", "https://b/nzb")
+
+    result = fallback_streams._dedupe_candidates_by_pubdate(target, [first, second])
+
+    assert {item[3]["link"] for item in result} == {"https://a/nzb", "https://b/nzb"}
+
+
+def test_dedupe_pubdate_is_anchor_based_not_transitive():
+    from resources.lib import fallback_streams
+
+    target = {"pubdate": ""}
+    a = _dated(1, "Mon, 01 Jan 2024 00:00:00 +0000", "https://a/nzb")
+    b = _dated(1, "Mon, 01 Jan 2024 00:50:00 +0000", "https://b/nzb")
+    c = _dated(1, "Mon, 01 Jan 2024 01:40:00 +0000", "https://c/nzb")
+
+    result = fallback_streams._dedupe_candidates_by_pubdate(target, [a, b, c])
+    links = {item[3]["link"] for item in result}
+
+    # a & b (50 min) collapse to one; c is >1h from the a-anchor -> distinct.
+    assert len(result) == 2
+    assert "https://c/nzb" in links
+    assert ("https://a/nzb" in links) != ("https://b/nzb" in links)
+
+
+def test_dedupe_pubdate_drops_candidates_sharing_primary_date():
+    from resources.lib import fallback_streams
+
+    target = {"pubdate": "Mon, 01 Jan 2024 00:00:00 +0000"}
+    same_as_primary = _dated(0, "Mon, 01 Jan 2024 00:30:00 +0000", "https://a/nzb")
+    distinct = _dated(1, "Mon, 01 Jan 2024 03:00:00 +0000", "https://b/nzb")
+
+    result = fallback_streams._dedupe_candidates_by_pubdate(
+        target, [same_as_primary, distinct]
+    )
+
+    assert [item[3]["link"] for item in result] == ["https://b/nzb"]
+
+
+def test_dedupe_pubdate_keeps_all_undated_candidates():
+    from resources.lib import fallback_streams
+
+    target = {"pubdate": ""}
+    one = (1, 1, 0, {"link": "https://a/nzb"})  # no pubdate key
+    two = (1, 1, 0, {"link": "https://b/nzb", "pubdate": ""})  # empty pubdate
+    three = (1, 1, 0, {"link": "https://c/nzb", "pubdate": "not a date"})
+
+    result = fallback_streams._dedupe_candidates_by_pubdate(target, [one, two, three])
+
+    assert {item[3]["link"] for item in result} == {
+        "https://a/nzb",
+        "https://b/nzb",
+        "https://c/nzb",
+    }

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -4458,3 +4458,99 @@ def test_fallback_candidates_sorted_best_tier_first(mock_settings, mock_fetch):
     attach_fallback_candidates([primary, worse, best])
 
     assert primary["_fallback_candidates"] == [best, worse]
+
+
+def test_metadata_profiles_match_fails_closed_on_unknown_resolution_same_group():
+    """When same-group backups are required, a candidate whose resolution PTT
+    could not parse must be REJECTED — the user requires the backup share the
+    primary's resolution, so the gate fails closed like the group gate."""
+    from resources.lib import fallback_streams
+
+    primary = _result(
+        "Example Movie 2026 1080p WEB-DL x265-GROUP",
+        "https://a/nzb",
+        1000,
+        meta=_movie_meta(resolution="1080p", codec="x265/HEVC", group="GROUP"),
+    )
+    unknown_res = _result(
+        "Example Movie 2026 WEB-DL x265-GROUP",
+        "https://b/nzb",
+        1000,
+        meta=_movie_meta(resolution="", codec="x265/HEVC", group="GROUP"),
+    )
+    assert not fallback_streams._metadata_profiles_match(
+        primary, unknown_res, require_same_group=True
+    )
+
+
+def test_metadata_profiles_match_rejects_different_resolution_same_group():
+    from resources.lib import fallback_streams
+
+    primary = _result(
+        "Example Movie 2026 1080p WEB-DL x265-GROUP",
+        "https://a/nzb",
+        1000,
+        meta=_movie_meta(resolution="1080p", codec="x265/HEVC", group="GROUP"),
+    )
+    other_res = _result(
+        "Example Movie 2026 2160p WEB-DL x265-GROUP",
+        "https://b/nzb",
+        1000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
+    )
+    assert not fallback_streams._metadata_profiles_match(
+        primary, other_res, require_same_group=True
+    )
+
+
+def test_metadata_profiles_match_accepts_same_resolution_same_group():
+    from resources.lib import fallback_streams
+
+    primary = _result(
+        "Example Movie 2026 1080p WEB-DL x265-GROUP",
+        "https://a/nzb",
+        1000,
+        meta=_movie_meta(resolution="1080p", codec="x265/HEVC", group="GROUP"),
+    )
+    same = _result(
+        "Example Movie 2026 1080p WEB-DL x265-GROUP",
+        "https://b/nzb",
+        1000,
+        meta=_movie_meta(resolution="1080p", codec="x265/HEVC", group="GROUP"),
+    )
+    assert fallback_streams._metadata_profiles_match(
+        primary, same, require_same_group=True
+    )
+
+
+def test_rank_fallback_candidates_prefers_exact_same_filename():
+    """An exact-same-filename repost (different upload) must be ranked ahead of a
+    closer-by-tier/size peer — the user wants exact filenames preferred first."""
+    from resources.lib import fallback_streams
+
+    meta = _movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP")
+    target = _result(
+        "Example 2026 2160p BluRay x265-GROUP", "https://t/nzb", 60000000000, meta=meta
+    )
+    target["_fallback_manifest"] = _manifest(
+        "video", "example.2026.2160p.group.mkv", 60000000000, "t"
+    )
+    # Tier 0 peer (same res+codec+group, size within 3%) but DIFFERENT filename.
+    closer = _result(
+        "Example 2026 2160p BluRay x265-GROUP", "https://c/nzb", 60000000000, meta=meta
+    )
+    closer["_fallback_manifest"] = _manifest(
+        "video", "different.name.mkv", 60000000000, "c"
+    )
+    # Tier 1 peer (size ~10% off -> not tier 0) but EXACT same filename.
+    exact = _result(
+        "Example 2026 2160p BluRay x265-GROUP", "https://e/nzb", 66000000000, meta=meta
+    )
+    exact["_fallback_manifest"] = _manifest(
+        "video", "example.2026.2160p.group.mkv", 66000000000, "e"
+    )
+
+    ranked = fallback_streams._rank_fallback_candidates(target, [closer, exact])
+
+    assert ranked[0] is exact
+    assert ranked[1] is closer

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -4460,6 +4460,49 @@ def test_fallback_candidates_sorted_best_tier_first(mock_settings, mock_fetch):
     assert primary["_fallback_candidates"] == [best, worse]
 
 
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_attach_fallback_candidates_prefers_exact_filename_over_tier(
+    mock_settings, mock_fetch
+):
+    """Through the production attach path, an exact-same-filename repost (a
+    different upload of the byte-identical file) must rank ahead of a closer
+    tier/size peer — the user requirement to try exact filenames first."""
+    mock_settings.return_value = (True, 5)
+    primary = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/primary.nzb",
+        60000000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
+    )
+    # Tier 0 (size within 3%) but a DIFFERENT filename — listed first to prove
+    # the exact-filename key re-orders ahead of the better tier.
+    closer = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/closer.nzb",
+        60100000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
+    )
+    # Tier 1 (size beyond 3%, within the 10% peer band) but the EXACT same
+    # filename as the primary.
+    exact = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/exact.nzb",
+        62500000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
+    )
+    manifests = {
+        "https://idx/primary.nzb": _manifest("video", "dune.mkv", 60000000000, "a"),
+        "https://idx/closer.nzb": _manifest("video", "other.mkv", 60100000000, "c"),
+        "https://idx/exact.nzb": _manifest("video", "dune.mkv", 62500000000, "b"),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    attach_fallback_candidates([primary, closer, exact])
+
+    assert primary["_fallback_candidates"] == [exact, closer]
+
+
 def test_metadata_profiles_match_fails_closed_on_unknown_resolution_same_group():
     """When same-group backups are required, a candidate whose resolution PTT
     could not parse must be REJECTED — the user requires the backup share the

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -4689,3 +4689,45 @@ def test_dedupe_pubdate_keeps_all_undated_candidates():
         "https://b/nzb",
         "https://c/nzb",
     }
+
+
+def test_attach_candidates_dedupes_same_postdate_keeping_best_tier():
+    from resources.lib import fallback_streams
+
+    meta = _movie_meta(resolution="1080p", codec="x265/HEVC", group="GROUP")
+    target = _result(
+        "Example 2026 1080p WEB-DL x265-GROUP", "https://t/nzb", 10000000000, meta=meta
+    )
+    target["_fallback_manifest"] = _manifest(
+        "video", "example.2026.1080p.group.mkv", 10000000000, "t"
+    )
+    target["pubdate"] = "Wed, 01 May 2024 12:00:00 +0000"
+
+    # Same content + group + size -> tier 0. Posted 20 min apart -> same article.
+    keep = _result(
+        "Example 2026 1080p WEB-DL x265-GROUP",
+        "https://keep/nzb",
+        10000000000,
+        meta=meta,
+    )
+    keep["_fallback_manifest"] = _manifest(
+        "video", "example.2026.1080p.group.mkv", 10000000000, "keep"
+    )
+    keep["pubdate"] = "Thu, 02 May 2024 00:00:00 +0000"
+
+    drop = _result(
+        "Example 2026 1080p WEB-DL x265-GROUP",
+        "https://drop/nzb",
+        10000000000,
+        meta=meta,
+    )
+    drop["_fallback_manifest"] = _manifest(
+        "video", "example.2026.1080p.group.mkv", 10000000000, "drop"
+    )
+    drop["pubdate"] = "Thu, 02 May 2024 00:20:00 +0000"
+
+    fallback_streams._attach_candidates_for_target(target, [keep, drop], 5)
+
+    links = [c["link"] for c in target["_fallback_candidates"]]
+    assert len(links) == 1
+    assert links[0] in ("https://keep/nzb", "https://drop/nzb")

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -4642,7 +4642,22 @@ def test_dedupe_pubdate_is_anchor_based_not_transitive():
     # a & b (50 min) collapse to one; c is >1h from the a-anchor -> distinct.
     assert len(result) == 2
     assert "https://c/nzb" in links
-    assert ("https://a/nzb" in links) != ("https://b/nzb" in links)
+    assert "https://a/nzb" in links  # equal tier -> order_index tie-break keeps first
+    assert "https://b/nzb" not in links
+
+
+def test_dedupe_pubdate_boundary_exactly_one_hour_collapses():
+    from resources.lib import fallback_streams
+
+    target = {"pubdate": ""}
+    first = _dated(1, "Mon, 01 Jan 2024 00:00:00 +0000", "https://a/nzb")
+    # Exactly 3600s later -> inclusive window -> same article -> collapse.
+    second = _dated(1, "Mon, 01 Jan 2024 01:00:00 +0000", "https://b/nzb")
+
+    result = fallback_streams._dedupe_candidates_by_pubdate(target, [first, second])
+
+    assert len(result) == 1
+    assert result[0][3]["link"] == "https://a/nzb"
 
 
 def test_dedupe_pubdate_drops_candidates_sharing_primary_date():

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -4718,16 +4718,70 @@ def test_attach_candidates_dedupes_same_postdate_keeping_best_tier():
     drop = _result(
         "Example 2026 1080p WEB-DL x265-GROUP",
         "https://drop/nzb",
-        10000000000,
+        11000000000,
         meta=meta,
     )
     drop["_fallback_manifest"] = _manifest(
-        "video", "example.2026.1080p.group.mkv", 10000000000, "drop"
+        "video", "example.2026.1080p.group.mkv", 11000000000, "drop"
     )
     drop["pubdate"] = "Thu, 02 May 2024 00:20:00 +0000"
 
     fallback_streams._attach_candidates_for_target(target, [keep, drop], 5)
 
     links = [c["link"] for c in target["_fallback_candidates"]]
-    assert len(links) == 1
-    assert links[0] in ("https://keep/nzb", "https://drop/nzb")
+    assert links == ["https://keep/nzb"]
+
+
+def test_rank_fallback_candidates_dedupes_same_postdate():
+    from resources.lib import fallback_streams
+
+    meta = _movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP")
+    target = _result(
+        "Example 2026 2160p BluRay x265-GROUP", "https://t/nzb", 60000000000, meta=meta
+    )
+    target["_fallback_manifest"] = _manifest(
+        "video", "example.2026.2160p.group.mkv", 60000000000, "t"
+    )
+    target["pubdate"] = "Fri, 10 May 2024 08:00:00 +0000"
+
+    early = _result(
+        "Example 2026 2160p BluRay x265-GROUP",
+        "https://early/nzb",
+        60000000000,
+        meta=meta,
+    )
+    early["_fallback_manifest"] = _manifest(
+        "video", "example.2026.2160p.group.mkv", 60000000000, "early"
+    )
+    early["pubdate"] = "Sat, 11 May 2024 09:00:00 +0000"
+
+    # 40 min after `early` -> same article -> must collapse.
+    dupe = _result(
+        "Example 2026 2160p BluRay x265-GROUP",
+        "https://dupe/nzb",
+        60000000000,
+        meta=meta,
+    )
+    dupe["_fallback_manifest"] = _manifest(
+        "video", "example.2026.2160p.group.mkv", 60000000000, "dupe"
+    )
+    dupe["pubdate"] = "Sat, 11 May 2024 09:40:00 +0000"
+
+    # 3 hours after `early` -> distinct -> must survive.
+    distinct = _result(
+        "Example 2026 2160p BluRay x265-GROUP",
+        "https://distinct/nzb",
+        60000000000,
+        meta=meta,
+    )
+    distinct["_fallback_manifest"] = _manifest(
+        "video", "example.2026.2160p.group.mkv", 60000000000, "distinct"
+    )
+    distinct["pubdate"] = "Sat, 11 May 2024 12:00:00 +0000"
+
+    ranked = fallback_streams._rank_fallback_candidates(target, [early, dupe, distinct])
+    links = {c["link"] for c in ranked}
+
+    assert "https://distinct/nzb" in links
+    assert ("https://early/nzb" in links) != ("https://dupe/nzb" in links)
+    assert len(ranked) == 2

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -1318,7 +1318,7 @@ def test_selection_fallback_rejects_batch_after_unusable_selected_manifest(
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALT{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALTx{:02d}".format(index),
             "https://idx/fallback-unusable-selected-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -1370,7 +1370,7 @@ def test_selection_fallback_skips_candidate_wait_after_unusable_selected_manifes
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-SLOW{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-SLOWx{:02d}".format(index),
             "https://idx/fallback-slow-unusable-selected-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -1792,7 +1792,7 @@ def test_selection_fallback_stops_manifest_fetch_after_max_candidates(
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALT{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALTx{:02d}".format(index),
             "https://idx/fallback-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -1846,7 +1846,7 @@ def test_selection_fallback_fetches_candidate_manifests_in_parallel(
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-PAR{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-PARx{:02d}".format(index),
             "https://idx/fallback-parallel-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -1911,7 +1911,7 @@ def test_selection_fallback_overlaps_selected_manifest_with_candidate_batch(
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-OVR{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-OVRx{:02d}".format(index),
             "https://idx/fallback-overlap-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -1970,7 +1970,7 @@ def test_selection_fallback_pipelines_second_manifest_wave_after_underfill(
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-PIPE{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-PIPEx{:02d}".format(index),
             "https://idx/fallback-pipeline-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -2179,7 +2179,7 @@ def test_selection_fallback_scales_second_wave_to_remaining_slots(
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-SCALE{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-SCALEx{:02d}".format(index),
             "https://idx/fallback-scaled-wave-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -2380,7 +2380,7 @@ def test_selection_fallback_stops_prefilter_scan_after_max_attached_candidates(
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALT{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALTx{:02d}".format(index),
             "https://idx/fallback-extra-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -2447,7 +2447,7 @@ def test_selection_fallback_reuses_prefilter_match_for_manifest_gate(
     )
     candidates = [
         _result(
-            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALT{:02d}".format(index),
+            "The.Matrix.1999.UHD.BluRay.2160p.DV.HEVC.REMUX-ALTx{:02d}".format(index),
             "https://idx/fallback-{}.nzb".format(index),
             60000000000,
             meta=selected["_meta"],
@@ -3215,6 +3215,11 @@ def test_fetch_content_length_reuses_validated_probe_url_for_precomputed_bases()
 def test_precomputed_probe_bases_reuse_base_origin_checks_for_range_digest():
     from resources.lib import fallback_streams
 
+    # The module-level @lru_cache on _cached_validated_probe_url leaks across
+    # tests; clear it so this assertion is independent of test execution order.
+    if hasattr(fallback_streams._cached_validated_probe_url, "cache_clear"):
+        fallback_streams._cached_validated_probe_url.cache_clear()
+
     body = b"A" * 4
     response = _mock_range_response(
         body,
@@ -3319,13 +3324,14 @@ def test_fetch_range_digest_accepts_matching_partial_content(mock_urlopen):
 
 @patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
 @patch("resources.lib.fallback_streams._fallback_settings")
-def test_video_manifest_peer_match_accepts_size_within_20_percent_tolerance(
+def test_video_manifest_peer_match_accepts_size_within_10_percent_tolerance(
     mock_settings, mock_fetch
 ):
     """Different uploads of the same source MKV use different yEnc segment sizes,
     so two video manifests for the same release will report different group_bytes.
-    Accept matches when the bytes are within +/-20% as long as title and profile
-    gates already passed.
+    Accept matches when the bytes are within the +/-10% Tier-1 band as long as the
+    content-identity gate already passed. (Tightened from the old +/-20% band so a
+    differently-encoded release can no longer slip through on size alone.)
     """
     mock_settings.return_value = (True, 5)
     primary = _result(
@@ -3344,7 +3350,7 @@ def test_video_manifest_peer_match_accepts_size_within_20_percent_tolerance(
     repost_within_tolerance = _result(
         "Once.Upon.a.Time.in.the.West.1968.PROPER.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HEVC.HYBRID.REMUX-FraMeSToR",
         "https://idx/repost.nzb",
-        110000000000,
+        103000000000,
         meta={
             "resolution": "2160p",
             "quality": "BluRay REMUX",
@@ -3359,7 +3365,7 @@ def test_video_manifest_peer_match_accepts_size_within_20_percent_tolerance(
             "video", "once upon a time framestor.mkv", 95000000000, "articles-a"
         ),
         "https://idx/repost.nzb": _manifest(
-            "video", "once upon a time alt repost.mkv", 110000000000, "articles-b"
+            "video", "once upon a time alt repost.mkv", 103000000000, "articles-b"
         ),
     }
     mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
@@ -3687,3 +3693,350 @@ def test_archive_peers_with_shared_archive_base_match_via_group_key_short_circui
 
     assert primary["_fallback_candidates"] == [repost_shared_base]
     assert repost_shared_base["_fallback_candidates"] == [primary]
+
+
+# ---------------------------------------------------------------------------
+# Tiered content-identity fallback (F1/F2/F3)
+# ---------------------------------------------------------------------------
+
+
+def _movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"):
+    return {
+        "resolution": resolution,
+        "quality": "BluRay REMUX",
+        "codec": codec,
+        "hdr": ["Dolby Vision"],
+        "group": group,
+        "container": "mkv",
+    }
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_content_identity_gate_rejects_different_movie_part(mock_settings, mock_fetch):
+    """Dune Part Two must never fall back to Dune Part One even though the
+    release tokens (dune, part, year, profile) overlap heavily."""
+    mock_settings.return_value = (True, 5)
+    part_two = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/part-two.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    part_one = _result(
+        "Dune.Part.One.2021.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/part-one.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    manifests = {
+        "https://idx/part-two.nzb": _manifest(
+            "video", "dune two.mkv", 60000000000, "a"
+        ),
+        "https://idx/part-one.nzb": _manifest(
+            "video", "dune one.mkv", 60000000000, "b"
+        ),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    attach_fallback_candidates([part_two, part_one])
+
+    assert part_two["_fallback_candidates"] == []
+    assert part_one["_fallback_candidates"] == []
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_content_identity_gate_rejects_different_movie_year(mock_settings, mock_fetch):
+    """Same title, different year (Avatar 2009 vs 2022) is different content."""
+    mock_settings.return_value = (True, 5)
+    old = _result(
+        "Avatar.2009.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/avatar-2009.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    new = _result(
+        "Avatar.2022.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/avatar-2022.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    manifests = {
+        "https://idx/avatar-2009.nzb": _manifest("video", "a.mkv", 60000000000, "a"),
+        "https://idx/avatar-2022.nzb": _manifest("video", "b.mkv", 60000000000, "b"),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    attach_fallback_candidates([old, new])
+
+    assert old["_fallback_candidates"] == []
+    assert new["_fallback_candidates"] == []
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_content_identity_gate_rejects_different_episode(mock_settings, mock_fetch):
+    """S02E05 must not fall back to S02E06 or S01E05."""
+    mock_settings.return_value = (True, 5)
+    e05 = _result(
+        "Show.Name.S02E05.2160p.WEB-DL.x265-GROUP",
+        "https://idx/e05.nzb",
+        6000000000,
+        meta=_movie_meta(),
+    )
+    e06 = _result(
+        "Show.Name.S02E06.2160p.WEB-DL.x265-GROUP",
+        "https://idx/e06.nzb",
+        6000000000,
+        meta=_movie_meta(),
+    )
+    s01 = _result(
+        "Show.Name.S01E05.2160p.WEB-DL.x265-GROUP",
+        "https://idx/s01e05.nzb",
+        6000000000,
+        meta=_movie_meta(),
+    )
+    manifests = {
+        "https://idx/e05.nzb": _manifest("video", "e05.mkv", 6000000000, "a"),
+        "https://idx/e06.nzb": _manifest("video", "e06.mkv", 6000000000, "b"),
+        "https://idx/s01e05.nzb": _manifest("video", "s1e5.mkv", 6000000000, "c"),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    attach_fallback_candidates([e05, e06, s01])
+
+    assert e05["_fallback_candidates"] == []
+    assert e06["_fallback_candidates"] == []
+    assert s01["_fallback_candidates"] == []
+
+
+def test_same_content_rejects_part_vs_bare_movie():
+    """FS-1: an explicit-part release is different content from the bare title.
+
+    PTT keeps the part word in the title, so "dune part two" != "dune" and the
+    old `primary_title == candidate_title` guard never fired. A sequel must not
+    peer with the bare original even when the sequel omits its year.
+    """
+    from resources.lib import fallback_streams as fs
+
+    part_two = _result(
+        "Dune.Part.Two.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/part-two.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    bare = _result(
+        "Dune.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/bare.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(part_two, bare) is False
+    assert fs._same_content(bare, part_two) is False
+
+
+def test_same_content_rejects_part_one_vs_part_two():
+    """FS-1: differing explicit parts stay different content."""
+    from resources.lib import fallback_streams as fs
+
+    part_two = _result(
+        "Dune.Part.Two.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/part-two.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    part_one = _result(
+        "Dune.Part.One.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/part-one.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(part_two, part_one) is False
+
+
+def test_titles_core_related_fails_closed_on_empty_token_set():
+    """FS-2: an empty core-title token set must not fail open.
+
+    A subject that normalizes to no word tokens (all punctuation) paired with an
+    empty PTT title used to return True; without corroborating identity it must
+    fail closed.
+    """
+    from resources.lib import fallback_streams as fs
+
+    assert fs._titles_core_related("", "dune") is False
+    assert fs._titles_core_related("dune", "") is False
+    # But corroborating identity (matching year/episode) rescues the empty case.
+    assert fs._titles_core_related("", "dune", corroborated=True) is True
+
+
+def test_same_content_rejects_subtitled_sequel_without_year():
+    """FS-3: a subset title relation with no year/episode backstop is rejected.
+
+    "Avatar" must not peer with "Avatar The Way Of Water" when neither carries a
+    year, because the extra tokens are a distinguishing subtitle, not junk.
+    """
+    from resources.lib import fallback_streams as fs
+
+    avatar = _result(
+        "Avatar.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/avatar.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    sequel = _result(
+        "Avatar.The.Way.Of.Water.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/sequel.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(avatar, sequel) is False
+    assert fs._same_content(sequel, avatar) is False
+
+
+def test_same_content_keeps_junk_suffix_repost_peering():
+    """Legitimate junk-SUFFIX repost of the SAME release must still peer.
+
+    "Movie" vs "Movie mirror" (trailing noise, no distinguishing subtitle) is a
+    true repost and must keep matching even with no year on either side.
+    """
+    from resources.lib import fallback_streams as fs
+
+    primary = _result(
+        "Movie.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/movie.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    mirror = _result(
+        "Movie.mirror.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/movie-mirror.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(primary, mirror) is True
+    assert fs._same_content(mirror, primary) is True
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_same_episode_different_group_is_allowed_fallback(mock_settings, mock_fetch):
+    """Same show/season/episode, different group is a valid same-content peer."""
+    mock_settings.return_value = (True, 5)
+    primary = _result(
+        "Show.Name.S02E05.2160p.WEB-DL.x265-GROUP",
+        "https://idx/primary.nzb",
+        6000000000,
+        meta=_movie_meta(group="GROUP"),
+    )
+    repost = _result(
+        "Show.Name.S02E05.2160p.WEB-DL.x265-ALT",
+        "https://idx/repost.nzb",
+        6100000000,
+        meta=_movie_meta(group="ALT"),
+    )
+    manifests = {
+        "https://idx/primary.nzb": _manifest("video", "p.mkv", 6000000000, "a"),
+        "https://idx/repost.nzb": _manifest("video", "r.mkv", 6100000000, "b"),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    attach_fallback_candidates([primary, repost])
+
+    assert primary["_fallback_candidates"] == [repost]
+    assert repost["_fallback_candidates"] == [primary]
+
+
+def test_release_similarity_tiers():
+    from resources.lib import fallback_streams as fs
+
+    primary = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/p.nzb",
+        60000000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
+    )
+    # Tier 0: same res/codec/group, ~same size.
+    tier0 = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/t0.nzb",
+        60500000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
+    )
+    # Tier 1: same res/codec, different group, within ~10%.
+    tier1 = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-ALT",
+        "https://idx/t1.nzb",
+        63000000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="ALT"),
+    )
+    # Tier 2: same res, different codec.
+    tier2 = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.x264-ALT",
+        "https://idx/t2.nzb",
+        62000000000,
+        meta=_movie_meta(resolution="2160p", codec="x264/AVC", group="ALT"),
+    )
+    # Tier 3: same content, different resolution.
+    tier3 = _result(
+        "Dune.Part.Two.2024.1080p.BluRay.x264-ALT",
+        "https://idx/t3.nzb",
+        20000000000,
+        meta=_movie_meta(resolution="1080p", codec="x264/AVC", group="ALT"),
+    )
+    # Different content -> None.
+    other = _result(
+        "Dune.Part.One.2021.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/o.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+
+    assert fs._release_similarity(primary, tier0) == 0
+    assert fs._release_similarity(primary, tier1) == 1
+    assert fs._release_similarity(primary, tier2) == 2
+    assert fs._release_similarity(primary, tier3) == 3
+    assert fs._release_similarity(primary, other) is None
+
+
+@patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
+@patch("resources.lib.fallback_streams._fallback_settings")
+def test_fallback_candidates_sorted_best_tier_first(mock_settings, mock_fetch):
+    """Candidates are ordered by tier (most-similar first), not pool order.
+
+    Both peers share the primary's resolution+codec (so both clear the profile
+    gate); ranking must still place the same-group ~identical-size repost
+    (Tier 0) ahead of the different-group repost (Tier 1) even though the pool
+    lists the Tier-1 peer first.
+    """
+    mock_settings.return_value = (True, 5)
+    primary = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/primary.nzb",
+        60000000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
+    )
+    # Tier 1 (different group), listed first to prove ranking re-orders them.
+    worse = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-OTHER",
+        "https://idx/worse.nzb",
+        61000000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="OTHER"),
+    )
+    # Tier 0 (same group, size within 3%).
+    best = _result(
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/best.nzb",
+        60100000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
+    )
+    manifests = {
+        "https://idx/primary.nzb": _manifest("video", "p.mkv", 60000000000, "a"),
+        "https://idx/worse.nzb": _manifest("video", "w.mkv", 61000000000, "b"),
+        "https://idx/best.nzb": _manifest("video", "x.mkv", 60100000000, "c"),
+    }
+    mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]
+
+    attach_fallback_candidates([primary, worse, best])
+
+    assert primary["_fallback_candidates"] == [best, worse]

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -467,6 +467,7 @@ def test_prefetch_title_tokens_are_reused_for_selection_attach(
         "codec": "x265/HEVC",
         "hdr": ["Dolby Vision"],
         "audio": ["TrueHD", "Atmos"],
+        "group": "GROUP",
         "container": "mkv",
     }
     selected = _result(
@@ -569,7 +570,7 @@ def test_similar_reposts_with_different_manifest_names_are_fallbacks(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["DTS:X"],
-            "group": "ALT",
+            "group": "FraMeSToR",
             "container": "mkv",
         },
     )
@@ -771,7 +772,7 @@ def test_too_large_manifest_can_attach_same_profile_metadata_fallback(
     repost = {
         "title": (
             "The.Matrix.1999.UHD.BluRay.2160p.TrueHD.Atmos.7.1."
-            "DV.HEVC.REMUX.FraMeSToR"
+            "DV.HEVC.REMUX-FraMeSToR"
         ),
         "link": "https://idx/repost.nzb",
         "size": 61538207424,
@@ -815,6 +816,7 @@ def test_unsupported_manifest_uses_indexer_size_as_synthetic_video_manifest(
         "codec": "x265/HEVC",
         "hdr": ["Dolby Vision"],
         "audio": ["TrueHD", "Atmos"],
+        "group": "GROUP",
         "container": "mkv",
     }
     primary = _result(
@@ -924,6 +926,7 @@ def test_selection_fallback_prefilter_skips_manifest_fetch_for_unrelated_candida
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -978,6 +981,7 @@ def test_selection_fallback_logs_manifest_timing(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -1055,6 +1059,7 @@ def test_selection_prefilled_unsupported_manifest_can_synthesize_indexer_manifes
         "codec": "x265/HEVC",
         "hdr": ["Dolby Vision"],
         "audio": ["TrueHD", "Atmos"],
+        "group": "GROUP",
         "container": "mkv",
     }
     selected = _result(
@@ -1138,6 +1143,7 @@ def test_selection_fallback_does_not_reset_unselected_candidate_lists(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -1313,6 +1319,7 @@ def test_selection_fallback_rejects_batch_after_unusable_selected_manifest(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -1365,6 +1372,7 @@ def test_selection_fallback_skips_candidate_wait_after_unusable_selected_manifes
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -1427,6 +1435,7 @@ def test_selection_fallback_reuses_selected_title_tokens_while_prefiltering(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -1787,6 +1796,7 @@ def test_selection_fallback_stops_manifest_fetch_after_max_candidates(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -1841,6 +1851,7 @@ def test_selection_fallback_fetches_candidate_manifests_in_parallel(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -1906,6 +1917,7 @@ def test_selection_fallback_overlaps_selected_manifest_with_candidate_batch(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -1965,6 +1977,7 @@ def test_selection_fallback_pipelines_second_manifest_wave_after_underfill(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2039,6 +2052,7 @@ def test_selection_fallback_uses_later_completed_candidate_instead_of_slow_gap(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2106,6 +2120,7 @@ def test_selection_fallback_starts_followup_fetch_before_first_wave_tail_finishe
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2174,6 +2189,7 @@ def test_selection_fallback_scales_second_wave_to_remaining_slots(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2233,6 +2249,7 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_max_filled(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2304,6 +2321,7 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_partial_match(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2375,6 +2393,7 @@ def test_selection_fallback_stops_prefilter_scan_after_max_attached_candidates(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2442,6 +2461,7 @@ def test_selection_fallback_reuses_prefilter_match_for_manifest_gate(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2501,6 +2521,7 @@ def test_selection_fallback_reuses_known_prefetch_peer_profile_match(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -2655,6 +2676,7 @@ def test_manifest_fetches_are_cached_across_short_lived_selection_calls(
                 "codec": "x265/HEVC",
                 "hdr": ["Dolby Vision"],
                 "audio": ["TrueHD", "Atmos"],
+                "group": "GROUP",
                 "container": "mkv",
             },
         )
@@ -2730,6 +2752,7 @@ def test_short_lived_manifest_cache_expires_between_selection_calls(
                 "codec": "x265/HEVC",
                 "hdr": ["Dolby Vision"],
                 "audio": ["TrueHD", "Atmos"],
+                "group": "GROUP",
                 "container": "mkv",
             },
         )
@@ -2830,6 +2853,7 @@ def test_attach_fallbacks_reuses_known_prefetch_peer_profile_match(
             "codec": "x265/HEVC",
             "hdr": ["Dolby Vision"],
             "audio": ["TrueHD", "Atmos"],
+            "group": "GROUP",
             "container": "mkv",
         },
     )
@@ -4266,8 +4290,11 @@ def test_same_content_rejects_disjoint_tail_franchise_without_year():
 
 @patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")
 @patch("resources.lib.fallback_streams._fallback_settings")
-def test_same_episode_different_group_is_allowed_fallback(mock_settings, mock_fetch):
-    """Same show/season/episode, different group is a valid same-content peer."""
+def test_same_episode_different_group_is_rejected_fallback(mock_settings, mock_fetch):
+    """A different release group is no longer a qualified fallback (user
+    requirement). Even with the same show/season/episode and matching profile, a
+    candidate from a different group is a different file that can never byte-match
+    for a seamless cutover, so it must not be attached as a fallback."""
     mock_settings.return_value = (True, 5)
     primary = _result(
         "Show.Name.S02E05.2160p.WEB-DL.x265-GROUP",
@@ -4289,8 +4316,51 @@ def test_same_episode_different_group_is_allowed_fallback(mock_settings, mock_fe
 
     attach_fallback_candidates([primary, repost])
 
-    assert primary["_fallback_candidates"] == [repost]
-    assert repost["_fallback_candidates"] == [primary]
+    assert primary["_fallback_candidates"] == []
+    assert repost["_fallback_candidates"] == []
+
+
+def test_metadata_profiles_match_requires_same_release_group():
+    """User-reported scenario: a FraMeSToR release must NOT pull in an RU4HD
+    encode of the same movie as a backup. Two releases with an IDENTICAL encode
+    profile that differ ONLY in release group are group-agnostic peers by default
+    but are rejected once require_same_group is set -- proving the group, not any
+    other attribute, is the discriminator. A same-group re-post still peers.
+    """
+    from resources.lib import fallback_streams as fs
+
+    # Raw results (no pre-set _meta) so the group is parsed from the release
+    # title -- the real production path. Identical encode profile, group only
+    # differs.
+    framestor = {
+        "title": "Goodfellas.1990.2160p.UHD.BluRay.REMUX.DV.HEVC.TrueHD.7.1-FraMeSToR",
+        "link": "https://idx/goodfellas-framestor.nzb",
+        "size": 60000000000,
+    }
+    ru4hd = {
+        "title": "Goodfellas.1990.2160p.UHD.BluRay.REMUX.DV.HEVC.TrueHD.7.1-RU4HD",
+        "link": "https://idx/goodfellas-ru4hd.nzb",
+        "size": 60000000000,
+    }
+    same_group_repost = {
+        "title": "Goodfellas.1990.2160p.UHD.BluRay.REMUX.DV.HEVC.TrueHD.7.1-FraMeSToR",
+        "link": "https://idx/goodfellas-framestor-mirror.nzb",
+        "size": 60000000000,
+    }
+    # Sanity: groups parse distinct / equal; the encode profile is otherwise
+    # identical (so a False below is caused by the group, nothing else).
+    assert fs._meta_value(framestor, "group") == "framestor"
+    assert fs._meta_value(ru4hd, "group") == "ru4hd"
+    assert fs._metadata_profiles_match(framestor, ru4hd) is True
+    assert (
+        fs._metadata_profiles_match(framestor, ru4hd, require_same_group=True) is False
+    )
+    assert (
+        fs._metadata_profiles_match(
+            framestor, same_group_repost, require_same_group=True
+        )
+        is True
+    )
 
 
 def test_release_similarity_tiers():
@@ -4350,10 +4420,11 @@ def test_release_similarity_tiers():
 def test_fallback_candidates_sorted_best_tier_first(mock_settings, mock_fetch):
     """Candidates are ordered by tier (most-similar first), not pool order.
 
-    Both peers share the primary's resolution+codec (so both clear the profile
-    gate); ranking must still place the same-group ~identical-size repost
-    (Tier 0) ahead of the different-group repost (Tier 1) even though the pool
-    lists the Tier-1 peer first.
+    All peers share the primary's release group (a different group is no longer a
+    qualified fallback), so tiering is exercised within the same group by size:
+    ranking must still place the ~identical-size repost (Tier 0, size within 3%)
+    ahead of the larger same-encode repost (Tier 1, size beyond 3% but within the
+    10% peer band) even though the pool lists the Tier-1 peer first.
     """
     mock_settings.return_value = (True, 5)
     primary = _result(
@@ -4362,12 +4433,13 @@ def test_fallback_candidates_sorted_best_tier_first(mock_settings, mock_fetch):
         60000000000,
         meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
     )
-    # Tier 1 (different group), listed first to prove ranking re-orders them.
+    # Tier 1 (same group, same res+codec, size beyond the 3% Tier-0 band but
+    # within the 10% peer band), listed first to prove ranking re-orders them.
     worse = _result(
-        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-OTHER",
+        "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
         "https://idx/worse.nzb",
-        61000000000,
-        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="OTHER"),
+        62500000000,
+        meta=_movie_meta(resolution="2160p", codec="x265/HEVC", group="GROUP"),
     )
     # Tier 0 (same group, size within 3%).
     best = _result(
@@ -4378,7 +4450,7 @@ def test_fallback_candidates_sorted_best_tier_first(mock_settings, mock_fetch):
     )
     manifests = {
         "https://idx/primary.nzb": _manifest("video", "p.mkv", 60000000000, "a"),
-        "https://idx/worse.nzb": _manifest("video", "w.mkv", 61000000000, "b"),
+        "https://idx/worse.nzb": _manifest("video", "w.mkv", 62500000000, "b"),
         "https://idx/best.nzb": _manifest("video", "x.mkv", 60100000000, "c"),
     }
     mock_fetch.side_effect = lambda url, **_kwargs: manifests[url]

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -4017,6 +4017,174 @@ def test_same_content_rejects_numeric_sequel_suffix_without_year():
     assert fs._same_content(rocky, rocky2) is False
 
 
+def test_same_content_rejects_roman_ordinal_sequel_suffix_without_year():
+    """FS-M: a lone MULTI-CHARACTER Roman-numeral or ordinal-word sequel tail
+    ("Rocky IV", "Rambo III", "Iron Man Three") is a content discriminator, not
+    a junk suffix, and must be rejected when neither side parses a year (PTT
+    keeps the sequel discriminator inside the title)."""
+    from resources.lib import fallback_streams as fs
+
+    rocky4 = _result(
+        "Rocky.IV.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/rocky4.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    rocky = _result(
+        "Rocky.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/rocky.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    # Sanity: PTT keeps the Roman tail in the title, parses no year.
+    assert fs._release_identity(rocky4)[0] == "rocky iv"
+    assert fs._release_identity(rocky4)[1] == 0
+    assert fs._release_identity(rocky)[0] == "rocky"
+    assert fs._same_content(rocky4, rocky) is False
+    assert fs._same_content(rocky, rocky4) is False
+
+    rambo3 = _result(
+        "Rambo.III.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/rambo3.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    rambo = _result(
+        "Rambo.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/rambo.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(rambo3, rambo) is False
+    assert fs._same_content(rambo, rambo3) is False
+
+    iron_man_three = _result(
+        "Iron.Man.Three.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/iron3.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    iron_man = _result(
+        "Iron.Man.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/iron.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(iron_man_three, iron_man) is False
+    assert fs._same_content(iron_man, iron_man_three) is False
+
+
+def test_same_content_keeps_single_letter_and_one_eleven_tails_peering():
+    """FS-M: the sequel-tail reject is MULTI-CHARACTER only.
+
+    Single-letter Roman tails (i/v/x) collide with stray junk-suffix letters, so
+    "Saw X" / "Final Destination V" must still peer; "one" is never a real
+    sequel tail; and the ordinal-word ceiling stops at "ten" so "Ocean's Eleven"
+    (eleven) is unaffected. All must still peer with the bare title when no year
+    corroborates."""
+    from resources.lib import fallback_streams as fs
+
+    saw_x = _result(
+        "Saw.X.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/sawx.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    saw = _result(
+        "Saw.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/saw.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(saw_x, saw) is True
+    assert fs._same_content(saw, saw_x) is True
+
+    fd_v = _result(
+        "Final.Destination.V.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/fdv.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    fd = _result(
+        "Final.Destination.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/fd.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    assert fs._same_content(fd_v, fd) is True
+    assert fs._same_content(fd, fd_v) is True
+
+    # Direct title-predicate checks for "one" exclusion and the "eleven" ceiling
+    # (these PTT-parse cleanly to bare-vs-tail core titles).
+    assert fs._titles_core_related("show one", "show", corroborated=False) is True
+    assert fs._titles_core_related("show", "show one", corroborated=False) is True
+    assert (
+        fs._titles_core_related("oceans eleven", "oceans", corroborated=False) is True
+    )
+    assert (
+        fs._titles_core_related("oceans", "oceans eleven", corroborated=False) is True
+    )
+
+
+def test_titles_core_related_sequel_tail_predicate_matrix():
+    """FS-M: direct-predicate matrix for the sequel-tail reject."""
+    from resources.lib import fallback_streams as fs
+
+    # Multi-character Roman / ordinal tails: rejected without corroboration,
+    # rescued by corroboration.
+    assert fs._titles_core_related("rocky iv", "rocky", corroborated=False) is False
+    assert fs._titles_core_related("rocky", "rocky iv", corroborated=False) is False
+    assert fs._titles_core_related("rocky iv", "rocky", corroborated=True) is True
+    assert fs._titles_core_related("iron man three", "iron man", False) is False
+    # Legit junk suffix stays a repost.
+    assert fs._titles_core_related("movie", "movie mirror", corroborated=False) is True
+    # Single-letter ambiguity preserved.
+    assert fs._titles_core_related("saw x", "saw", corroborated=False) is True
+    # "one" exclusion.
+    assert fs._titles_core_related("show one", "show", corroborated=False) is True
+    # The new constant excludes single-letter romans and "one"/"eleven".
+    assert "ii" in fs._SEQUEL_TAIL_TOKENS
+    assert "three" in fs._SEQUEL_TAIL_TOKENS
+    assert "ten" in fs._SEQUEL_TAIL_TOKENS
+    for excluded in ("i", "v", "x", "one", "eleven"):
+        assert excluded not in fs._SEQUEL_TAIL_TOKENS
+
+
+def test_same_content_rescues_roman_sequel_with_matching_year():
+    """FS-M: a matching parsed year on both sides corroborates and rescues an
+    otherwise-rejected Roman/ordinal sequel tail (legit repost short-circuit)."""
+    from resources.lib import fallback_streams as fs
+
+    rocky4_a = _result(
+        "Rocky.IV.2025.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/rocky4a.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    rocky4_b = _result(
+        "Rocky.2025.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+        "https://idx/rocky4b.nzb",
+        60000000000,
+        meta=_movie_meta(),
+    )
+    # Sanity: both parse the same year, so identity is corroborated.
+    assert fs._release_identity(rocky4_a)[1] == 2025
+    assert fs._release_identity(rocky4_b)[1] == 2025
+    assert fs._same_content(rocky4_a, rocky4_b) is True
+    assert fs._same_content(rocky4_b, rocky4_a) is True
+
+
+def test_part_number_from_title_roman_sequel_tails_are_not_parts():
+    """FS-M regression guard: a bare Roman/ordinal sequel tail is NOT a
+    labeled part, but an explicit Part/Chapter label still parses."""
+    from resources.lib import fallback_streams as fs
+
+    assert fs._part_number_from_title("Rocky IV") == 0
+    assert fs._part_number_from_title("Saw X") == 0
+    assert fs._part_number_from_title("Dune Part Two") == 2
+    assert fs._part_number_from_title("John Wick Chapter 4") == 4
+
+
 def test_same_content_ignores_phantom_season_for_movie_peer():
     """FS: a movie whose release-group suffix mis-parses as a season (e.g.
     REMUX-ALT01 -> seasons=[1]) must still peer with the same movie posted by a

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -3,7 +3,13 @@
 
 from unittest.mock import MagicMock, patch
 
-from resources.lib.http_util import HttpResponseTooLarge, http_get, notify, redact_url
+from resources.lib.http_util import (
+    HttpResponseTooLarge,
+    http_get,
+    notify,
+    pubdate_to_epoch,
+    redact_url,
+)
 
 
 @patch("resources.lib.http_util.urlopen")
@@ -257,3 +263,25 @@ def test_redact_url_preserves_userinfo_without_password():
     result = redact_url(url)
     assert "REDACTED" not in result
     assert "alice@host.example.com" in result
+
+
+def test_pubdate_to_epoch_parses_rfc2822_with_timezone():
+    """An RFC-2822 pubdate with an explicit timezone offset converts to
+    the correct absolute UTC epoch (the offset is normalized away)."""
+    # 2021-12-15 12:00:00 +0000
+    assert pubdate_to_epoch("Wed, 15 Dec 2021 12:00:00 +0000") == 1639569600
+    # Same instant expressed as -0500 must yield the SAME epoch.
+    assert pubdate_to_epoch("Wed, 15 Dec 2021 07:00:00 -0500") == 1639569600
+
+
+def test_pubdate_to_epoch_assumes_utc_when_naive():
+    """A pubdate with no timezone is treated as UTC rather than local
+    time, so the epoch is deterministic across machines."""
+    assert pubdate_to_epoch("Wed, 15 Dec 2021 12:00:00") == 1639569600
+
+
+def test_pubdate_to_epoch_returns_none_on_garbage():
+    """Unparseable / empty input returns None (caller fails open)."""
+    assert pubdate_to_epoch("") is None
+    assert pubdate_to_epoch("not a date") is None
+    assert pubdate_to_epoch(None) is None

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -180,6 +180,25 @@ def test_strings_po_has_added_orphan_ids():
     assert "Maximum standby fallback streams" in content
 
 
+def test_strings_po_has_readahead_buffer_label():
+    """settings.xml references #30207 for readahead_buffer_mb; Kodi renders
+    raw numbers without a matching msgctxt entry."""
+    import os
+
+    po_path = os.path.join(
+        "repo",
+        "plugin.video.nzbdav",
+        "resources",
+        "language",
+        "resource.language.en_gb",
+        "strings.po",
+    )
+    with open(po_path, encoding="utf-8") as fh:
+        content = fh.read()
+    assert '"#30207"' in content, "missing msgctxt #30207 in strings.po"
+    assert "Read-ahead buffer" in content
+
+
 def test_settings_xml_uses_30129_for_prowlarr_api_key():
     """The orphan #30129 ("Prowlarr API Key") msgctxt previously had
     no consumer — settings.xml reused the generic #30003 ("API Key")

--- a/tests/test_nzbdav_api.py
+++ b/tests/test_nzbdav_api.py
@@ -699,6 +699,7 @@ def test_get_completed_jobs_returns_completed_job_map(mock_http, mock_settings):
                             "/mnt/nzbdav/completed-symlinks/uncategorized/Movie.A.2024"
                         ),
                         "nzo_id": "SABnzbd_nzo_a",
+                        "bytes": 12345678901,
                     },
                     {"name": "Movie.B.2023", "status": "Failed"},
                 ]
@@ -719,6 +720,7 @@ def test_get_completed_jobs_returns_completed_job_map(mock_http, mock_settings):
             "storage": ("/mnt/nzbdav/completed-symlinks/uncategorized/Movie.A.2024"),
             "name": "Movie.A.2024",
             "nzo_id": "SABnzbd_nzo_a",
+            "bytes": 12345678901,
             "fail_message": "",
             "completed": None,
         }

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1145,6 +1145,7 @@ def test_resolve_starts_fallback_worker_after_primary_submit_and_uses_snapshot(
             fallback_candidates,
             candidate_loader=None,
             prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
+            wait_for_playback=True,
         )
         return (
             "http://webdav/content/primary/movie.mp4",
@@ -1182,6 +1183,7 @@ def test_resolve_starts_fallback_worker_after_primary_submit_and_uses_snapshot(
         fallback_candidates,
         candidate_loader=None,
         prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
+        wait_for_playback=True,
     )
     mock_start_prepare.assert_called_once_with(
         "http://webdav/content/primary/movie.mp4",
@@ -2560,6 +2562,7 @@ def test_resolve_and_play_defers_fallback_loader_until_primary_accept(
         [],
         candidate_loader=loader_kwarg,
         prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
+        wait_for_playback=True,
     )
 
 
@@ -3183,6 +3186,43 @@ def test_fallback_submit_worker_defers_prewarm_burst(mock_submit):
         prewarm_delay=30.0,
     )
     # Stop during the deferral window → burst cancelled, nothing submitted.
+    state["stop"].set()
+    assert state["finished"].wait(timeout=2)
+    mock_submit.assert_not_called()
+
+
+@patch("resources.lib.resolver._submit_fallback_candidates")
+def test_fallback_submit_worker_waits_for_playback_start_before_prewarm(mock_submit):
+    """With ``wait_for_playback``, the burst is held until playback is signaled,
+    then for ``prewarm_delay`` -- so backups submit INTO playback, never during
+    the pre-playback download. Nothing is submitted before the signal; after it
+    (with prewarm_delay=0) the worker submits."""
+    from resources.lib.resolver import _signal_fallback_playback_started
+
+    mock_submit.return_value = ("SABnzbd_nzo_fallback", None)
+
+    state = _start_fallback_submit_worker(
+        candidates=[{"title": "Fallback A", "link": "http://hydra/getnzb/a"}],
+        prewarm_delay=0,
+        wait_for_playback=True,
+    )
+    # Playback not signaled yet → worker parked, nothing submitted.
+    assert not state["finished"].wait(timeout=0.3)
+    mock_submit.assert_not_called()
+    # Signal playback start → worker proceeds (prewarm_delay=0) and submits.
+    _signal_fallback_playback_started(state)
+    assert state["finished"].wait(timeout=2)
+    mock_submit.assert_called_once()
+
+
+@patch("resources.lib.resolver._submit_fallback_candidates")
+def test_fallback_submit_worker_playback_wait_is_cancellable(mock_submit):
+    """A stop during the pre-playback wait aborts the burst with no submission."""
+    state = _start_fallback_submit_worker(
+        candidates=[{"title": "Fallback A", "link": "http://hydra/getnzb/a"}],
+        prewarm_delay=0,
+        wait_for_playback=True,
+    )
     state["stop"].set()
     assert state["finished"].wait(timeout=2)
     mock_submit.assert_not_called()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6917,3 +6917,163 @@ def test_maybe_clear_queue_skips_completed_probe_when_picker_already_checked(
 
     mock_find.assert_not_called()
     mock_clear.assert_called_once()
+
+
+# --- (E) download-ledger pubdate recorded only after stream confirmed playable ---
+
+
+def _poll_dialog():
+    dlg = MagicMock()
+    dlg.iscanceled.return_value = False
+    return dlg
+
+
+@patch("resources.lib.resolver.record_download")
+@patch("resources.lib.resolver._handle_history_result")
+@patch("resources.lib.resolver._handle_job_status", return_value=(False, None))
+@patch("resources.lib.resolver._poll_once", return_value=({}, None, None))
+@patch("resources.lib.resolver._submit_nzb_with_retries", return_value="nzo-1")
+@patch("resources.lib.resolver._existing_completed_stream", return_value=None)
+@patch("resources.lib.resolver.xbmc")
+def test_poll_until_ready_records_ledger_only_on_playable_success(
+    mock_xbmc,
+    _mock_existing,
+    _mock_submit,
+    _mock_poll_once,
+    _mock_status,
+    mock_history,
+    mock_record,
+):
+    """A submit whose poll returns a stream URL DOES record the ledger pubdate
+    (keyed to THIS confirmed-playable download)."""
+    mock_xbmc.Monitor.return_value = _make_monitor()
+    mock_history.return_value = (False, "http://webdav/movie.mkv", {"H": "1"}, 0)
+
+    result = _poll_until_ready(
+        "http://hydra/getnzb/primary",
+        "movie.mkv",
+        _poll_dialog(),
+        poll_interval=1,
+        download_timeout=60,
+        download_pubdate="2026-01-02",
+        download_size=12345,
+    )
+
+    assert result == ("http://webdav/movie.mkv", {"H": "1"})
+    mock_record.assert_called_once_with("movie.mkv", "2026-01-02", 12345)
+
+
+@patch("resources.lib.resolver.record_download")
+@patch("resources.lib.resolver._handle_history_result")
+@patch("resources.lib.resolver._handle_job_status", return_value=(True, None))
+@patch(
+    "resources.lib.resolver._poll_once", return_value=({"status": "Failed"}, None, None)
+)
+@patch("resources.lib.resolver._submit_nzb_with_retries", return_value="nzo-1")
+@patch("resources.lib.resolver._existing_completed_stream", return_value=None)
+@patch("resources.lib.resolver.xbmc")
+def test_poll_until_ready_does_not_record_ledger_when_poll_fails(
+    mock_xbmc,
+    _mock_existing,
+    _mock_submit,
+    _mock_poll_once,
+    _mock_status,
+    mock_history,
+    mock_record,
+):
+    """A submit that succeeds but whose poll returns (None, None) (job failed /
+    timed out / cancelled) must NOT record a ledger pubdate — otherwise a
+    different repost's same-name completed row could later look adopted."""
+    mock_xbmc.Monitor.return_value = _make_monitor()
+    mock_history.return_value = (False, None, None, 0)
+
+    result = _poll_until_ready(
+        "http://hydra/getnzb/primary",
+        "movie.mkv",
+        _poll_dialog(),
+        poll_interval=1,
+        download_timeout=60,
+        download_pubdate="2026-01-02",
+        download_size=12345,
+    )
+
+    assert result == (None, None)
+    mock_record.assert_not_called()
+
+
+# --- (J) delayed fallback submit aborts when playback goes inactive ---
+
+
+def test_fallback_worker_stop_event_during_prewarm_aborts_submit():
+    """Existing behavior: stop event set during the prewarm wait -> no submit."""
+    from resources.lib.resolver import (
+        _signal_fallback_playback_started,
+        _start_fallback_submit_worker,
+    )
+
+    submitted = []
+
+    def fake_submit(*_args, **_kwargs):
+        submitted.append(True)
+
+    with patch(
+        "resources.lib.resolver._submit_fallback_candidates", side_effect=fake_submit
+    ), patch("resources.lib.resolver._FALLBACK_PREWARM_POLL_SECONDS", 0.01), patch(
+        "resources.lib.resolver.xbmcgui"
+    ) as mock_gui:
+        mock_gui.Window.return_value.getProperty.return_value = "true"
+        state = _start_fallback_submit_worker(
+            candidates=[{"nzb_url": "x"}],
+            prewarm_delay=5,
+            wait_for_playback=True,
+        )
+        _signal_fallback_playback_started(state)
+        _time.sleep(0.05)
+        state["stop"].set()
+        state["thread"].join(timeout=2)
+
+    assert not submitted
+
+
+def test_fallback_worker_inactive_property_during_prewarm_aborts_submit():
+    """NEW: after playback is signaled, the cross-process ``nzbdav.active``
+    property going non-"true" (service.py cleared it on stop/end) must abort the
+    prewarm wait so no standby NZBs are submitted for a dead session."""
+    from resources.lib.resolver import (
+        _signal_fallback_playback_started,
+        _start_fallback_submit_worker,
+    )
+
+    submitted = []
+
+    def fake_submit(*_args, **_kwargs):
+        submitted.append(True)
+
+    active_value = {"v": "true"}
+
+    def get_property(_name):
+        return active_value["v"]
+
+    with patch(
+        "resources.lib.resolver._submit_fallback_candidates", side_effect=fake_submit
+    ), patch("resources.lib.resolver._FALLBACK_PREWARM_POLL_SECONDS", 0.01), patch(
+        "resources.lib.resolver.xbmcgui"
+    ) as mock_gui:
+        mock_gui.Window.return_value.getProperty.side_effect = get_property
+        state = _start_fallback_submit_worker(
+            candidates=[{"nzb_url": "x"}],
+            prewarm_delay=5,
+            wait_for_playback=True,
+        )
+        _signal_fallback_playback_started(state)
+        _time.sleep(0.05)
+        # Simulate service.py clearing nzbdav.active on stop/end (cross-process).
+        active_value["v"] = ""
+        # prewarm_delay is 5s but the worker must abort well before that once the
+        # active flag clears; a short join proves it returned early rather than
+        # the join merely timing out before a still-pending submit.
+        state["thread"].join(timeout=2)
+
+    assert not state["thread"].is_alive(), "worker did not abort on inactive flag"
+    assert not submitted
+    assert not state["stop"].is_set()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,7 +4,7 @@
 import sys
 import threading
 import time as _time
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from resources.lib.resolver import (
     _DOWNLOAD_TIMEOUT_MAX,
@@ -519,7 +519,15 @@ def test_fallback_worker_append_invokes_on_append_hook():
 
     captured = {}
 
-    def fake_submit(cands, monitor, stop_event=None, on_job=None, settings_getter=None):
+    def fake_submit(
+        cands,
+        monitor,
+        stop_event=None,
+        on_job=None,
+        settings_getter=None,
+        dead=None,
+        primary_nzb_url=None,
+    ):
         captured["on_job"] = on_job
 
     with patch(
@@ -600,7 +608,15 @@ def test_fallback_worker_append_swallows_on_append_errors():
 
     captured = {}
 
-    def fake_submit(cands, monitor, stop_event=None, on_job=None, settings_getter=None):
+    def fake_submit(
+        cands,
+        monitor,
+        stop_event=None,
+        on_job=None,
+        settings_getter=None,
+        dead=None,
+        primary_nzb_url=None,
+    ):
         captured["on_job"] = on_job
 
     with patch(
@@ -1196,6 +1212,8 @@ def test_resolve_starts_fallback_worker_after_primary_submit_and_uses_snapshot(
             candidate_loader=None,
             prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
             wait_for_playback=True,
+            dead=ANY,
+            primary_nzb_url="http://hydra/getnzb/primary",
         )
         return (
             "http://webdav/content/primary/movie.mp4",
@@ -1234,6 +1252,8 @@ def test_resolve_starts_fallback_worker_after_primary_submit_and_uses_snapshot(
         candidate_loader=None,
         prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
         wait_for_playback=True,
+        dead=ANY,
+        primary_nzb_url="http://hydra/getnzb/primary",
     )
     mock_start_prepare.assert_called_once_with(
         "http://webdav/content/primary/movie.mp4",
@@ -2613,6 +2633,8 @@ def test_resolve_and_play_defers_fallback_loader_until_primary_accept(
         candidate_loader=loader_kwarg,
         prewarm_delay=_FALLBACK_PREWARM_DELAY_SECONDS,
         wait_for_playback=True,
+        dead=ANY,
+        primary_nzb_url="http://hydra/getnzb/primary",
     )
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -5447,6 +5447,83 @@ def test_poll_until_ready_success(
     assert headers == {"Authorization": "x"}
 
 
+@patch("resources.lib.resolver.record_download")
+@patch("resources.lib.resolver._existing_completed_stream", return_value=None)
+@patch("resources.lib.resolver._validate_stream_url", return_value=True)
+@patch("resources.lib.resolver.get_webdav_stream_url_for_path")
+@patch("resources.lib.resolver.find_video_file")
+@patch("resources.lib.resolver.get_job_history")
+@patch("resources.lib.resolver.get_job_status")
+@patch("resources.lib.resolver.submit_nzb")
+@patch("resources.lib.resolver.xbmc")
+def test_poll_until_ready_records_pubdate_on_submit_success(
+    mock_xbmc,
+    mock_submit,
+    mock_status,
+    mock_history,
+    mock_find,
+    mock_stream_url,
+    mock_validate,
+    mock_find_completed,
+    mock_record,
+):
+    """On a fresh submit, the selected result's pubdate is recorded against
+    the title so the picker can later tell this download apart from a
+    same-name repost posted on a different day."""
+    mock_submit.return_value = ("nzo_abc", None)
+    mock_status.return_value = {"status": "Downloading", "percentage": "100"}
+    mock_history.return_value = {
+        "status": "Completed",
+        "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+    }
+    mock_find.return_value = "/content/uncategorized/movie/movie.mkv"
+    mock_stream_url.return_value = ("http://webdav/movie.mkv", {"Authorization": "x"})
+    mock_xbmc.Monitor.return_value = _make_monitor()
+
+    url, _ = _poll_until_ready(
+        "http://hydra/nzb",
+        "movie",
+        _make_dialog(),
+        2,
+        3600,
+        download_pubdate="Wed, 15 Dec 2021 12:00:00 +0000",
+        download_size="1000",
+    )
+
+    assert url == "http://webdav/movie.mkv"
+    mock_record.assert_called_once_with(
+        "movie", "Wed, 15 Dec 2021 12:00:00 +0000", "1000"
+    )
+
+
+@patch("resources.lib.resolver.record_download")
+@patch(
+    "resources.lib.resolver._existing_completed_stream",
+    return_value=("http://webdav/cached.mkv", {"Authorization": "x"}),
+)
+@patch("resources.lib.resolver.submit_nzb")
+@patch("resources.lib.resolver.xbmc")
+def test_poll_until_ready_cache_hit_does_not_record(
+    mock_xbmc, mock_submit, mock_existing, mock_record
+):
+    """A cache hit (already-completed row) returns before any submit, so it
+    must not record a pubdate (nothing was downloaded this time)."""
+    mock_xbmc.Monitor.return_value = _make_monitor()
+
+    url, _ = _poll_until_ready(
+        "http://hydra/nzb",
+        "movie",
+        _make_dialog(),
+        2,
+        3600,
+        download_pubdate="Wed, 15 Dec 2021 12:00:00 +0000",
+    )
+
+    assert url == "http://webdav/cached.mkv"
+    mock_record.assert_not_called()
+    mock_submit.assert_not_called()
+
+
 @patch("resources.lib.resolver._handle_history_result")
 @patch("resources.lib.resolver._poll_once")
 @patch("resources.lib.resolver._submit_nzb_with_retries", return_value="nzo_abc")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2765,6 +2765,7 @@ def test_resolve_and_play_passes_settings_snapshot_to_proxy_prepare(
         "retry_ladder_enabled": "true",
         "send_200_no_range": "false",
         "proxy_convert_subs": "true",
+        "readahead_buffer_mb": "256",
     }
 
     def settings_getter(key, default=""):
@@ -2793,6 +2794,7 @@ def test_prepare_direct_playback_retry_reuses_settings_snapshot():
         "retry_ladder_enabled": "true",
         "send_200_no_range": "false",
         "proxy_convert_subs": "true",
+        "readahead_buffer_mb": "256",
     }
     settings_getter = MagicMock(
         side_effect=lambda key, default="": values.get(key, default)
@@ -2861,7 +2863,7 @@ def test_start_direct_playback_prepare_snapshots_settings_in_worker(
         release_settings.set()
 
     assert prepared["proxy_url"] == "http://127.0.0.1:57800/stream/abc"
-    assert len(calls) == 9
+    assert len(calls) == 10
 
 
 @patch("resources.lib.resolver._completed_stream_body_available", return_value=True)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7007,7 +7007,10 @@ def test_poll_until_ready_does_not_record_ledger_when_poll_fails(
 
 
 def test_fallback_worker_stop_event_during_prewarm_aborts_submit():
-    """Existing behavior: stop event set during the prewarm wait -> no submit."""
+    """Sanity check of the pre-existing in-process stop-event abort (held across
+    the J fix). The nzbdav.playing regression itself is guarded by
+    test_fallback_worker_submits_when_playback_stays_live and
+    test_fallback_worker_inactive_property_during_prewarm_aborts_submit."""
     from resources.lib.resolver import (
         _signal_fallback_playback_started,
         _start_fallback_submit_worker,
@@ -7098,8 +7101,11 @@ def test_fallback_worker_submits_when_playback_stays_live():
     def fake_submit(*_args, **_kwargs):
         submitted.append(True)
 
+    queried = []
+
     def get_property(name):
         # nzbdav.playing stays live; nzbdav.active is already consumed/empty.
+        queried.append(name)
         return "true" if name == "nzbdav.playing" else ""
 
     with patch(
@@ -7118,6 +7124,12 @@ def test_fallback_worker_submits_when_playback_stays_live():
 
     assert not state["thread"].is_alive()
     assert submitted, "worker must submit while playback stays live"
+    # Pin the actual fix: the worker must consult the DEDICATED liveness flag
+    # ``nzbdav.playing``, never the consume-once ``nzbdav.active`` the buggy
+    # version polled. Without this the test is a false-green (the old code also
+    # reaches a submit, just via the degraded never-latched path).
+    assert "nzbdav.playing" in queried
+    assert "nzbdav.active" not in queried
 
 
 def test_fallback_worker_submits_when_liveness_never_set():

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2788,6 +2788,7 @@ def test_resolve_and_play_passes_settings_snapshot_to_proxy_prepare(
         "send_200_no_range": "false",
         "proxy_convert_subs": "true",
         "readahead_buffer_mb": "256",
+        "passthrough_stall_wait": "120",
     }
 
     def settings_getter(key, default=""):
@@ -2817,6 +2818,7 @@ def test_prepare_direct_playback_retry_reuses_settings_snapshot():
         "send_200_no_range": "false",
         "proxy_convert_subs": "true",
         "readahead_buffer_mb": "256",
+        "passthrough_stall_wait": "120",
     }
     settings_getter = MagicMock(
         side_effect=lambda key, default="": values.get(key, default)
@@ -2885,7 +2887,7 @@ def test_start_direct_playback_prepare_snapshots_settings_in_worker(
         release_settings.set()
 
     assert prepared["proxy_url"] == "http://127.0.0.1:57800/stream/abc"
-    assert len(calls) == 10
+    assert len(calls) == 11
 
 
 @patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
@@ -7036,9 +7038,10 @@ def test_fallback_worker_stop_event_during_prewarm_aborts_submit():
 
 
 def test_fallback_worker_inactive_property_during_prewarm_aborts_submit():
-    """NEW: after playback is signaled, the cross-process ``nzbdav.active``
-    property going non-"true" (service.py cleared it on stop/end) must abort the
-    prewarm wait so no standby NZBs are submitted for a dead session."""
+    """After playback is signaled and the cross-process ``nzbdav.playing``
+    liveness flag has been observed live, it going non-"true" (service.py
+    cleared it on stop/end) must abort the prewarm wait so no standby NZBs are
+    submitted for a dead session."""
     from resources.lib.resolver import (
         _signal_fallback_playback_started,
         _start_fallback_submit_worker,
@@ -7049,10 +7052,10 @@ def test_fallback_worker_inactive_property_during_prewarm_aborts_submit():
     def fake_submit(*_args, **_kwargs):
         submitted.append(True)
 
-    active_value = {"v": "true"}
+    playing_value = {"v": "true"}
 
-    def get_property(_name):
-        return active_value["v"]
+    def get_property(name):
+        return playing_value["v"] if name == "nzbdav.playing" else ""
 
     with patch(
         "resources.lib.resolver._submit_fallback_candidates", side_effect=fake_submit
@@ -7067,13 +7070,85 @@ def test_fallback_worker_inactive_property_during_prewarm_aborts_submit():
         )
         _signal_fallback_playback_started(state)
         _time.sleep(0.05)
-        # Simulate service.py clearing nzbdav.active on stop/end (cross-process).
-        active_value["v"] = ""
+        # Simulate service.py clearing nzbdav.playing on stop/end (cross-process).
+        playing_value["v"] = ""
         # prewarm_delay is 5s but the worker must abort well before that once the
-        # active flag clears; a short join proves it returned early rather than
+        # liveness flag clears; a short join proves it returned early rather than
         # the join merely timing out before a still-pending submit.
         state["thread"].join(timeout=2)
 
     assert not state["thread"].is_alive(), "worker did not abort on inactive flag"
     assert not submitted
     assert not state["stop"].is_set()
+
+
+def test_fallback_worker_submits_when_playback_stays_live():
+    """REGRESSION (J): while ``nzbdav.playing`` stays "true" for the whole
+    prewarm window, the worker must submit the standby backups. The prior fix
+    polled ``nzbdav.active``, which ``service._check_active()`` consumes on the
+    first tick after playback starts, so the worker wrongly read "inactive" and
+    never submitted during normal service-monitored playback."""
+    from resources.lib.resolver import (
+        _signal_fallback_playback_started,
+        _start_fallback_submit_worker,
+    )
+
+    submitted = []
+
+    def fake_submit(*_args, **_kwargs):
+        submitted.append(True)
+
+    def get_property(name):
+        # nzbdav.playing stays live; nzbdav.active is already consumed/empty.
+        return "true" if name == "nzbdav.playing" else ""
+
+    with patch(
+        "resources.lib.resolver._submit_fallback_candidates", side_effect=fake_submit
+    ), patch("resources.lib.resolver._FALLBACK_PREWARM_POLL_SECONDS", 0.01), patch(
+        "resources.lib.resolver.xbmcgui"
+    ) as mock_gui:
+        mock_gui.Window.return_value.getProperty.side_effect = get_property
+        state = _start_fallback_submit_worker(
+            candidates=[{"nzb_url": "x"}],
+            prewarm_delay=0.05,
+            wait_for_playback=True,
+        )
+        _signal_fallback_playback_started(state)
+        state["thread"].join(timeout=2)
+
+    assert not state["thread"].is_alive()
+    assert submitted, "worker must submit while playback stays live"
+
+
+def test_fallback_worker_submits_when_liveness_never_set():
+    """When ``nzbdav.playing`` is never set (e.g. the await-playback cap path /
+    an unusual handoff where service never marked liveness), the seen-live latch
+    never engages, so the worker degrades to a late submit rather than being
+    wrongly stranded."""
+    from resources.lib.resolver import (
+        _signal_fallback_playback_started,
+        _start_fallback_submit_worker,
+    )
+
+    submitted = []
+
+    def fake_submit(*_args, **_kwargs):
+        submitted.append(True)
+
+    with patch(
+        "resources.lib.resolver._submit_fallback_candidates", side_effect=fake_submit
+    ), patch("resources.lib.resolver._FALLBACK_PREWARM_POLL_SECONDS", 0.01), patch(
+        "resources.lib.resolver.xbmcgui"
+    ) as mock_gui:
+        # Liveness flag never observed live (always empty).
+        mock_gui.Window.return_value.getProperty.return_value = ""
+        state = _start_fallback_submit_worker(
+            candidates=[{"nzb_url": "x"}],
+            prewarm_delay=0.05,
+            wait_for_playback=True,
+        )
+        _signal_fallback_playback_started(state)
+        state["thread"].join(timeout=2)
+
+    assert not state["thread"].is_alive()
+    assert submitted, "never-live liveness must not strand the late submit"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -392,7 +392,32 @@ def test_completed_job_stream_passes_settings_getter_to_webdav_lookup(mock_find_
     mock_find_stream.assert_called_once_with(
         "/content/uncategorized/movie/",
         settings_getter=settings_getter,
+        title_hint="movie.mkv",
     )
+
+
+@patch("resources.lib.resolver._find_video_stream_for_folder")
+def test_completed_job_stream_threads_title_as_episode_hint(mock_find_stream):
+    """The requested release title is threaded into webdav as ``title_hint`` so a
+    multi-episode pack returns the requested episode, not the largest file."""
+    mock_find_stream.return_value = (
+        "/content/uncategorized/Show/Show.S02E05.mkv",
+        "http://webdav/Show.S02E05.mkv",
+        {"Authorization": "Basic x"},
+    )
+
+    job = {
+        "status": "Completed",
+        "name": "Show.S02E05.1080p.WEB-DL",
+        "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/Show",
+    }
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_probe_response(content_length=85_000_000, body=b"\x00"),
+    ):
+        _completed_job_stream("Show.S02E05.1080p.WEB-DL", job)
+
+    assert mock_find_stream.call_args.kwargs["title_hint"] == "Show.S02E05.1080p.WEB-DL"
 
 
 @patch("resources.lib.resolver._find_video_stream_for_folder")
@@ -2185,7 +2210,7 @@ def test_resolve_overlaps_bookmark_cleanup_with_existing_completed_fast_path(
         _time.sleep(0.2)
         timing["cleanup_end"] = _time.perf_counter()
 
-    def find_video(_path):
+    def find_video(_path, **_kwargs):
         timing["video_scan_start"] = _time.perf_counter()
         _time.sleep(0.2)
         timing["video_scan_end"] = _time.perf_counter()
@@ -2426,7 +2451,7 @@ def test_resolve_and_play_skips_duplicate_stale_picker_completed_probe_before_su
     timing = {}
     scanned_folders = []
 
-    def slow_find_video(folder):
+    def slow_find_video(folder, **_kwargs):
         scanned_folders.append(folder)
         _time.sleep(0.09)
         if folder.endswith("/ready/"):
@@ -2989,6 +3014,29 @@ def test_delegated_find_video_stream_remembers_content_length_hint(mock_size_hin
         resolver._get_stream_content_length_hint(stream_url, "Basic delegated")
         == 4294967296
     )
+
+
+def test_find_video_stream_for_folder_threads_title_hint_to_webdav():
+    """``_find_video_stream_for_folder`` forwards ``title_hint`` to the webdav
+    delegate so the episode-pack preference reaches discovery at runtime."""
+    from resources.lib import resolver
+    from resources.lib.resolver import _find_video_stream_for_folder
+
+    delegated = MagicMock(
+        return_value=(
+            "/content/Show/Show.S02E05.mkv",
+            "http://webdav/content/Show/Show.S02E05.mkv",
+            {"Authorization": "Basic x"},
+        )
+    )
+
+    with patch("resources.lib.webdav.find_video_stream_for_folder", delegated):
+        with patch.object(resolver, "find_video_stream_for_folder", delegated):
+            _find_video_stream_for_folder(
+                "/content/Show/", title_hint="Show.S02E05.1080p.WEB-DL"
+            )
+
+    assert delegated.call_args.kwargs["title_hint"] == "Show.S02E05.1080p.WEB-DL"
 
 
 @patch("resources.lib.resolver._stop_fallback_submit_worker")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -19,6 +19,7 @@ from resources.lib.resolver import (
     _direct_playback_service_config,
     _existing_completed_stream,
     _fallback_submit_jobs_snapshot,
+    _get_fallback_submit_delay_seconds,
     _get_poll_settings,
     _get_submit_timeout_seconds,
     _handle_history_result,
@@ -264,6 +265,55 @@ def test_get_submit_timeout_seconds_uses_requested_default_for_empty_setting():
         assert _get_submit_timeout_seconds() == 300
     finally:
         sys.modules["xbmcaddon"].Addon.return_value = original
+
+
+def test_get_fallback_submit_delay_seconds_defaults_to_prewarm_constant():
+    """An empty setting falls back to the documented 120s prewarm default."""
+
+    def settings_getter(_key, default=""):
+        return ""
+
+    assert (
+        _get_fallback_submit_delay_seconds(settings_getter=settings_getter)
+        == _FALLBACK_PREWARM_DELAY_SECONDS
+    )
+
+
+def test_get_fallback_submit_delay_seconds_uses_configured_value():
+    """A user-configured defer is honored verbatim (the requirement)."""
+
+    def settings_getter(key, default=""):
+        return "45" if key == "fallback_submit_delay" else default
+
+    assert _get_fallback_submit_delay_seconds(settings_getter=settings_getter) == 45
+
+
+def test_get_fallback_submit_delay_seconds_allows_zero():
+    """Zero means submit right at playback start — a valid configuration."""
+
+    def settings_getter(key, default=""):
+        return "0" if key == "fallback_submit_delay" else default
+
+    assert _get_fallback_submit_delay_seconds(settings_getter=settings_getter) == 0
+
+
+def test_get_fallback_submit_delay_seconds_rejects_garbage_and_negatives():
+    """Non-numeric or negative values fall back to the safe default."""
+
+    def garbage(key, default=""):
+        return "soon" if key == "fallback_submit_delay" else default
+
+    def negative(key, default=""):
+        return "-30" if key == "fallback_submit_delay" else default
+
+    assert (
+        _get_fallback_submit_delay_seconds(settings_getter=garbage)
+        == _FALLBACK_PREWARM_DELAY_SECONDS
+    )
+    assert (
+        _get_fallback_submit_delay_seconds(settings_getter=negative)
+        == _FALLBACK_PREWARM_DELAY_SECONDS
+    )
 
 
 def test_direct_playback_service_config_reads_proxy_window_once_for_fast_start():

--- a/tests/test_resolver_errors.py
+++ b/tests/test_resolver_errors.py
@@ -305,3 +305,39 @@ def test_submit_fallback_does_not_record_dead_on_timeout():
         resolver._submit_fallback_candidates(candidates, monitor, dead=dead)
 
     assert not dead.has_url("http://x/slow.nzb")
+
+
+def test_playback_fallback_sources_excludes_dead_nzo():
+    from resources.lib import resolver
+    from resources.lib.dead_candidates import DeadCandidates
+
+    dead = DeadCandidates()
+    dead.add(nzo_id="nzo_dead")
+    jobs = [
+        {"nzo_id": "nzo_dead", "title": "Dead", "nzb_url": "http://x/d.nzb"},
+        {"nzo_id": "nzo_ok", "title": "Ok", "nzb_url": "http://x/o.nzb"},
+    ]
+
+    sources = resolver._playback_fallback_sources_for_stream(
+        "http://primary/stream", jobs, dead=dead
+    )
+
+    assert [s["nzo_id"] for s in sources] == ["nzo_ok"]
+
+
+def test_playback_fallback_sources_excludes_dead_url():
+    from resources.lib import resolver
+    from resources.lib.dead_candidates import DeadCandidates
+
+    dead = DeadCandidates()
+    dead.add(nzb_url="http://x/d.nzb")
+    jobs = [
+        {"nzo_id": "nzo_a", "title": "Dead", "nzb_url": "http://x/d.nzb"},
+        {"nzo_id": "nzo_ok", "title": "Ok", "nzb_url": "http://x/o.nzb"},
+    ]
+
+    sources = resolver._playback_fallback_sources_for_stream(
+        "http://primary/stream", jobs, dead=dead
+    )
+
+    assert [s["nzo_id"] for s in sources] == ["nzo_ok"]

--- a/tests/test_resolver_errors.py
+++ b/tests/test_resolver_errors.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 nzbdav contributors
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from resources.lib.resolver import resolve
 
@@ -230,4 +230,78 @@ def test_poll_until_ready_does_not_record_dead_on_timeout(resolver_mocks):
             )
 
     assert stream_url is None
+    assert not dead.has_url("http://x/slow.nzb")
+
+
+def test_submit_fallback_skips_dead_and_primary_url():
+    from resources.lib import resolver
+    from resources.lib.dead_candidates import DeadCandidates
+
+    dead = DeadCandidates()
+    dead.add(nzb_url="http://x/dead.nzb")
+    candidates = [
+        {"link": "http://x/dead.nzb", "title": "Dead.Release"},
+        {"link": "http://x/primary.nzb", "title": "Primary.Release"},
+        {"link": "http://x/good.nzb", "title": "Good.Release"},
+    ]
+    monitor = MagicMock()
+    monitor.waitForAbort.return_value = False
+
+    with patch(
+        "resources.lib.resolver.find_completed_by_names", return_value={}
+    ), patch("resources.lib.resolver.find_queued_by_names", return_value={}), patch(
+        "resources.lib.resolver.submit_nzb", return_value=("nzo_good", None)
+    ) as submit:
+        jobs = resolver._submit_fallback_candidates(
+            candidates,
+            monitor,
+            dead=dead,
+            primary_nzb_url="http://x/primary.nzb",
+        )
+
+    submitted_urls = [call.args[0] for call in submit.call_args_list]
+    assert submitted_urls == ["http://x/good.nzb"]
+    assert [j["nzb_url"] for j in jobs] == ["http://x/good.nzb"]
+
+
+def test_submit_fallback_records_dead_on_provable_submit_error():
+    from resources.lib import resolver
+    from resources.lib.dead_candidates import DeadCandidates
+
+    dead = DeadCandidates()
+    candidates = [{"link": "http://x/bad.nzb", "title": "Bad.Release"}]
+    monitor = MagicMock()
+    monitor.waitForAbort.return_value = False
+
+    with patch(
+        "resources.lib.resolver.find_completed_by_names", return_value={}
+    ), patch("resources.lib.resolver.find_queued_by_names", return_value={}), patch(
+        "resources.lib.resolver.submit_nzb",
+        return_value=(None, {"status": 500, "message": "boom"}),
+    ):
+        jobs = resolver._submit_fallback_candidates(candidates, monitor, dead=dead)
+
+    assert jobs == []
+    assert dead.has_url("http://x/bad.nzb")
+
+
+def test_submit_fallback_does_not_record_dead_on_timeout():
+    from resources.lib import resolver
+    from resources.lib.dead_candidates import DeadCandidates
+
+    dead = DeadCandidates()
+    candidates = [{"link": "http://x/slow.nzb", "title": "Slow.Release"}]
+    monitor = MagicMock()
+    monitor.waitForAbort.return_value = False
+
+    with patch(
+        "resources.lib.resolver.find_completed_by_names", return_value={}
+    ), patch("resources.lib.resolver.find_queued_by_names", return_value={}), patch(
+        "resources.lib.resolver.submit_nzb",
+        return_value=(None, {"status": "timeout", "message": "slow"}),
+    ), patch(
+        "resources.lib.resolver._adopt_queued_or_completed_job", return_value=None
+    ):
+        resolver._submit_fallback_candidates(candidates, monitor, dead=dead)
+
     assert not dead.has_url("http://x/slow.nzb")

--- a/tests/test_resolver_errors.py
+++ b/tests/test_resolver_errors.py
@@ -281,7 +281,7 @@ def test_submit_fallback_records_dead_on_provable_submit_error():
     ):
         jobs = resolver._submit_fallback_candidates(candidates, monitor, dead=dead)
 
-    assert jobs == []
+    assert not jobs
     assert dead.has_url("http://x/bad.nzb")
 
 

--- a/tests/test_resolver_errors.py
+++ b/tests/test_resolver_errors.py
@@ -167,3 +167,67 @@ def test_resolve_surfaces_http_500_body_to_user(
     )
     # Single submit attempt — no retry on 500
     assert resolver_mocks.submit.call_count == 1
+
+
+def test_poll_until_ready_records_dead_on_job_failed(resolver_mocks):
+    """When the queue API reports Failed, _poll_until_ready must record the
+    nzb_url and nzo_id into the dead set (so the fallback pool won't resubmit
+    the same release)."""
+    from resources.lib import resolver
+    from resources.lib.dead_candidates import DeadCandidates
+
+    dead = DeadCandidates()
+    # Queue API returns Failed status — drives _handle_job_status to
+    # should_stop=True via the failed/deleted branch.
+    resolver_mocks.status.return_value = {"status": "Failed", "percentage": "0"}
+    # History returns None so _handle_history_result short-circuits early and
+    # does not itself trigger a stop before we reach the job-status check.
+    resolver_mocks.history.return_value = None
+
+    with patch("resources.lib.resolver._existing_completed_stream", return_value=None):
+        with patch(
+            "resources.lib.resolver._submit_nzb_with_retries", return_value="nzo_1"
+        ):
+            stream_url, _ = resolver._poll_until_ready(
+                "http://x/dead.nzb",
+                "Dead.Release",
+                resolver_mocks.dialog,
+                1,
+                60,
+                dead=dead,
+            )
+
+    assert stream_url is None
+    assert dead.has_url("http://x/dead.nzb")
+    assert dead.has_nzo("nzo_1")
+
+
+def test_poll_until_ready_does_not_record_dead_on_timeout(resolver_mocks):
+    """When the poll loop times out, _poll_until_ready must NOT record the
+    release as dead — a timeout is a transient condition, not a Usenet failure."""
+    from resources.lib import resolver
+    from resources.lib.dead_candidates import DeadCandidates
+
+    dead = DeadCandidates()
+    # Drive the elapsed-time abort: monotonic() returns 0.0 for start_time,
+    # then 10_000.0 for the first elapsed check inside the loop — well past the
+    # 60 s download_timeout — so _abort_poll_before_fetch returns True on
+    # iteration 1 before _poll_once is even called.
+    resolver_mocks.time.monotonic.side_effect = [0.0, 10_000.0]
+    resolver_mocks.history.return_value = None
+
+    with patch("resources.lib.resolver._existing_completed_stream", return_value=None):
+        with patch(
+            "resources.lib.resolver._submit_nzb_with_retries", return_value="nzo_2"
+        ):
+            stream_url, _ = resolver._poll_until_ready(
+                "http://x/slow.nzb",
+                "Slow.Release",
+                resolver_mocks.dialog,
+                1,
+                60,
+                dead=dead,
+            )
+
+    assert stream_url is None
+    assert not dead.has_url("http://x/slow.nzb")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3023,3 +3023,34 @@ def test_tag_available_fails_open_when_size_unknown(mock_completed):
     r2 = {"title": "Movie.mkv", "size": ""}
     _tag_available([r2])
     assert r2.get("_available") is True
+
+
+@patch("resources.lib.nzbdav_api.find_completed_by_name")
+def test_script_completed_job_for_selection_gates_by_size(mock_find):
+    """The RunScript error/auto-select completed re-fetch must honor the same
+    size gate as _tag_available, so a same-name different-size upload isn't
+    reused (RH-3)."""
+    from resources.lib.router import _script_completed_job_for_selection
+
+    # Same name, MATCHING size -> returned.
+    mock_find.return_value = {
+        "status": "Completed",
+        "name": "Movie.mkv",
+        "nzo_id": "x",
+        "bytes": 60_000_000_000,
+    }
+    assert _script_completed_job_for_selection(
+        {"title": "Movie.mkv", "size": "60500000000"}
+    )
+    # Same name, clearly different size -> dropped (download fresh).
+    assert (
+        _script_completed_job_for_selection(
+            {"title": "Movie.mkv", "size": "10000000000"}
+        )
+        is None
+    )
+    # Unknown size -> fail open (returned).
+    mock_find.return_value = {"status": "Completed", "name": "Movie.mkv", "nzo_id": "x"}
+    assert _script_completed_job_for_selection(
+        {"title": "Movie.mkv", "size": "60000000000"}
+    )

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2970,3 +2970,56 @@ def test_direct_play_decodes_percent_escaped_userinfo_for_basic_auth(
     assert request.full_url == "http://example.test/movie.mkv"
     assert request.headers["Authorization"] == "Basic dXNlckBuYW1lOnBAc3M6d29yZA=="
     mock_xbmcplugin.setResolvedUrl.assert_called_once()
+
+
+@patch("resources.lib.router.get_completed_jobs")
+def test_tag_available_requires_size_match(mock_completed):
+    """nzbdav history is name-keyed, so a name match alone collapses distinct
+    uploads sharing a filename. The DL/cache tag must also require a SIZE match,
+    so a different-size same-name release is NOT marked available / reused."""
+    from resources.lib.router import _tag_available
+
+    mock_completed.return_value = {
+        "Movie.mkv": {
+            "status": "Completed",
+            "name": "Movie.mkv",
+            "nzo_id": "x",
+            "bytes": 60_000_000_000,
+        },
+    }
+    same = {"title": "Movie.mkv", "size": "60500000000"}  # ~same size -> match
+    diff = {"title": "Movie.mkv", "size": "10000000000"}  # clearly different
+    _tag_available([same, diff])
+
+    assert same.get("_available") is True
+    assert same.get("_completed_job")
+    assert "_available" not in diff
+    assert "_completed_job" not in diff
+
+
+@patch("resources.lib.router.get_completed_jobs")
+def test_tag_available_fails_open_when_size_unknown(mock_completed):
+    """When size can't be compared (job has no bytes, or result has no size),
+    keep the prior name-only behavior rather than hide a real cache hit."""
+    from resources.lib.router import _tag_available
+
+    # completed job has no bytes -> cannot disambiguate -> fail open
+    mock_completed.return_value = {
+        "Movie.mkv": {"status": "Completed", "name": "Movie.mkv", "nzo_id": "x"},
+    }
+    r1 = {"title": "Movie.mkv", "size": "60000000000"}
+    _tag_available([r1])
+    assert r1.get("_available") is True
+
+    # result has no size -> fail open
+    mock_completed.return_value = {
+        "Movie.mkv": {
+            "status": "Completed",
+            "name": "Movie.mkv",
+            "nzo_id": "x",
+            "bytes": 60_000_000_000,
+        },
+    }
+    r2 = {"title": "Movie.mkv", "size": ""}
+    _tag_available([r2])
+    assert r2.get("_available") is True

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2541,6 +2541,9 @@ def test_handle_search_picker_fetches_fallbacks_after_selection(
         "year": "",
         "tmdb_id": "603",
         "_fallback_candidates": [],
+        # Threaded from the selected result so a fresh submit records the
+        # download's identity for later same-name-repost disambiguation.
+        "_download_size": 8589934592,
     }
 
     mock_fetch_manifest.assert_not_called()
@@ -3023,6 +3026,152 @@ def test_tag_available_fails_open_when_size_unknown(mock_completed):
     r2 = {"title": "Movie.mkv", "size": ""}
     _tag_available([r2])
     assert r2.get("_available") is True
+
+
+_PUBDATE_A = "Wed, 15 Dec 2021 12:00:00 +0000"  # epoch 1639569600
+_PUBDATE_B = "Thu, 16 Dec 2021 12:00:00 +0000"  # epoch 1639656000 (1 day later)
+
+
+def test_attach_selected_result_metadata_threads_pubdate_and_size():
+    """The picker must hand the selected result's pubdate and size to the
+    resolver so a fresh download can be recorded for later disambiguation."""
+    from resources.lib.router import _attach_selected_result_metadata
+
+    params = {}
+    _attach_selected_result_metadata(
+        params,
+        {"indexer": "hydra", "pubdate": _PUBDATE_A, "size": "12345"},
+    )
+    assert params["_selected_indexer"] == "hydra"
+    assert params["_download_pubdate"] == _PUBDATE_A
+    assert params["_download_size"] == "12345"
+
+
+def test_attach_selected_result_metadata_omits_absent_fields():
+    """No pubdate/size on the result -> no spurious keys (resolver fails open)."""
+    from resources.lib.router import _attach_selected_result_metadata
+
+    params = {}
+    _attach_selected_result_metadata(params, {"title": "x"})
+    assert "_download_pubdate" not in params
+    assert "_download_size" not in params
+    assert "_selected_indexer" not in params
+
+
+@patch("resources.lib.router.downloaded_pubdate_epochs")
+@patch("resources.lib.router.get_completed_jobs")
+def test_tag_available_requires_pubdate_match(mock_completed, mock_epochs):
+    """Same name AND same size still isn't enough when we have recorded the
+    pubdate of what we actually downloaded: a same-name repost posted on a
+    different day is a DIFFERENT file and must not be marked DL / reused."""
+    from resources.lib.router import _tag_available
+
+    mock_completed.return_value = {
+        "Movie.mkv": {
+            "status": "Completed",
+            "name": "Movie.mkv",
+            "nzo_id": "x",
+            "bytes": 60_000_000_000,
+        },
+    }
+    # We downloaded the release posted at PUBDATE_A.
+    mock_epochs.return_value = [1639569600]
+
+    same_age = {"title": "Movie.mkv", "size": "60000000000", "pubdate": _PUBDATE_A}
+    diff_age = {"title": "Movie.mkv", "size": "60000000000", "pubdate": _PUBDATE_B}
+    _tag_available([same_age, diff_age])
+
+    assert same_age.get("_available") is True
+    assert "_available" not in diff_age
+    assert "_completed_job" not in diff_age
+
+
+@patch("resources.lib.router.downloaded_pubdate_epochs")
+@patch("resources.lib.router.get_completed_jobs")
+def test_tag_available_pubdate_match_within_tolerance(mock_completed, mock_epochs):
+    """Sub-tolerance jitter (indexer rounding / TZ formatting of the SAME
+    post) must still match, so a real cache hit is never hidden."""
+    from resources.lib import router
+
+    mock_completed.return_value = {
+        "Movie.mkv": {"status": "Completed", "name": "Movie.mkv", "bytes": 1000},
+    }
+    mock_epochs.return_value = [1639569600]
+    jittered = 1639569600 + router._PUBDATE_MATCH_TOLERANCE_SECONDS - 1
+    from resources.lib.http_util import pubdate_to_epoch  # sanity on the bound
+
+    assert pubdate_to_epoch(_PUBDATE_A) == 1639569600
+    from datetime import datetime, timezone
+    from email.utils import format_datetime
+
+    result = {
+        "title": "Movie.mkv",
+        "size": "1000",
+        "pubdate": format_datetime(datetime.fromtimestamp(jittered, tz=timezone.utc)),
+    }
+    router._tag_available([result])
+    assert result.get("_available") is True
+
+
+@patch("resources.lib.router.downloaded_pubdate_epochs")
+@patch("resources.lib.router.get_completed_jobs")
+def test_tag_available_fails_open_when_no_recorded_pubdate(mock_completed, mock_epochs):
+    """No recorded pubdate for this name (e.g. downloaded before this feature,
+    or via an external invocation) -> keep prior name+size behavior."""
+    from resources.lib.router import _tag_available
+
+    mock_completed.return_value = {
+        "Movie.mkv": {"status": "Completed", "name": "Movie.mkv", "bytes": 1000},
+    }
+    mock_epochs.return_value = []
+    result = {"title": "Movie.mkv", "size": "1000", "pubdate": _PUBDATE_B}
+    _tag_available([result])
+    assert result.get("_available") is True
+
+
+@patch("resources.lib.router.downloaded_pubdate_epochs")
+@patch("resources.lib.router.get_completed_jobs")
+def test_tag_available_fails_open_when_result_pubdate_missing(
+    mock_completed, mock_epochs
+):
+    """Recorded pubdates exist but the result advertises none -> we can't
+    compare, so fail open rather than hide a real cache hit."""
+    from resources.lib.router import _tag_available
+
+    mock_completed.return_value = {
+        "Movie.mkv": {"status": "Completed", "name": "Movie.mkv", "bytes": 1000},
+    }
+    mock_epochs.return_value = [1639569600]
+    result = {"title": "Movie.mkv", "size": "1000"}  # no pubdate
+    _tag_available([result])
+    assert result.get("_available") is True
+
+
+@patch("resources.lib.router.downloaded_pubdate_epochs")
+@patch("resources.lib.nzbdav_api.find_completed_by_name")
+def test_script_completed_job_for_selection_gates_by_pubdate(mock_find, mock_epochs):
+    """The RunScript completed re-fetch must honor the pubdate gate too, so a
+    same-name same-size repost posted on a different day isn't reused."""
+    from resources.lib.router import _script_completed_job_for_selection
+
+    mock_find.return_value = {
+        "status": "Completed",
+        "name": "Movie.mkv",
+        "nzo_id": "x",
+        "bytes": 60_000_000_000,
+    }
+    mock_epochs.return_value = [1639569600]
+    # Matching pubdate -> returned.
+    assert _script_completed_job_for_selection(
+        {"title": "Movie.mkv", "size": "60000000000", "pubdate": _PUBDATE_A}
+    )
+    # Different pubdate -> dropped (download fresh).
+    assert (
+        _script_completed_job_for_selection(
+            {"title": "Movie.mkv", "size": "60000000000", "pubdate": _PUBDATE_B}
+        )
+        is None
+    )
 
 
 @patch("resources.lib.nzbdav_api.find_completed_by_name")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -184,6 +184,31 @@ def test_tick_deactivates_when_retries_exhausted(mock_window):
 
 
 @patch("service._HOME_WINDOW")
+def test_tick_terminal_error_clears_playing_flag(mock_window):
+    """Regression (id 3365909884 follow-up): a terminal ERROR->IDLE transition
+    must clear the persistent ``nzbdav.playing`` liveness flag, so the
+    plugin-process fallback submit worker observes the dead session and aborts
+    its standby wait instead of submitting backups. Covers the retries-disabled
+    and max-retries terminal paths."""
+    from service import _PROP_PLAYING
+
+    for read_settings in ((False, 3, 5), (True, 3, 1)):
+        mock_window.reset_mock()
+        mock_window.getProperty.return_value = ""
+        player = NzbdavPlayer()
+        player._state = PlaybackState.ERROR
+        player._retry_count = 5  # already past max for the (True, 3, 1) case
+        player._title = "test"
+
+        with patch.object(player, "_read_settings", return_value=read_settings):
+            player.tick()
+
+        assert player._state == PlaybackState.IDLE
+        cleared = {call.args[0] for call in mock_window.clearProperty.call_args_list}
+        assert _PROP_PLAYING in cleared, (read_settings, cleared)
+
+
+@patch("service._HOME_WINDOW")
 def test_tick_does_nothing_when_no_error(mock_window):
     """tick() does nothing when playback is fine."""
     mock_window.getProperty.return_value = ""

--- a/tests/test_settings_layout.py
+++ b/tests/test_settings_layout.py
@@ -159,6 +159,31 @@ def test_prowlarr_indexer_ids_precedes_test_action(settings_root):
 # --- Sanity: every setting has a unique id (when id is present) -----------
 
 
+def _setting_anywhere(root, setting_id):
+    for setting in root.iter("setting"):
+        if setting.get("id") == setting_id:
+            return setting
+    return None
+
+
+def test_readahead_buffer_mb_setting_present(settings_root):
+    """The read-ahead prefetch cache is gated by readahead_buffer_mb; pin its
+    layout (type=number, default=256) like the sibling tuning settings."""
+    setting = _setting_anywhere(settings_root, "readahead_buffer_mb")
+    assert setting is not None, "readahead_buffer_mb setting missing"
+    assert setting.get("type") == "number"
+    assert setting.get("default") == "256"
+    assert setting.get("label") == "30207"
+
+
+def test_passthrough_stall_wait_setting_present(settings_root):
+    """Pin the passthrough_stall_wait layout (was previously unasserted)."""
+    setting = _setting_anywhere(settings_root, "passthrough_stall_wait")
+    assert setting is not None
+    assert setting.get("type") == "number"
+    assert setting.get("default") == "120"
+
+
 def test_no_duplicate_setting_ids(settings_root):
     """Settings with an id attribute should be unique across the file —
     Kodi keys by id, and a dup silently shadows."""

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -2929,6 +2929,80 @@ def test_stream_upstream_range_counts_cached_prefix_when_remaining_open_fails():
     assert _collect_written(handler) == cached
 
 
+def test_stream_upstream_range_midstream_404_is_awaiting_not_terminal():
+    """A 404 on an ESTABLISHED read (start > 0) means nzbdav has not yet
+    downloaded this byte range (it 404s past its download high-water), NOT a
+    permanent path error. It must be reported as AWAITING_DOWNLOAD so the
+    retry ladder + patient wait + fallback cutover engage, instead of a hard
+    CLIENT_ERROR abort that kills playback the instant playback catches the
+    download high-water (the "Dune died on a 404" incident)."""
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+    )
+
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 68867978518,
+    }
+    handler = _make_handler_with_server(ctx)
+    # nzbdav 404s the range past its download high-water mid-file.
+    err = HTTPError("http://host/movie.mkv", 404, "Not Found", {}, None)
+
+    with patch("resources.lib.stream_proxy.urlopen", side_effect=err):
+        result, written = handler._stream_upstream_range(ctx, 321791899, 321800090)
+
+    assert result == _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD
+    assert written == 0
+    handler.wfile.write.assert_not_called()
+
+
+def test_stream_upstream_range_byte_zero_404_stays_terminal():
+    """A 404 on the INITIAL open (start == 0) is a genuine missing path —
+    byte 0 must exist if the path is valid — so it stays a terminal
+    CLIENT_ERROR and must NOT wait the full patient-wait budget."""
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_CLIENT_ERROR
+
+    ctx = {
+        "remote_url": "http://host/gone.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 2048,
+    }
+    handler = _make_handler_with_server(ctx)
+    err = HTTPError("http://host/gone.mkv", 404, "Not Found", {}, None)
+
+    with patch("resources.lib.stream_proxy.urlopen", side_effect=err):
+        result, written = handler._stream_upstream_range(ctx, 0, 2047)
+
+    assert result == _UPSTREAM_RANGE_CLIENT_ERROR
+    assert written == 0
+
+
+def test_stream_upstream_range_midstream_401_stays_terminal():
+    """Auth failures (401/403) are always terminal even mid-stream — waiting
+    cannot fix bad credentials, and they must not be disguised as a
+    still-downloading range."""
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_CLIENT_ERROR
+
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": "Basic expired",
+        "content_type": "video/x-matroska",
+        "content_length": 4096,
+    }
+    handler = _make_handler_with_server(ctx)
+    err = HTTPError("http://host/movie.mkv", 401, "Unauthorized", {}, None)
+
+    with patch("resources.lib.stream_proxy.urlopen", side_effect=err), patch(
+        "resources.lib.stream_proxy._notify"
+    ):
+        result, written = handler._stream_upstream_range(ctx, 1024, 2047)
+
+    assert result == _UPSTREAM_RANGE_CLIENT_ERROR
+
+
 def test_prepare_stream_falls_back_to_proxy_without_ffmpeg():
     from resources.lib.stream_proxy import StreamProxy
 
@@ -15470,8 +15544,6 @@ def test_maybe_notify_stream_starvation_fires_on_recent_outage_disconnect():
     outage (nzbdav blipped back ~9s before Kodi gave up), only ~140MB of a 57GB
     file delivered. Must fire ONE clear 'can't keep up' toast, not a silent
     black screen."""
-    import time
-
     from resources.lib import stream_proxy
 
     ctx = {
@@ -15503,8 +15575,6 @@ def test_maybe_notify_stream_starvation_silent_on_long_recovered_outage():
     """FP-1/FP-2: a stream that had an EARLY transient outage, recovered, played,
     then was stopped (healthy client_disconnected) must NOT fire — the sticky
     upstream_unreachable_count is gated on recency."""
-    import time
-
     from resources.lib import stream_proxy
 
     ctx = {

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -2797,18 +2797,24 @@ def test_prevalidated_fallback_reuses_current_probe_for_first_fallback_bytes():
     ) as probe_open, patch(
         "resources.lib.stream_proxy.urlopen", side_effect=stream_urlopen
     ) as stream_open:
-        started = time.monotonic()
         handler._serve_proxy(ctx)
 
     assert first_write_at, "fallback did not write playable bytes"
-    first_byte_elapsed = first_write_at[0] - started
     assert ctx["fallback_switch_count"] == 1
     assert _collect_written(handler) == payload
     assert probe_open.call_count == 1
-    assert (
-        first_byte_elapsed < probe_delay + stream_delay
-    ), "first fallback byte took {:.3f}s".format(first_byte_elapsed)
-    assert stream_open.call_count <= 1
+    # The fallback's first range is served from the reused prevalidation probe,
+    # so the live stream path must never open the fallback URL itself. Assert that
+    # behavior directly (zero fallback stream-opens) rather than via a global
+    # call_count or wall-clock timing: a stray background read-ahead open from a
+    # leaked sibling-test daemon, or scheduler jitter under parallel suite load,
+    # would otherwise flake this without indicating any real regression.
+    fallback_stream_opens = sum(
+        1
+        for call in stream_open.call_args_list
+        if call.args and call.args[0].full_url.endswith("/fallback.mkv")
+    )
+    assert fallback_stream_opens == 0
 
 
 def test_prevalidated_fallback_cached_sample_writes_without_post_error_probe():

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -10810,7 +10810,7 @@ def test_select_live_fallback_refreshes_completed_standby_job():
     assert source["stream_headers"] == {"Authorization": "Basic fallback"}
     assert source["content_length"] == 10
     history.assert_called_once_with("nzo2")
-    find_video.assert_called_once_with("/content/movies/Fallback/")
+    find_video.assert_called_once_with("/content/movies/Fallback/", title_hint=None)
     stream_url.assert_called_once_with("/content/movies/Fallback/fallback.mkv")
     assert fetch_length.call_args[0] == (
         "http://webdav/fallback.mkv",
@@ -11066,7 +11066,7 @@ def test_standby_refresh_reuses_probe_bases_for_content_length_checks():
             {"Authorization": "Basic fallback"},
         )
 
-    def find_video_path(path):
+    def find_video_path(path, title_hint=None):
         return "{}movie.mkv".format(path)
 
     with patch(
@@ -15269,3 +15269,79 @@ def test_non_awaiting_read_resets_awaiting_streak():
     )
     assert count == 1
     assert ctx["_awaiting_download_no_progress"] == 1
+
+
+def test_standby_refresh_threads_source_title_as_find_video_file_hint():
+    """A standby fallback source title must reach find_video_file as title_hint.
+
+    For a multi-episode fallback pack the proxy must resolve the requested
+    episode (via title_hint), not the largest sibling, so the resolved file
+    can pass content-length/fingerprint validation.
+    """
+    handler = _make_handler()
+    source = {
+        "nzo_id": "nzo-episode",
+        "title": "The.Show.S03E07.1080p.WEB-DL.x264-GRP",
+        "stream_url": "",
+        "stream_headers": {},
+        "content_length": 0,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {"fallback_sources": [source]}
+
+    with patch(
+        "resources.lib.nzbdav_api.get_job_history",
+        return_value={
+            "status": "Completed",
+            "storage": "/mnt/nzbdav/completed-symlinks/tv/TheShow.S03",
+        },
+    ), patch(
+        "resources.lib.webdav.find_video_file",
+        return_value="/content/tv/TheShow.S03/S03E07.mkv",
+    ) as find_video, patch(
+        "resources.lib.webdav.get_webdav_stream_url_for_path",
+        return_value=("", {}),
+    ), patch(
+        "resources.lib.fallback_streams.fetch_content_length",
+        return_value=0,
+    ):
+        handler._refresh_standby_fallback_source(ctx, source)
+
+    assert find_video.call_args.kwargs["title_hint"] == (
+        "The.Show.S03E07.1080p.WEB-DL.x264-GRP"
+    )
+
+
+def test_standby_refresh_passes_none_hint_when_source_title_absent():
+    """A source with no title must pass title_hint=None (largest-wins, f12b3c3)."""
+    handler = _make_handler()
+    source = {
+        "nzo_id": "nzo-no-title",
+        "stream_url": "",
+        "stream_headers": {},
+        "content_length": 0,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {"fallback_sources": [source]}
+
+    with patch(
+        "resources.lib.nzbdav_api.get_job_history",
+        return_value={
+            "status": "Completed",
+            "storage": "/mnt/nzbdav/completed-symlinks/movies/NoTitle",
+        },
+    ), patch(
+        "resources.lib.webdav.find_video_file",
+        return_value="/content/movies/NoTitle/movie.mkv",
+    ) as find_video, patch(
+        "resources.lib.webdav.get_webdav_stream_url_for_path",
+        return_value=("", {}),
+    ), patch(
+        "resources.lib.fallback_streams.fetch_content_length",
+        return_value=0,
+    ):
+        handler._refresh_standby_fallback_source(ctx, source)
+
+    assert find_video.call_args.kwargs["title_hint"] is None

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -15457,14 +15457,19 @@ def test_storage_to_webdav_path_content_passthrough_unchanged():
     )
 
 
-def test_maybe_notify_stream_starvation_fires_on_backend_outage():
-    """A pass-through stream that ends starved while the backend was unreachable
-    must fire ONE clear 'can't keep up' notification, not a silent black screen
-    (the live Shawshank incident: client_disconnected, upstream_unreachable=3,
-    only ~140MB of a 57GB file delivered)."""
+def test_maybe_notify_stream_starvation_fires_on_recent_outage_disconnect():
+    """The live Shawshank incident: client_disconnected, a RECENT upstream
+    outage (nzbdav blipped back ~9s before Kodi gave up), only ~140MB of a 57GB
+    file delivered. Must fire ONE clear 'can't keep up' toast, not a silent
+    black screen."""
+    import time
+
     from resources.lib import stream_proxy
 
-    ctx = {"upstream_unreachable_count": 3}
+    ctx = {
+        "upstream_unreachable_count": 3,
+        "last_upstream_unreachable_at": time.time() - 9,
+    }
     with patch("resources.lib.stream_proxy._notify") as mock_notify:
         fired = stream_proxy._maybe_notify_stream_starvation(
             None, ctx, "client_disconnected", 140558304, 57740611174
@@ -15472,6 +15477,39 @@ def test_maybe_notify_stream_starvation_fires_on_backend_outage():
     assert fired is True
     mock_notify.assert_called_once()
     assert "keep up" in mock_notify.call_args[0][1].lower()
+
+
+def test_maybe_notify_stream_starvation_fires_when_upstream_still_down():
+    from resources.lib import stream_proxy
+
+    ctx = {"upstream_unreachable_count": 2, "upstream_down_notified": True}
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        fired = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "client_disconnected", 5_000_000, 57740611174
+        )
+    assert fired is True
+    mock_notify.assert_called_once()
+
+
+def test_maybe_notify_stream_starvation_silent_on_long_recovered_outage():
+    """FP-1/FP-2: a stream that had an EARLY transient outage, recovered, played,
+    then was stopped (healthy client_disconnected) must NOT fire — the sticky
+    upstream_unreachable_count is gated on recency."""
+    import time
+
+    from resources.lib import stream_proxy
+
+    ctx = {
+        "upstream_unreachable_count": 1,
+        "last_upstream_unreachable_at": time.time() - 3600,
+        "upstream_last_recovered_at": time.time() - 3590,
+    }
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        fired = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "client_disconnected", 30_000_000, 57740611174
+        )
+    assert fired is False
+    mock_notify.assert_not_called()
 
 
 def test_maybe_notify_stream_starvation_fires_on_stall_reason_without_outage():

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -7904,12 +7904,16 @@ def test_serve_proxy_survives_five_stream_outages_with_backup_sources():
     assert ctx["auth_header"] == "Basic fallback4"
     assert ctx["fallback_switch_count"] == 5
     assert ctx["fallback_active_index"] == 4
+    # The demoted primary is appended as a last-resort entry (demoted=True,
+    # failed not set) when the first cutover fires, so fallback_sources now
+    # has 6 entries: the original 5 + the demoted primary at the end.
     assert [source.get("failed") for source in fallback_sources] == [
         True,
         True,
         True,
         True,
         False,
+        None,  # demoted primary: not failed, just demoted
     ]
     assert mock_select.call_count == 5
     assert _collect_written(handler) == b"S" * content_length
@@ -16039,3 +16043,63 @@ def test_maybe_notify_stream_starvation_silent_on_density_breaker():
         )
     assert fired is False
     mock_notify.assert_not_called()
+
+
+def test_activate_fallback_readds_demoted_active_source():
+    from resources.lib import stream_proxy
+
+    handler = stream_proxy._StreamHandler.__new__(stream_proxy._StreamHandler)
+    fallback = {
+        "stream_url": "http://fb/stream",
+        "stream_headers": {"Authorization": "Bearer fb"},
+        "content_length": 100,
+    }
+    ctx = {
+        "remote_url": "http://primary/stream",
+        "auth_header": "Bearer primary",
+        "content_length": 100,
+        "fallback_sources": [fallback],
+    }
+
+    handler._activate_fallback_source(ctx, fallback, current=None)
+
+    assert ctx["remote_url"] == "http://fb/stream"
+    demoted = [
+        s
+        for s in ctx["fallback_sources"]
+        if s.get("stream_url") == "http://primary/stream"
+    ]
+    assert len(demoted) == 1
+    assert demoted[0]["stream_headers"]["Authorization"] == "Bearer primary"
+    assert demoted[0]["content_length"] == 100
+
+
+def test_activate_fallback_does_not_duplicate_demoted_source():
+    from resources.lib import stream_proxy
+
+    handler = stream_proxy._StreamHandler.__new__(stream_proxy._StreamHandler)
+    fallback = {
+        "stream_url": "http://fb/stream",
+        "stream_headers": {},
+        "content_length": 100,
+    }
+    already = {
+        "stream_url": "http://primary/stream",
+        "stream_headers": {},
+        "content_length": 100,
+    }
+    ctx = {
+        "remote_url": "http://primary/stream",
+        "auth_header": None,
+        "content_length": 100,
+        "fallback_sources": [fallback, already],
+    }
+
+    handler._activate_fallback_source(ctx, fallback, current=None)
+
+    demoted = [
+        s
+        for s in ctx["fallback_sources"]
+        if s.get("stream_url") == "http://primary/stream"
+    ]
+    assert len(demoted) == 1

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -2929,6 +2929,46 @@ def test_stream_upstream_range_counts_cached_prefix_when_remaining_open_fails():
     assert _collect_written(handler) == cached
 
 
+def test_stream_upstream_range_404_after_written_prefix_is_recoverable():
+    """A verified cached prefix proves the file exists; a 404 on the remaining
+    tail is then nzbdav reporting "not downloaded yet" (past its high-water),
+    NOT a missing path. The prefix advances ``start`` past 0, so the 404 lands
+    on the established-stream branch and is reported as a RECOVERABLE short
+    read carrying the prefix bytes — distinct from the network-error
+    ConnectionRefused path above, which never reaches the 404 branch."""
+    from resources.lib.stream_proxy import (
+        _FALLBACK_CURRENT_RANGE_CACHE_KEY,
+        _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE,
+    )
+
+    cached = b"C" * 4096
+    ctx = {
+        "remote_url": "http://webdav/content/fallback.mkv",
+        "auth_header": "Basic fallback",
+        "content_type": "video/x-matroska",
+        "content_length": 8192,
+        _FALLBACK_CURRENT_RANGE_CACHE_KEY: {
+            (
+                "http://webdav/content/fallback.mkv",
+                "Basic fallback",
+                8192,
+                0,
+                4095,
+            ): cached
+        },
+    }
+    handler = _make_handler_with_server(ctx)
+    # nzbdav 404s the tail (bytes 4096-8191) it has not downloaded yet.
+    err = HTTPError("http://webdav/content/fallback.mkv", 404, "Not Found", {}, None)
+
+    with patch("resources.lib.stream_proxy.urlopen", side_effect=err):
+        result, written = handler._stream_upstream_range(ctx, 0, 8191)
+
+    assert result == _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE
+    assert written == len(cached)
+    assert _collect_written(handler) == cached
+
+
 def test_stream_upstream_range_midstream_404_is_awaiting_not_terminal():
     """A 404 on an ESTABLISHED read (start > 0) means nzbdav has not yet
     downloaded this byte range (it 404s past its download high-water), NOT a

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -1147,6 +1147,31 @@ def test_prepare_stream_uses_settings_snapshot_without_kodi_setting_reads():
     assert "_passthrough_runtime_settings_thread" not in ctx
 
 
+def test_settings_snapshot_carries_passthrough_stall_wait():
+    """Regression (id 3365909882): passthrough_stall_wait must be serialized into
+    the /prepare settings snapshot so a user-tuned (or 0-to-disable) value is
+    honored on the service-proxied path instead of silently defaulting to 120."""
+    import resources.lib.stream_proxy as sp
+
+    assert "passthrough_stall_wait" in sp._SETTINGS_SNAPSHOT_KEYS
+
+    def getter(key, _default=""):
+        return "0" if key == "passthrough_stall_wait" else ""
+
+    snap = sp.build_settings_snapshot(settings_getter=getter)
+    assert snap["passthrough_stall_wait"] == "0"
+    # 0 disables the patient stall wait — and now actually reaches the consumer.
+    runtime = sp._passthrough_runtime_settings_from_snapshot(snap)
+    assert runtime["passthrough_stall_wait_seconds"] == 0
+
+    def getter45(key, _default=""):
+        return "45" if key == "passthrough_stall_wait" else ""
+
+    snap45 = sp.build_settings_snapshot(settings_getter=getter45)
+    runtime45 = sp._passthrough_runtime_settings_from_snapshot(snap45)
+    assert runtime45["passthrough_stall_wait_seconds"] == 45
+
+
 def test_prepare_stream_unknown_length_mkv_without_ffmpeg_raises_in_matroska_mode():
     """Matroska mode cannot handle unknown-size non-MP4 streams without ffmpeg."""
     from resources.lib.stream_proxy import StreamProxy

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -15345,3 +15345,50 @@ def test_standby_refresh_passes_none_hint_when_source_title_absent():
         handler._refresh_standby_fallback_source(ctx, source)
 
     assert find_video.call_args.kwargs["title_hint"] is None
+
+
+def test_storage_to_webdav_path_mnt_data_no_category():
+    from resources.lib.stream_proxy import _storage_to_webdav_path
+
+    # No-category /mnt/data row must strip the mount prefix, not fall
+    # through to last-two-components (which yields a bogus
+    # /content/completed-symlinks/... folder).
+    assert (
+        _storage_to_webdav_path("/mnt/data/completed-symlinks/The Matrix 1999")
+        == "/content/The Matrix 1999/"
+    )
+
+
+def test_storage_to_webdav_path_mnt_data_with_category():
+    from resources.lib.stream_proxy import _storage_to_webdav_path
+
+    assert (
+        _storage_to_webdav_path("/mnt/data/completed-symlinks/movies/The Matrix 1999")
+        == "/content/movies/The Matrix 1999/"
+    )
+
+
+def test_storage_to_webdav_path_mnt_nzbdav_inputs_map_identically():
+    from resources.lib.stream_proxy import _storage_to_webdav_path
+
+    # Already-working /mnt/nzbdav cases (no-category and categorized) must
+    # map exactly as before the /mnt/data prefix was added.
+    assert (
+        _storage_to_webdav_path("/mnt/nzbdav/completed-symlinks/The Matrix 1999")
+        == "/content/The Matrix 1999/"
+    )
+    assert (
+        _storage_to_webdav_path("/mnt/nzbdav/completed-symlinks/movies/The Matrix 1999")
+        == "/content/movies/The Matrix 1999/"
+    )
+
+
+def test_storage_to_webdav_path_content_passthrough_unchanged():
+    from resources.lib.stream_proxy import _storage_to_webdav_path
+
+    # A storage already under /content/ is passed through (trailing-slash
+    # normalized) regardless of the prefix list.
+    assert (
+        _storage_to_webdav_path("/content/movies/The Matrix 1999")
+        == "/content/movies/The Matrix 1999/"
+    )

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -14489,6 +14489,70 @@ def test_serve_proxy_fallback_primary_recovers_on_final_retry_ladder(mock_xbmc):
 
 
 @patch("resources.lib.stream_proxy.xbmc")
+def test_serve_proxy_surfaces_client_error_from_final_retry_ladder_not_fallback_exhausted(  # noqa: E501
+    mock_xbmc,
+):
+    """F4 cap must NOT mask a terminal upstream result returned by the FINAL
+    retry-ladder attempt. The cap-fire block runs after the retry ladder but
+    before the CLIENT_ERROR/PROTOCOL_MISMATCH terminal branch, so a primary
+    whose cap-th ladder attempt returns a 401/403 (CLIENT_ERROR) or a contract
+    mismatch (PROTOCOL_MISMATCH) would otherwise exit as fallback_exhausted and
+    hide the real root cause. The guard lets a terminal result fall through to
+    the terminal branch so the genuine reason is surfaced instead."""
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_CLIENT_ERROR,
+        _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE,
+    )
+
+    content_length = 1_000_000
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+        "fallback_sources": [{"nzo_id": "alt", "stream_url": "http://host/alt.mkv"}],
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes=0-{}".format(content_length - 1)
+    )
+
+    # The primary read always short-reads with zero bytes, driving the
+    # fall-through counter up via the L4546 gate while the fallback never
+    # validates. The retry ladder makes no progress on attempts 1 and 2, then
+    # on the cap-th (3rd) attempt the upstream returns a terminal CLIENT_ERROR
+    # (a 401/403). Without the guard the cap would fire first and report
+    # fallback_exhausted; with it, the terminal result is surfaced.
+    def _stream(active_ctx, start, end, contract_mode=None):
+        return _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE, 0
+
+    retry_calls = {"n": 0}
+
+    def _fake_retry(active_ctx, start, end, contract_mode, first_byte=False):
+        retry_calls["n"] += 1
+        if retry_calls["n"] >= 3:
+            return _UPSTREAM_RANGE_CLIENT_ERROR, 0, start
+        return _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE, 0, start
+
+    with patch.object(
+        handler, "_stream_upstream_range", side_effect=_stream
+    ), patch.object(
+        handler, "_select_live_fallback_source", return_value=None
+    ), patch.object(
+        handler, "_retry_original_range", side_effect=_fake_retry
+    ), patch.object(
+        handler, "_find_skip_offset", return_value=4096
+    ):
+        handler._serve_proxy(ctx)
+
+    logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
+    # The 403 surfaces on the cap-th ladder attempt.
+    assert retry_calls["n"] == 3
+    # The real terminal reason is surfaced, not masked as fallback_exhausted.
+    assert "reason=upstream_client_error" in logged
+    assert "reason=fallback_exhausted" not in logged
+
+
+@patch("resources.lib.stream_proxy.xbmc")
 def test_serve_proxy_cutover_resets_fallthrough_exhaustion_counter(mock_xbmc):
     """SM-1: the F4 bounded-exhaustion counters
     (fallback_pending_fallthroughs / last_fallthrough_streamed) must be RESET on

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -15933,6 +15933,83 @@ def test_serve_proxy_forward_stall_gives_up_after_budget_exhausted():
     mock_zeros.assert_not_called()  # skip-probe returned None -> recovery_exhausted
 
 
+def test_serve_proxy_forward_stall_kodi_shutdown_is_benign_exit():
+    """A Kodi shutdown (waitForAbort True) landing inside the patient
+    forward-stall backoff must be reported as a BENIGN exit
+    (reason=client_disconnected), not the default reason=unknown. Leaving it
+    'unknown' makes the finally block treat a clean teardown as a genuine
+    failure: WARNING-level summary log and a spurious pending-fallback failure
+    toast. The abort IS Kodi closing the session — client-side, never an
+    upstream error."""
+    import sys
+
+    from resources.lib.stream_proxy import (
+        _PASSTHROUGH_RUNTIME_SETTINGS_KEY,
+        _STRICT_CONTRACT_MODE_OFF,
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+    )
+
+    start, end = 1000, 1099  # mid-file, established (start>0)
+    ctx = {
+        "remote_url": "http://webdav/remux.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 100_000,
+        "upstream_down_notified": True,
+        "upstream_unreachable_count": 1,
+        _PASSTHROUGH_RUNTIME_SETTINGS_KEY: {
+            "contract_mode": _STRICT_CONTRACT_MODE_OFF,
+            "density_breaker_enabled": False,
+            "zero_fill_budget_enabled": True,
+            "retry_ladder_enabled": False,  # stall gate is the only waitForAbort site
+            "send_200_no_range_enabled": False,
+            "passthrough_stall_wait_seconds": 120,
+        },
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes={}-{}".format(start, end)
+    )
+
+    def stream_range(active_ctx, s, e, contract_mode=None):
+        del active_ctx, e, contract_mode
+        if s == start:
+            # Established read: real bytes flow, so the patient wait is allowed
+            # to engage (streamed_real_upstream_bytes becomes sticky-True).
+            handler.wfile.write(b"A" * 40)
+            return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 40
+        # Then the region stalls -> forward-stall gate engages and backs off.
+        return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0
+
+    monitor = sys.modules["xbmc"].Monitor.return_value
+    original_wait = monitor.waitForAbort.side_effect
+    # Kodi shutdown arrives during the stall backoff.
+    monitor.waitForAbort.side_effect = lambda timeout=0.0: True
+
+    log_lines = []
+    real_log = sys.modules["xbmc"].log
+    sys.modules["xbmc"].log = lambda msg, level=0: log_lines.append(msg)
+    try:
+        with patch.object(
+            handler, "_stream_upstream_range", side_effect=stream_range
+        ), patch.object(
+            handler, "_select_live_fallback_source", return_value=None
+        ), patch.object(
+            handler, "_find_skip_offset", return_value=1
+        ), patch.object(
+            handler, "_write_zeros"
+        ):
+            handler._serve_proxy(ctx)
+    finally:
+        sys.modules["xbmc"].log = real_log
+        monitor.waitForAbort.side_effect = original_wait
+
+    summary = [line for line in log_lines if "Pass-through summary" in line]
+    assert summary, "expected a pass-through summary log line"
+    assert "reason=client_disconnected" in summary[0]
+    assert "reason=unknown" not in summary[0]
+
+
 def test_maybe_notify_stream_starvation_fires_on_forward_stall_exhaustion():
     """A pure slow-backend give-up — the patient forward-stall wait exhausted
     with NO 5xx outage recorded (download-lag only) — must still tell the user,

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -12137,7 +12137,12 @@ def test_serve_proxy_debounces_recovery_notify_within_one_session():
     finally:
         sys.modules["xbmcaddon"].Addon.return_value = original
 
-    mock_notify.assert_called_once()
+    # The recovery summary stays debounced to a single toast across recoveries;
+    # the separate graceful-starvation guard adds one clear "can't keep up" toast
+    # when the session aborts on backend starvation.
+    notify_msgs = [call.args[1] for call in mock_notify.call_args_list]
+    assert sum("recoveries" in msg for msg in notify_msgs) == 1
+    assert any("keep up" in msg.lower() for msg in notify_msgs)
 
 
 def test_serve_proxy_retries_original_range_before_skip_probe():
@@ -12405,7 +12410,11 @@ def test_serve_proxy_aborts_when_session_zero_fill_ratio_exceeds_cap(mock_xbmc):
         sys.modules["xbmcaddon"].Addon.return_value = original
 
     mock_write_zeros.assert_not_called()
-    mock_notify.assert_called_once()
+    # The recovery summary still fires exactly once; the graceful-starvation
+    # guard adds one clear "can't keep up" toast on this backend-starvation abort.
+    notify_msgs = [call.args[1] for call in mock_notify.call_args_list]
+    assert sum("recoveries" in msg for msg in notify_msgs) == 1
+    assert any("keep up" in msg.lower() for msg in notify_msgs)
     logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
     assert "reason=session_zero_fill_budget_exceeded" in logged
 
@@ -15446,3 +15455,74 @@ def test_storage_to_webdav_path_content_passthrough_unchanged():
         _storage_to_webdav_path("/content/movies/The Matrix 1999")
         == "/content/movies/The Matrix 1999/"
     )
+
+
+def test_maybe_notify_stream_starvation_fires_on_backend_outage():
+    """A pass-through stream that ends starved while the backend was unreachable
+    must fire ONE clear 'can't keep up' notification, not a silent black screen
+    (the live Shawshank incident: client_disconnected, upstream_unreachable=3,
+    only ~140MB of a 57GB file delivered)."""
+    from resources.lib import stream_proxy
+
+    ctx = {"upstream_unreachable_count": 3}
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        fired = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "client_disconnected", 140558304, 57740611174
+        )
+    assert fired is True
+    mock_notify.assert_called_once()
+    assert "keep up" in mock_notify.call_args[0][1].lower()
+
+
+def test_maybe_notify_stream_starvation_fires_on_stall_reason_without_outage():
+    from resources.lib import stream_proxy
+
+    ctx = {"upstream_unreachable_count": 0}
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        fired = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "passthrough_stall", 5000000, 57740611174
+        )
+    assert fired is True
+    mock_notify.assert_called_once()
+
+
+def test_maybe_notify_stream_starvation_silent_on_clean_complete():
+    from resources.lib import stream_proxy
+
+    ctx = {"upstream_unreachable_count": 3}
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        fired = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "complete", 57740611174, 57740611174
+        )
+    assert fired is False
+    mock_notify.assert_not_called()
+
+
+def test_maybe_notify_stream_starvation_silent_on_healthy_user_stop():
+    """A normal stop of a healthy stream (no upstream trouble, not a stall
+    reason) must NOT fire the starvation toast."""
+    from resources.lib import stream_proxy
+
+    ctx = {"upstream_unreachable_count": 0}
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        fired = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "client_disconnected", 5000000, 57740611174
+        )
+    assert fired is False
+    mock_notify.assert_not_called()
+
+
+def test_maybe_notify_stream_starvation_debounced_once_per_session():
+    from resources.lib import stream_proxy
+
+    ctx = {"upstream_unreachable_count": 3}
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        first = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "fallback_exhausted", 1000, 57740611174
+        )
+        second = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "fallback_exhausted", 1000, 57740611174
+        )
+    assert first is True
+    assert second is False
+    mock_notify.assert_called_once()

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -15735,3 +15735,89 @@ def test_serve_proxy_pre_bytes_stall_does_not_engage_long_wait():
     assert wait_calls["n"] == 0
     mock_zeros.assert_not_called()
     assert _collect_written(handler) == b""
+
+
+def test_serve_proxy_forward_stall_gives_up_after_budget_exhausted():
+    """A TRULY-stuck established forward stream (no progress, backend never
+    recovers) must EXHAUST the patient-wait budget and then give up via the
+    existing path — it must not wait forever. Drives monotonic past the budget
+    so the gate stops waiting after the first backoff and falls through to the
+    recovery_exhausted close (skip-probe returns None)."""
+    import sys
+
+    from resources.lib.stream_proxy import (
+        _PASSTHROUGH_RUNTIME_SETTINGS_KEY,
+        _STRICT_CONTRACT_MODE_OFF,
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+    )
+
+    start, end = 1000, 99_999  # mid-file, established (start>0)
+    ctx = {
+        "remote_url": "http://webdav/remux.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 100_000,
+        "upstream_down_notified": True,
+        "upstream_unreachable_count": 1,
+        _PASSTHROUGH_RUNTIME_SETTINGS_KEY: {
+            "contract_mode": _STRICT_CONTRACT_MODE_OFF,
+            "density_breaker_enabled": False,
+            "zero_fill_budget_enabled": True,
+            "retry_ladder_enabled": False,
+            "send_200_no_range_enabled": False,
+            "passthrough_stall_wait_seconds": 120,
+        },
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes={}-{}".format(start, end)
+    )
+
+    def stream_range(active_ctx, s, e, contract_mode=None):
+        del active_ctx, contract_mode
+        if s == start:
+            # Established: stream 40 real bytes, then the region is stuck at the
+            # high-water and never advances.
+            handler.wfile.write(b"A" * 40)
+            return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 40
+        return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0
+
+    # monotonic jumps 1000s per call, so the second gate pass is far past the
+    # 120s budget regardless of incidental monotonic calls -> budget exhausts.
+    mono = {"t": 0}
+
+    def fake_monotonic():
+        value = mono["t"]
+        mono["t"] += 1000
+        return value
+
+    wait_calls = {"n": 0}
+
+    def _counting_wait(timeout=0.0):
+        del timeout
+        wait_calls["n"] += 1
+        return False  # never abort, never really sleep
+
+    monitor = sys.modules["xbmc"].Monitor.return_value
+    original_wait = monitor.waitForAbort.side_effect
+    monitor.waitForAbort.side_effect = _counting_wait
+    try:
+        with patch.object(
+            handler, "_stream_upstream_range", side_effect=stream_range
+        ) as mock_stream, patch.object(
+            handler, "_select_live_fallback_source", return_value=None
+        ), patch.object(
+            handler, "_find_skip_offset", return_value=None
+        ), patch.object(
+            handler, "_write_zeros"
+        ) as mock_zeros, patch(
+            "resources.lib.stream_proxy.time.monotonic", side_effect=fake_monotonic
+        ):
+            handler._serve_proxy(ctx)
+    finally:
+        monitor.waitForAbort.side_effect = original_wait
+
+    # Terminated (no infinite wait): one stalled read, one backoff, then the
+    # next pass saw the budget exhausted and gave up via the existing path.
+    assert mock_stream.call_count == 2
+    assert wait_calls["n"] == 1
+    mock_zeros.assert_not_called()  # skip-probe returned None -> recovery_exhausted

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -1141,6 +1141,7 @@ def test_prepare_stream_uses_settings_snapshot_without_kodi_setting_reads():
         "zero_fill_budget_enabled": True,
         "retry_ladder_enabled": True,
         "send_200_no_range_enabled": False,
+        "passthrough_stall_wait_seconds": 120,
     }
     assert "_passthrough_runtime_settings_thread" not in ctx
 
@@ -11962,6 +11963,9 @@ def test_serve_proxy_zero_fills_on_upstream_failure():
     mock_addon = MagicMock()
     mock_addon.getSetting.side_effect = lambda key: {
         "retry_ladder_enabled": "false",
+        # Disable the patient forward-stall wait so this test stays targeted at
+        # the zero-fill recovery branch (the wait is covered separately).
+        "passthrough_stall_wait": "0",
     }.get(key, "")
     original = sys.modules["xbmcaddon"].Addon.return_value
     sys.modules["xbmcaddon"].Addon.return_value = mock_addon
@@ -12008,6 +12012,7 @@ def test_serve_proxy_notifies_first_recovery_with_bytes_and_count():
         "density_breaker_enabled": "false",
         "zero_fill_budget_enabled": "true",
         "retry_ladder_enabled": "false",
+        "passthrough_stall_wait": "0",
     }.get(key, "")
     original = sys.modules["xbmcaddon"].Addon.return_value
     sys.modules["xbmcaddon"].Addon.return_value = mock_addon
@@ -12070,6 +12075,7 @@ def test_serve_proxy_retries_probes_when_upstream_briefly_down():
     mock_addon.getSetting.side_effect = lambda key: {
         "retry_ladder_enabled": "false",
         "zero_fill_budget_enabled": "false",
+        "passthrough_stall_wait": "0",
     }.get(key, "")
     original = sys.modules["xbmcaddon"].Addon.return_value
     sys.modules["xbmcaddon"].Addon.return_value = mock_addon
@@ -12216,6 +12222,7 @@ def test_serve_proxy_falls_back_to_skip_probe_after_retry_ladder_exhausted():
         "density_breaker_enabled": "false",
         "zero_fill_budget_enabled": "true",
         "retry_ladder_enabled": "true",
+        "passthrough_stall_wait": "0",
     }.get(key, "")
     original = sys.modules["xbmcaddon"].Addon.return_value
     sys.modules["xbmcaddon"].Addon.return_value = mock_addon
@@ -12346,6 +12353,7 @@ def test_serve_proxy_logs_terminal_summary_on_recovery_exhausted(mock_xbmc):
     mock_addon = MagicMock()
     mock_addon.getSetting.side_effect = lambda key: {
         "retry_ladder_enabled": "false",
+        "passthrough_stall_wait": "0",
     }.get(key, "")
     original = sys.modules["xbmcaddon"].Addon.return_value
     sys.modules["xbmcaddon"].Addon.return_value = mock_addon
@@ -15564,3 +15572,166 @@ def test_maybe_notify_stream_starvation_debounced_once_per_session():
     assert first is True
     assert second is False
     mock_notify.assert_called_once()
+
+
+def test_serve_proxy_established_forward_stall_waits_then_completes_on_recovery():
+    """An ESTABLISHED forward stream (real bytes already streamed) that hits a
+    transient backend outage with the session circuit breaker tripped must KEEP
+    the client connection open and keep retrying (with abortable backoff) until
+    the backend recovers — instead of giving up in milliseconds and closing (the
+    live 4K-REMUX mid-stream black screen). Recovery then completes the range;
+    no zero-fill, no skip-probe."""
+    import sys
+
+    from resources.lib.stream_proxy import (
+        _PASSTHROUGH_RUNTIME_SETTINGS_KEY,
+        _STRICT_CONTRACT_MODE_OFF,
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+    )
+
+    start, end = 1000, 1099  # mid-file (start>0): not the byte-0 first open
+    ctx = {
+        "remote_url": "http://webdav/remux.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 100_000,
+        # Breaker already tripped by an earlier 5xx — the exact live condition
+        # that made the loop give up in ~ms.
+        "upstream_down_notified": True,
+        "upstream_unreachable_count": 1,
+        _PASSTHROUGH_RUNTIME_SETTINGS_KEY: {
+            "contract_mode": _STRICT_CONTRACT_MODE_OFF,
+            "density_breaker_enabled": False,
+            "zero_fill_budget_enabled": True,
+            "retry_ladder_enabled": False,  # isolate the backoff to the new gate
+            "send_200_no_range_enabled": False,
+            "passthrough_stall_wait_seconds": 120,
+        },
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes={}-{}".format(start, end)
+    )
+
+    def stream_range(active_ctx, s, e, contract_mode=None):
+        del active_ctx, contract_mode
+        remaining = e - s + 1
+        if s == 1000:
+            # Established read: streams 40 real bytes then hits the download
+            # high-water (still-downloading) -> AWAITING with written>0.
+            handler.wfile.write(b"A" * 40)
+            return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 40
+        if s == 1040 and stream_range.stalls < 2:
+            stream_range.stalls += 1
+            return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0
+        handler.wfile.write(b"B" * remaining)
+        return _UPSTREAM_RANGE_OK, remaining
+
+    stream_range.stalls = 0
+
+    wait_calls = {"n": 0}
+
+    def _counting_wait(timeout=0.0):
+        del timeout
+        wait_calls["n"] += 1
+        return False  # never abort, never really sleep
+
+    monitor = sys.modules["xbmc"].Monitor.return_value
+    original_wait = monitor.waitForAbort.side_effect
+    monitor.waitForAbort.side_effect = _counting_wait
+    try:
+        with patch.object(
+            handler, "_stream_upstream_range", side_effect=stream_range
+        ) as mock_stream, patch.object(
+            handler, "_select_live_fallback_source", return_value=None
+        ), patch.object(
+            handler, "_find_skip_offset", return_value=1
+        ) as mock_skip, patch.object(
+            handler, "_write_zeros"
+        ) as mock_zeros:
+            handler._serve_proxy(ctx)
+    finally:
+        monitor.waitForAbort.side_effect = original_wait
+
+    # Kept retrying across the outage rather than closing after the stall.
+    assert mock_stream.call_count >= 4
+    # The forward-stall gate backed off (waited) at least once; with the ladder
+    # disabled, no other loop site calls waitForAbort.
+    assert wait_calls["n"] >= 1
+    # It WAITED for the primary — never zero-filled / skip-probed past the gap.
+    mock_skip.assert_not_called()
+    mock_zeros.assert_not_called()
+    # On recovery the full requested range was delivered (40 + 60 bytes).
+    assert _collect_written(handler) == b"A" * 40 + b"B" * 60
+
+
+def test_serve_proxy_pre_bytes_stall_does_not_engage_long_wait():
+    """A stall BEFORE any real bytes streamed (byte-0 first read / fresh seek)
+    must keep the issue-#214 fast-fail: the patient wait must NOT engage, so a
+    genuinely-dead open closes promptly instead of holding Kodi's initial open."""
+    import sys
+
+    from resources.lib.stream_proxy import (
+        _PASSTHROUGH_RUNTIME_SETTINGS_KEY,
+        _STRICT_CONTRACT_MODE_OFF,
+        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+    )
+
+    content_length = 100_000
+    ctx = {
+        "remote_url": "http://webdav/remux.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+        "upstream_down_notified": True,
+        "upstream_unreachable_count": 1,
+        _PASSTHROUGH_RUNTIME_SETTINGS_KEY: {
+            "contract_mode": _STRICT_CONTRACT_MODE_OFF,
+            "density_breaker_enabled": False,
+            "zero_fill_budget_enabled": True,
+            "retry_ladder_enabled": False,
+            "send_200_no_range_enabled": False,
+            "passthrough_stall_wait_seconds": 120,
+        },
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes=0-{}".format(content_length - 1)
+    )
+
+    wait_calls = {"n": 0}
+
+    def _counting_wait(timeout=0.0):
+        del timeout
+        wait_calls["n"] += 1
+        return False
+
+    monitor = sys.modules["xbmc"].Monitor.return_value
+    original_wait = monitor.waitForAbort.side_effect
+    monitor.waitForAbort.side_effect = _counting_wait
+    try:
+        with patch.object(
+            handler,
+            "_stream_upstream_range",
+            return_value=(_UPSTREAM_RANGE_UPSTREAM_ERROR, 0),
+        ) as mock_stream, patch.object(
+            handler, "_pop_cached_fallback_range", return_value=b""
+        ), patch.object(
+            handler, "_wait_for_initial_range_prefetch", return_value=None
+        ), patch.object(
+            handler, "_select_live_fallback_source", return_value=None
+        ), patch.object(
+            handler, "_find_skip_offset", return_value=None
+        ), patch.object(
+            handler, "_write_zeros"
+        ) as mock_zeros:
+            handler._serve_proxy(ctx)
+    finally:
+        monitor.waitForAbort.side_effect = original_wait
+
+    # Fast-fail preserved: did not spin extra reads on a dead pre-bytes open...
+    assert mock_stream.call_count == 1
+    # ...and the patient gate never backed off (no patience before any bytes).
+    assert wait_calls["n"] == 0
+    mock_zeros.assert_not_called()
+    assert _collect_written(handler) == b""

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -8043,41 +8043,51 @@ def test_serve_proxy_notifies_fallback_failure_on_terminal_client_error():
 
 
 def test_serve_proxy_suppresses_pending_failure_toast_on_client_disconnect():
-    """A client disconnect right after a fallback switch — before the new
-    candidate has delivered its first byte — is NOT a candidate failure. For the
-    client write to abort (BrokenPipeError), the candidate had to be serving
-    bytes; the CLIENT went away. The finally block must suppress the
-    'candidate #N was a failure' toast for a still-pending candidate when the
-    stream ends benignly (terminal_reason=client_disconnected) rather than
-    blaming the candidate for a demuxer probe/seek or a user stop.
+    """A client disconnect AFTER a candidate has already delivered real bytes is
+    NOT a candidate failure: the candidate was serving; the CLIENT went away
+    (demuxer probe/seek or a user stop). The candidate cleared itself with a
+    success toast on delivery, so the finally block must not emit a spurious
+    'candidate #N was a failure'.
+
+    NOTE: an EARLIER (F5) version of this test fed a BrokenPipeError on the
+    candidate's FIRST read and asserted suppression on the false premise that
+    "a client abort implies the candidate was serving bytes". The F11/F12 review
+    corrected that premise — a disconnect BEFORE any byte means the candidate
+    delivered nothing and IS a failure (see
+    test_serve_proxy_fallback_zero_bytes_then_disconnect_toasts_failure). This
+    test now exercises the genuinely-benign case: delivered THEN disconnected.
     """
-    from resources.lib.stream_proxy import _UPSTREAM_RANGE_UPSTREAM_ERROR
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+    )
 
     ctx = {
         "remote_url": "http://webdav/primary.mkv",
         "auth_header": None,
         "content_type": "video/x-matroska",
-        "content_length": 10,
+        "content_length": 20,
         "fallback_sources": [
             {
                 "nzo_id": "nzo2",
                 "stream_url": "http://webdav/fallback1.mkv",
                 "stream_headers": {"Authorization": "Basic f1"},
-                "content_length": 10,
+                "content_length": 20,
                 "validated": True,
                 "failed": False,
             }
         ],
         "fallback_switch_count": 0,
     }
-    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-19")
 
     with patch.object(
         handler,
         "_stream_upstream_range",
         side_effect=[
             (_UPSTREAM_RANGE_UPSTREAM_ERROR, 0),  # primary -> switch to #1
-            BrokenPipeError(),  # client write aborts before #1 delivers a byte
+            (_UPSTREAM_RANGE_OK, 10),  # #1 delivers real bytes (success)
+            BrokenPipeError(),  # client write aborts AFTER #1 delivered
         ],
     ), patch.object(
         handler,
@@ -8090,7 +8100,7 @@ def test_serve_proxy_suppresses_pending_failure_toast_on_client_disconnect():
 
     msgs = [call.args[1].lower() for call in mock_notify.call_args_list]
     assert not any("was a failure" in m for m in msgs), msgs
-    assert not any("successful" in m for m in msgs), msgs
+    assert any("candidate #1" in m and "successful" in m for m in msgs), msgs
 
 
 def test_serve_proxy_failure_toast_does_not_delay_next_candidate_cutover():
@@ -8280,7 +8290,14 @@ def test_select_live_fallback_rejects_same_length_different_fingerprint():
 
 
 def test_live_fallback_selection_probes_failed_range_before_full_fingerprint():
-    """Unreadable failed ranges should reject before expensive fingerprints."""
+    """Unreadable failed ranges reject before expensive fingerprints.
+
+    F8-dropout: an empty current-range digest is a TRANSIENT miss (the peer
+    just hasn't downloaded this offset yet), so the source is NOT selected
+    this round but is also NOT permanently failed — it stays eligible for the
+    next cutover with a bumped transient_miss_count. The probe-before-
+    fingerprint optimisation (one probe, no fingerprint sweep) is preserved.
+    """
     handler = _make_handler()
     content_length = 10000000
     failed_byte = 1234567
@@ -8315,7 +8332,9 @@ def test_live_fallback_selection_probes_failed_range_before_full_fingerprint():
         source = handler._select_live_fallback_source(ctx, failed_byte, range_end)
 
     assert source is None
-    assert ctx["fallback_sources"][0]["failed"] is True
+    # Transient miss: stays eligible (not permanently failed), counter bumped.
+    assert ctx["fallback_sources"][0].get("failed") is not True
+    assert ctx["fallback_sources"][0].get("transient_miss_count") == 1
     assert mock_digest.call_count == 1
     assert mock_digest.call_args[0][:4] == (
         "http://webdav/content/fallback.mkv",
@@ -8795,7 +8814,12 @@ def test_live_fallback_selection_keeps_primary_cache_for_later_attempts():
 
 
 def test_live_fallback_selection_skips_primary_read_for_unreadable_fallback_sample():
-    """An unreadable fallback fingerprint sample should reject before primary I/O."""
+    """An unreadable fallback fingerprint sample rejects before primary I/O.
+
+    F8-dropout: a missing fallback digest is INCONCLUSIVE (probe couldn't be
+    completed) — the source is not selected but is not permanently failed,
+    and the primary range is never read (the optimisation is preserved).
+    """
     from resources.lib.fallback_streams import fingerprint_ranges
 
     handler = _make_handler()
@@ -8835,7 +8859,9 @@ def test_live_fallback_selection_skips_primary_read_for_unreadable_fallback_samp
         source = handler._select_live_fallback_source(ctx, failed_byte, range_end)
 
     assert source is None
-    assert ctx["fallback_sources"][0]["failed"] is True
+    # Missing fallback digest is INCONCLUSIVE: eligible, not failed.
+    assert ctx["fallback_sources"][0].get("failed") is not True
+    assert ctx["fallback_sources"][0].get("transient_miss_count") == 1
     assert calls
     assert all(call[0] == "http://webdav/content/fallback.mkv" for call in calls)
 
@@ -11119,7 +11145,11 @@ def test_fallback_range_probe_failure_reenters_retry_and_zero_fill_recovery():
         handler._serve_proxy(ctx)
 
     assert ctx["remote_url"] == "http://webdav/primary.mkv"
-    assert ctx["fallback_sources"][0]["failed"] is True
+    # F8-dropout: a probe 5xx/timeout (OSError) is a TRANSIENT miss, so the
+    # fallback is NOT permanently failed on the first hiccup — it stays
+    # eligible (under the transient-miss bound) to be reconsidered later.
+    assert ctx["fallback_sources"][0].get("failed") is not True
+    assert ctx["fallback_sources"][0].get("transient_miss_count", 0) >= 1
     assert ctx["fallback_switch_count"] == 0
     # The fix: no validated fallback now re-enters the retry ladder and reaches
     # the skip-probe, rather than hard-closing before either.
@@ -13895,3 +13925,1093 @@ def test_prepare_stream_via_service_does_not_retry_http_error():
             prepare_stream_via_service(38699, "http://nzbdav/m.mkv")
 
     assert mock_urlopen.call_count == 1, "HTTPError must not be retried"
+
+
+def sys_modules_monitor():
+    import sys
+
+    return sys.modules["xbmc"].Monitor.return_value
+
+
+# ---------------------------------------------------------------------------
+# F5 — pending fallback-candidate failure must not be silently swallowed when
+# terminal_reason was never explicitly set (default sentinel, not "complete").
+# ---------------------------------------------------------------------------
+
+
+def test_serve_proxy_default_terminal_reason_is_unknown_not_complete():
+    """An exit that never sets terminal_reason must surface as a genuine
+    failure (toast the pending candidate), NOT be silently treated as a
+    benign "complete". Force an unexpected exception out of the streaming
+    loop after a fallback switch so terminal_reason stays at its default; the
+    finally block must report the pending candidate as a failure.
+    """
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_UPSTREAM_ERROR
+
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 10,
+        "fallback_sources": [
+            {
+                "nzo_id": "nzo2",
+                "stream_url": "http://webdav/fallback1.mkv",
+                "stream_headers": {"Authorization": "Basic f1"},
+                "content_length": 10,
+                "validated": True,
+                "failed": False,
+            }
+        ],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+
+    # primary errors -> switch to candidate #1; the candidate's first read
+    # raises a non-socket exception that is NOT caught by the
+    # BrokenPipe/timeout handler, so it propagates through finally with
+    # terminal_reason still at its default sentinel.
+    with patch.object(
+        handler,
+        "_stream_upstream_range",
+        side_effect=[
+            (_UPSTREAM_RANGE_UPSTREAM_ERROR, 0),
+            RuntimeError("unexpected"),
+        ],
+    ), patch.object(
+        handler,
+        "_select_live_fallback_source",
+        return_value=ctx["fallback_sources"][0],
+    ), patch(
+        "resources.lib.stream_proxy._notify"
+    ) as mock_notify:
+        with pytest.raises(RuntimeError):
+            handler._serve_proxy(ctx)
+
+    msgs = [call.args[1].lower() for call in mock_notify.call_args_list]
+    assert any("was a failure" in m for m in msgs), msgs
+
+
+def test_serve_proxy_complete_terminal_reason_set_explicitly_no_toast():
+    """The genuine success path must set terminal_reason="complete" explicitly
+    so a still-pending candidate that already delivered is NOT toasted as a
+    failure. Happy path: primary delivers everything, no candidate switch, no
+    fallback toast at all.
+    """
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 2048,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-2047")
+
+    payload = b"A" * 2048
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        return_value=_mock_urlopen_response([payload]),
+    ), patch("resources.lib.stream_proxy._notify") as mock_notify:
+        handler._serve_proxy(ctx)
+
+    msgs = [call.args[1].lower() for call in mock_notify.call_args_list]
+    assert not any("was a failure" in m for m in msgs), msgs
+
+
+# ---------------------------------------------------------------------------
+# F11 — a candidate that switched in but delivered ZERO bytes must be reported
+# as a FAILURE even when the stream ends on terminal_reason="complete" (a full
+# zero-fill to EOF). An explicit ``candidate_delivered`` flag — set only where
+# real bytes were written — drives the finally-block failure toast.
+# F12 (4decdd4) — but a benign client disconnect
+# (terminal_reason="client_disconnected") must NOT blame a still-pending
+# candidate: a BrokenPipeError can only raise at the client body write AFTER a
+# non-empty upstream read, so the candidate WAS serving bytes and the CLIENT
+# went away. That genuinely-benign exit is exempted from the failure toast.
+# ---------------------------------------------------------------------------
+
+
+def test_serve_proxy_fallback_delivered_then_complete_toasts_success_once():
+    """Case (a): a candidate that delivered real bytes and then the loop
+    completes must toast success exactly once and never a failure."""
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+    )
+
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 10,
+        "fallback_sources": [
+            {
+                "nzo_id": "nzo2",
+                "stream_url": "http://webdav/fallback1.mkv",
+                "stream_headers": {"Authorization": "Basic f1"},
+                "content_length": 10,
+                "validated": True,
+                "failed": False,
+            }
+        ],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+
+    with patch.object(
+        handler,
+        "_stream_upstream_range",
+        side_effect=[
+            (_UPSTREAM_RANGE_UPSTREAM_ERROR, 0),  # primary: 0 bytes -> switch
+            (_UPSTREAM_RANGE_OK, 10),  # candidate #1: delivers, completes
+        ],
+    ), patch.object(
+        handler,
+        "_select_live_fallback_source",
+        return_value=ctx["fallback_sources"][0],
+    ), patch(
+        "resources.lib.stream_proxy._notify"
+    ) as mock_notify:
+        handler._serve_proxy(ctx)
+
+    msgs = [call.args[1].lower() for call in mock_notify.call_args_list]
+    success = [m for m in msgs if "candidate #1" in m and "successful" in m]
+    assert len(success) == 1, msgs
+    assert not any("was a failure" in m for m in msgs), msgs
+
+
+def test_serve_proxy_fallback_zero_bytes_then_complete_toasts_failure():
+    """Case (b) — the F11 hole: a candidate switched in, delivered ZERO bytes,
+    and the loop reached EOF via zero-fill (terminal_reason="complete"). The
+    benign terminal reason must NOT swallow the failure: the candidate never
+    delivered, so it is reported as a failure."""
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE
+
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 10,
+        "fallback_sources": [
+            {
+                "nzo_id": "nzo2",
+                "stream_url": "http://webdav/fallback1.mkv",
+                "stream_headers": {"Authorization": "Basic f1"},
+                "content_length": 10,
+                "validated": True,
+                "failed": False,
+            }
+        ],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+
+    # Budget/density guards OFF so a full zero-fill to EOF exits the loop on the
+    # BENIGN reason="complete" path (current > end) rather than tripping one of
+    # the non-benign budget breakers — that is precisely the F11 hole where a
+    # never-delivering candidate would otherwise be swallowed.
+    runtime_settings = {
+        "contract_mode": "lenient",
+        "density_breaker_enabled": False,
+        "zero_fill_budget_enabled": False,
+        "retry_ladder_enabled": True,
+    }
+
+    with patch.object(
+        handler,
+        "_stream_upstream_range",
+        side_effect=[
+            (_UPSTREAM_RANGE_SHORT_READ_RECOVERABLE, 0),  # primary: 0 -> switch
+            (_UPSTREAM_RANGE_SHORT_READ_RECOVERABLE, 0),  # candidate #1: 0 bytes
+        ],
+    ), patch.object(
+        handler,
+        "_select_live_fallback_source",
+        # switch to #1 first, then no further candidate so we fall through to
+        # the skip-probe / zero-fill recovery on the dead candidate.
+        side_effect=[ctx["fallback_sources"][0], None],
+    ), patch.object(
+        handler,
+        "_retry_original_range",
+        return_value=(_UPSTREAM_RANGE_SHORT_READ_RECOVERABLE, 0, 0),
+    ), patch.object(
+        # Zero-fill the whole requested range to EOF -> loop exits current>end
+        # -> terminal_reason="complete" (benign), while no real byte was served.
+        handler,
+        "_find_skip_offset",
+        return_value=10,
+    ), patch(
+        "resources.lib.stream_proxy._passthrough_runtime_settings",
+        return_value=runtime_settings,
+    ), patch(
+        "resources.lib.stream_proxy._notify"
+    ) as mock_notify:
+        handler._serve_proxy(ctx)
+
+    msgs = [call.args[1].lower() for call in mock_notify.call_args_list]
+    assert any("candidate #1" in m and "was a failure" in m for m in msgs), msgs
+    assert not any("successful" in m for m in msgs), msgs
+
+
+def test_serve_proxy_fallback_zero_bytes_then_disconnect_toasts_failure():
+    """Case (c) — 4decdd4's invariant: a client disconnect right after a
+    fallback switch (terminal_reason="client_disconnected") must NOT toast the
+    still-pending candidate as a failure. A BrokenPipeError yielding
+    terminal_reason="client_disconnected" can only originate at the CLIENT body
+    write ``self.wfile.write(chunk)`` — reached only AFTER ``resp.read()``
+    returned a non-empty chunk. So the candidate's upstream WAS serving bytes
+    and the CLIENT went away (a Kodi demuxer probe/seek abandoning the range, or
+    a user stop). ``candidate_delivered`` stays False because the BrokenPipeError
+    raises before ``_stream_upstream_range`` returns, so without the
+    client_disconnect exemption a live/working candidate would be falsely
+    toasted as failed — a regression of 4decdd4's deliberate suppression.
+    """
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_UPSTREAM_ERROR
+
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 10,
+        "fallback_sources": [
+            {
+                "nzo_id": "nzo2",
+                "stream_url": "http://webdav/fallback1.mkv",
+                "stream_headers": {"Authorization": "Basic f1"},
+                "content_length": 10,
+                "validated": True,
+                "failed": False,
+            }
+        ],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+
+    with patch.object(
+        handler,
+        "_stream_upstream_range",
+        side_effect=[
+            (_UPSTREAM_RANGE_UPSTREAM_ERROR, 0),  # primary: 0 bytes -> switch
+            # candidate #1's first read: the candidate WAS serving bytes (the
+            # BrokenPipeError can only raise at the client body write, after a
+            # non-empty read) and the CLIENT went away before the read returned.
+            BrokenPipeError("client gone"),
+        ],
+    ), patch.object(
+        handler,
+        "_select_live_fallback_source",
+        return_value=ctx["fallback_sources"][0],
+    ), patch(
+        "resources.lib.stream_proxy._notify"
+    ) as mock_notify:
+        handler._serve_proxy(ctx)
+
+    msgs = [call.args[1].lower() for call in mock_notify.call_args_list]
+    # 4decdd4: a benign client disconnect must NOT blame the candidate.
+    assert not any("was a failure" in m for m in msgs), msgs
+    assert not any("successful" in m for m in msgs), msgs
+
+
+def test_serve_proxy_no_fallback_pending_emits_no_fallback_toast():
+    """Case (d): a plain stream that completes with no fallback ever pending
+    emits no fallback success/failure toast at all."""
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 2048,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-2047")
+
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        return_value=_mock_urlopen_response([b"A" * 2048]),
+    ), patch("resources.lib.stream_proxy._notify") as mock_notify:
+        handler._serve_proxy(ctx)
+
+    msgs = [call.args[1].lower() for call in mock_notify.call_args_list]
+    assert not any("candidate #" in m for m in msgs), msgs
+
+
+def test_serve_proxy_fallback_delivered_then_disconnect_toasts_success_only():
+    """Case (e): a candidate that delivered real bytes and was then cut by a
+    client disconnect must toast success only (its delivery already cleared the
+    pending state) — never a spurious failure."""
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+    )
+
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 20,
+        "fallback_sources": [
+            {
+                "nzo_id": "nzo2",
+                "stream_url": "http://webdav/fallback1.mkv",
+                "stream_headers": {"Authorization": "Basic f1"},
+                "content_length": 20,
+                "validated": True,
+                "failed": False,
+            }
+        ],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-19")
+
+    with patch.object(
+        handler,
+        "_stream_upstream_range",
+        side_effect=[
+            (_UPSTREAM_RANGE_UPSTREAM_ERROR, 0),  # primary: 0 bytes -> switch
+            (_UPSTREAM_RANGE_OK, 10),  # candidate #1: delivers real bytes
+            BrokenPipeError("client gone"),  # then client disconnects
+        ],
+    ), patch.object(
+        handler,
+        "_select_live_fallback_source",
+        return_value=ctx["fallback_sources"][0],
+    ), patch(
+        "resources.lib.stream_proxy._notify"
+    ) as mock_notify:
+        handler._serve_proxy(ctx)
+
+    msgs = [call.args[1].lower() for call in mock_notify.call_args_list]
+    success = [m for m in msgs if "candidate #1" in m and "successful" in m]
+    assert len(success) == 1, msgs
+    assert not any("was a failure" in m for m in msgs), msgs
+
+
+@patch("resources.lib.stream_proxy.xbmc")
+def test_serve_proxy_logs_complete_reason_on_natural_loop_exit(mock_xbmc):
+    """The pass-through summary on a fully-streamed range must read
+    reason=complete (the success sentinel), not the default sentinel."""
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 2048,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-2047")
+
+    with patch(
+        "resources.lib.stream_proxy.urlopen",
+        return_value=_mock_urlopen_response([b"A" * 2048]),
+    ):
+        handler._serve_proxy(ctx)
+
+    logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
+    assert "reason=complete" in logged
+    assert "reason=unknown" not in logged
+
+
+# ---------------------------------------------------------------------------
+# F4 — exhausted fallback chain must hit a BOUNDED stop (fallback_exhausted)
+# instead of spinning the retry ladder forever, while a TRANSIENT failure
+# still re-enters the ladder and recovers (preserving e3a74a1).
+# ---------------------------------------------------------------------------
+
+
+@patch("resources.lib.stream_proxy.xbmc")
+def test_serve_proxy_transient_trickle_still_recovers_via_ladder(mock_xbmc):
+    """e3a74a1 preserved: a single transient trickle with no validated
+    fallback re-enters the retry ladder and recovers — it must NOT trip the
+    bounded exhaustion stop on the first miss.
+    """
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_OK
+
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 4096,
+        "fallback_sources": [{"nzo_id": "alt", "stream_url": "http://host/alt.mkv"}],
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-4095")
+
+    chunks = [b"A" * 1024, b"B" * 1024]
+    monotonic_returns = iter([100.0, 105.0, 125.0] + [125.0] * 30)
+
+    def _fake_retry(active_ctx, start, end, contract_mode, first_byte=False):
+        remainder = b"C" * (end - start + 1)
+        handler.wfile.write(remainder)
+        return _UPSTREAM_RANGE_OK, len(remainder), end + 1
+
+    with patch(
+        "resources.lib.stream_proxy.time.monotonic",
+        side_effect=lambda: next(monotonic_returns),
+    ), patch(
+        "resources.lib.stream_proxy.urlopen",
+        return_value=_mock_urlopen_response(chunks),
+    ), patch.object(
+        handler, "_select_live_fallback_source", return_value=None
+    ), patch.object(
+        handler, "_retry_original_range", side_effect=_fake_retry
+    ) as mock_retry:
+        handler._serve_proxy(ctx)
+
+    mock_retry.assert_called()
+    assert _collect_written(handler) == b"A" * 1024 + b"B" * 1024 + b"C" * 2048
+    logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
+    assert "reason=fallback_pending_retry_primary" in logged
+    assert "reason=fallback_exhausted" not in logged
+
+
+@patch("resources.lib.stream_proxy.xbmc")
+def test_serve_proxy_bounded_exhaustion_stops_instead_of_looping(mock_xbmc):
+    """When fallbacks are attached but never validate and the primary never
+    recovers, the retry-ladder re-entry must be BOUNDED: after the cap of
+    fruitless cutover attempts it terminates with reason=fallback_exhausted
+    rather than zero-filling the whole file / looping until the client quits.
+    """
+    from resources.lib.stream_proxy import _UPSTREAM_RANGE_UPSTREAM_ERROR
+
+    content_length = 1_000_000
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+        "fallback_sources": [{"nzo_id": "alt", "stream_url": "http://host/alt.mkv"}],
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes=0-{}".format(content_length - 1)
+    )
+
+    # Every primary read errors with zero bytes and the retry ladder never makes
+    # progress; the skip-probe always offers a small skip, so without a bound the
+    # loop would zero-fill the ENTIRE file (garbage playback) or spin. The F4
+    # bound must stop the fruitless cutover re-entry early with
+    # fallback_exhausted instead.
+    probe_calls = {"n": 0}
+
+    def _stream(active_ctx, start, end, contract_mode=None):
+        return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0
+
+    def _fake_retry(active_ctx, start, end, contract_mode, first_byte=False):
+        return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0, start
+
+    def _skip(active_ctx, current, end):
+        probe_calls["n"] += 1
+        assert probe_calls["n"] < 10_000, "F4 bound never tripped"
+        return 4096
+
+    with patch.object(
+        handler, "_stream_upstream_range", side_effect=_stream
+    ), patch.object(
+        handler, "_select_live_fallback_source", return_value=None
+    ), patch.object(
+        handler, "_retry_original_range", side_effect=_fake_retry
+    ), patch.object(
+        handler, "_find_skip_offset", side_effect=_skip
+    ):
+        handler._serve_proxy(ctx)
+
+    logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
+    assert "reason=fallback_exhausted" in logged
+    written = _collect_written(handler)
+    # Stopped well before zero-filling the entire file.
+    assert len(written) < content_length
+
+
+@patch("resources.lib.stream_proxy.xbmc")
+def test_serve_proxy_cutover_resets_fallthrough_exhaustion_counter(mock_xbmc):
+    """SM-1: the F4 bounded-exhaustion counters
+    (fallback_pending_fallthroughs / last_fallthrough_streamed) must be RESET on
+    a successful cutover, exactly where awaiting_download_no_progress is. After
+    the primary drives the fall-through count up to ~2 (fruitless re-entries
+    with no validated source), a successful live cutover that delivers real
+    bytes resets the counter. A LATER single fruitless read must therefore NOT
+    immediately trip reason=fallback_exhausted off the stale primary-driven
+    count — otherwise a freshly-switched-but-dead source would be condemned
+    after roughly one read instead of getting the full bounded budget.
+    """
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+    )
+
+    content_length = 100
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+        "fallback_sources": [
+            {
+                "nzo_id": "alt",
+                "stream_url": "http://host/alt.mkv",
+                "content_length": content_length,
+                "validated": True,
+                "failed": False,
+            }
+        ],
+        "fallback_active_index": -1,
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes=0-{}".format(content_length - 1)
+    )
+
+    # The primary errors with no validated source: each such iteration falls
+    # through, the retry ladder makes no progress, then a small zero-fill
+    # (skip=10) advances one step. Zero-fill is black frames, not recovery, so it
+    # does NOT reset the F4 count, which climbs by one per fall-through toward the
+    # cap _FALLBACK_PENDING_FALLTHROUGH_MAX (3). State machine:
+    #   reads 1,2 -> no source -> fall-through (count 1, 2)
+    #   read  3   -> validated source -> CUTOVER: must RESET the counters, and
+    #                from now on the (now-active) source DELIVERS real bytes.
+    # WITHOUT the reset the stale count is 2 at cutover; the activated source
+    # delivering bytes would still be fine here, but had it needed one more
+    # fruitless read the stale 2 would trip the cap after a single miss. To prove
+    # the reset, the activated source first MISSES once more (a fresh fall-through
+    # — count 1 WITH reset, but the fatal 3 WITHOUT it) and only THEN delivers.
+    state = {"cut": False, "post_cut_misses": 0}
+
+    def _stream(active_ctx, start, end, contract_mode=None):
+        if state["cut"]:
+            # The cutover source misses once (fresh fall-through), then delivers.
+            if state["post_cut_misses"] < 1:
+                state["post_cut_misses"] += 1
+                return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0
+            remaining = end - start + 1
+            handler.wfile.write(b"\x00" * remaining)
+            return _UPSTREAM_RANGE_OK, remaining
+        return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0
+
+    selects = iter([None, None, ctx["fallback_sources"][0]])
+
+    def _select(active_ctx, current, end):
+        try:
+            value = next(selects)
+        except StopIteration:
+            return None
+        if value:
+            state["cut"] = True
+        return value
+
+    def _fake_retry(active_ctx, start, end, contract_mode, first_byte=False):
+        return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0, start
+
+    def _skip(active_ctx, current, end):
+        return min(10, end - current + 1)
+
+    runtime_settings = {
+        "contract_mode": "lenient",
+        "density_breaker_enabled": False,
+        "zero_fill_budget_enabled": False,
+        "retry_ladder_enabled": True,
+    }
+
+    with patch.object(
+        handler, "_stream_upstream_range", side_effect=_stream
+    ), patch.object(
+        handler, "_select_live_fallback_source", side_effect=_select
+    ), patch.object(
+        handler, "_retry_original_range", side_effect=_fake_retry
+    ), patch.object(
+        handler, "_find_skip_offset", side_effect=_skip
+    ), patch.object(
+        handler, "_activate_fallback_source"
+    ), patch(
+        "resources.lib.stream_proxy._passthrough_runtime_settings",
+        return_value=runtime_settings,
+    ):
+        handler._serve_proxy(ctx)
+
+    logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
+    # The cutover reset the counter, so the count never reached the cap even
+    # though more than _FALLBACK_PENDING_FALLTHROUGH_MAX fall-throughs occurred.
+    assert "reason=fallback_exhausted" not in logged
+    # The stream survived to a natural completion instead of being condemned.
+    assert "reason=complete" in logged
+
+
+# ---------------------------------------------------------------------------
+# F6/F7 — tail prewarm (MKV cues) must YIELD to startup playback: it must not
+# fire its upstream tail read until after a short defer (abortable), so it
+# cannot starve the byte-0 prefetch / initial first-byte range request.
+# ---------------------------------------------------------------------------
+
+
+def test_tail_prewarm_defers_before_fetching_to_yield_startup():
+    """Tail prewarm must wait (abortably) before issuing its tail read so it
+    yields the connection budget to the byte-0 prefetch and Kodi's first-byte
+    range request during the fragile startup window. The MKV-cues benefit is
+    preserved: after the defer it still fetches the tail.
+    """
+    from resources.lib.stream_proxy import (
+        _TAIL_PREWARM_BYTES,
+        StreamProxy,
+        _StreamHandler,
+    )
+
+    sp = StreamProxy.__new__(StreamProxy)
+    content_length = 50 * 1024 * 1024
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": "Basic primary",
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+    }
+    order = []
+
+    monitor = sys_modules_monitor()
+    original_wait = monitor.waitForAbort.side_effect
+
+    def _wait(timeout=0.0):
+        order.append(("wait", timeout))
+        return False
+
+    monitor.waitForAbort.side_effect = _wait
+
+    def record(url, auth_header, start, end, cl):
+        order.append(("fetch", start, end))
+        return b"X" * (end - start + 1)
+
+    try:
+        with patch.object(
+            _StreamHandler, "_fetch_primary_range_bytes", side_effect=record
+        ):
+            sp._prewarm_tail_range(ctx)
+    finally:
+        monitor.waitForAbort.side_effect = original_wait
+
+    # A defer happened BEFORE the tail fetch.
+    assert order, "tail prewarm did nothing"
+    assert order[0][0] == "wait", order
+    assert any(step[0] == "fetch" for step in order), order
+    fetch = [s for s in order if s[0] == "fetch"][-1]
+    assert fetch[1] == content_length - _TAIL_PREWARM_BYTES
+    assert fetch[2] == content_length - 1
+
+
+def test_tail_prewarm_aborts_during_defer_without_fetching():
+    """If Kodi shuts down (or the session aborts) during the prewarm defer, the
+    tail read must be skipped entirely — no wasted upstream connection."""
+    from resources.lib.stream_proxy import StreamProxy, _StreamHandler
+
+    sp = StreamProxy.__new__(StreamProxy)
+    content_length = 50 * 1024 * 1024
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+    }
+    fetched = []
+
+    monitor = sys_modules_monitor()
+    original_wait = monitor.waitForAbort.side_effect
+    monitor.waitForAbort.side_effect = lambda timeout=0.0: True  # abort signalled
+
+    try:
+        with patch.object(
+            _StreamHandler,
+            "_fetch_primary_range_bytes",
+            side_effect=lambda *a, **k: fetched.append(a) or b"",
+        ):
+            sp._prewarm_tail_range(ctx)
+    finally:
+        monitor.waitForAbort.side_effect = original_wait
+
+    assert not fetched, "tail prewarm must not fetch after an abort during defer"
+
+
+# ---------------------------------------------------------------------------
+# F8-dropout — tri-state fallback match: MATCH / MISMATCH / INCONCLUSIVE
+#
+# A correct same-release fallback that is momentarily a few bytes short, or
+# hiccups on one probe (5xx/timeout/empty digest), must NOT be permanently
+# killed for the whole session. Only a PROVABLE different file is permanently
+# failed; a transient miss keeps the source eligible (bounded reconsider).
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_match_classifies_missing_fallback_digest_as_inconclusive():
+    """An empty/unavailable fallback probe digest is transient, not a mismatch."""
+    from resources.lib import stream_proxy as sp
+
+    handler = _make_handler()
+    source = {
+        "nzo_id": "peer",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic peer"},
+        "content_length": 1000,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": 1000,
+        "fallback_sources": [source],
+    }
+
+    # current-range probe returns nothing yet (range not downloaded on the peer)
+    with patch.object(handler, "_fetch_fallback_current_range_digest", return_value=""):
+        result = handler._fallback_source_matches(ctx, source, 100, 999)
+
+    assert result is sp._FALLBACK_INCONCLUSIVE
+
+
+def test_fallback_match_classifies_differing_digest_as_mismatch():
+    """Both digests present and provably different is a definitive MISMATCH."""
+    from resources.lib import stream_proxy as sp
+
+    handler = _make_handler()
+    source = {
+        "nzo_id": "wrong",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic peer"},
+        "content_length": 1000,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": 1000,
+        "fallback_sources": [source],
+    }
+
+    with patch.object(
+        handler, "_fetch_fallback_current_range_digest", return_value="dead-beef"
+    ), patch.object(
+        handler, "_fetch_fallback_fingerprint_digest", return_value="aaaa"
+    ), patch.object(
+        handler, "_fetch_primary_fallback_range_digest", return_value="bbbb"
+    ):
+        result = handler._fallback_source_matches(ctx, source, 100, 4194)
+
+    assert result is sp._FALLBACK_MISMATCH
+
+
+def test_fallback_match_classifies_missing_primary_digest_as_inconclusive():
+    """A primary probe 5xx/timeout (empty digest) is transient, not a mismatch."""
+    from resources.lib import stream_proxy as sp
+
+    handler = _make_handler()
+    source = {
+        "nzo_id": "peer",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic peer"},
+        "content_length": 1000,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": 1000,
+        "fallback_sources": [source],
+    }
+
+    with patch.object(
+        handler, "_fetch_fallback_current_range_digest", return_value="dead-beef"
+    ), patch.object(
+        handler, "_fetch_fallback_fingerprint_digest", return_value="aaaa"
+    ), patch.object(
+        handler, "_fetch_primary_fallback_range_digest", return_value=""
+    ):
+        result = handler._fallback_source_matches(ctx, source, 100, 4194)
+
+    assert result is sp._FALLBACK_INCONCLUSIVE
+
+
+def test_fallback_match_returns_true_on_full_fingerprint_agreement():
+    """All sampled ranges agree -> usable now (MATCH)."""
+    handler = _make_handler()
+    source = {
+        "nzo_id": "good",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic peer"},
+        "content_length": 1000,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": 1000,
+        "fallback_sources": [source],
+    }
+
+    with patch.object(
+        handler, "_fetch_fallback_current_range_digest", return_value="dead-beef"
+    ), patch.object(
+        handler, "_fetch_fallback_fingerprint_digest", return_value="same"
+    ), patch.object(
+        handler, "_fetch_primary_fallback_range_digest", return_value="same"
+    ):
+        result = handler._fallback_source_matches(ctx, source, 100, 4194)
+
+    assert result is True
+
+
+def test_inconclusive_fallback_is_not_permanently_failed_and_retried():
+    """A transient (INCONCLUSIVE) miss must keep the source eligible for the
+    NEXT cutover — never set failed=True on the first transient hiccup."""
+    from resources.lib import stream_proxy as sp
+
+    handler = _make_handler()
+    source = {
+        "nzo_id": "peer",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic peer"},
+        "content_length": 1000,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": 1000,
+        "fallback_sources": [source],
+    }
+
+    with patch.object(
+        handler, "_fallback_source_matches", return_value=sp._FALLBACK_INCONCLUSIVE
+    ):
+        first = handler._select_resolved_fallback_source(
+            ctx, 100, 999, expected_length=1000
+        )
+        second = handler._select_resolved_fallback_source(
+            ctx, 100, 999, expected_length=1000
+        )
+
+    assert first is None
+    assert second is None
+    assert source.get("failed") is not True
+    # the transient miss is counted but stays under the abandon bound
+    assert source.get("transient_miss_count", 0) >= 1
+
+
+def test_definitive_mismatch_permanently_fails_the_source():
+    """A definitive MISMATCH (provably different file) is failed for good."""
+    from resources.lib import stream_proxy as sp
+
+    handler = _make_handler()
+    source = {
+        "nzo_id": "wrong",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic peer"},
+        "content_length": 1000,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": 1000,
+        "fallback_sources": [source],
+    }
+
+    with patch.object(
+        handler, "_fallback_source_matches", return_value=sp._FALLBACK_MISMATCH
+    ):
+        selected = handler._select_resolved_fallback_source(
+            ctx, 100, 999, expected_length=1000
+        )
+
+    assert selected is None
+    assert source["failed"] is True
+
+
+def test_stuck_inconclusive_source_is_abandoned_after_bound():
+    """A source stuck INCONCLUSIVE forever is abandoned once it exceeds the
+    bounded reconsider cap (so the queue can't reconsider it forever)."""
+    from resources.lib import stream_proxy as sp
+
+    handler = _make_handler()
+    source = {
+        "nzo_id": "peer",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic peer"},
+        "content_length": 1000,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": 1000,
+        "fallback_sources": [source],
+    }
+
+    with patch.object(
+        handler, "_fallback_source_matches", return_value=sp._FALLBACK_INCONCLUSIVE
+    ):
+        for _ in range(sp._FALLBACK_SOURCE_TRANSIENT_MISS_MAX + 2):
+            handler._select_resolved_fallback_source(
+                ctx, 100, 999, expected_length=1000
+            )
+
+    assert source["failed"] is True
+
+
+# ---------------------------------------------------------------------------
+# F-route — bounded failover from a STUCK no-progress AWAITING_DOWNLOAD
+#
+# 58f3d4f routed the clean high-water "still downloading" short read to the
+# retry ladder (NOT fallback) to avoid premature fallback_exhausted. But a DEAD
+# primary whose missing-article region reads as a clean short read would spin
+# the ladder forever and never fail over. After a bounded number of consecutive
+# AWAITING_DOWNLOAD reads that make NO forward progress, allow failover.
+# ---------------------------------------------------------------------------
+
+
+def test_progressing_awaiting_download_keeps_using_retry_ladder():
+    """AWAITING_DOWNLOAD reads that make real forward progress must keep using
+    the retry ladder and must NOT prematurely fail over (preserves 58f3d4f)."""
+    import sys
+
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+    )
+
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 40,
+        "fallback_sources": [
+            {
+                "nzo_id": "peer",
+                "stream_url": "http://webdav/fallback.mkv",
+                "stream_headers": {"Authorization": "Basic f"},
+                "content_length": 40,
+                "validated": True,
+                "failed": False,
+            }
+        ],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-39")
+
+    mock_addon = MagicMock()
+    mock_addon.getSetting.side_effect = lambda key: {
+        "strict_contract_mode": "warn",
+        "density_breaker_enabled": "false",
+        "zero_fill_budget_enabled": "true",
+        "retry_ladder_enabled": "true",
+    }.get(key, "")
+    original_addon = sys.modules["xbmcaddon"].Addon.return_value
+    sys.modules["xbmcaddon"].Addon.return_value = mock_addon
+
+    # Primary keeps short-reading at the high-water mark, but the retry ladder
+    # makes forward progress each time (download is genuinely advancing).
+    retry_calls = {"n": 0}
+
+    def fake_retry(_ctx, current, _end, _mode, first_byte=False):
+        del first_byte
+        retry_calls["n"] += 1
+        handler.wfile.write(b"P" * 10)
+        return _UPSTREAM_RANGE_OK, 10, current + 10
+
+    try:
+        with patch.object(
+            handler,
+            "_stream_upstream_range",
+            side_effect=[
+                (_UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0),
+                (_UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0),
+                (_UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0),
+                (_UPSTREAM_RANGE_OK, 10),
+            ],
+        ), patch.object(
+            handler, "_retry_original_range", side_effect=fake_retry
+        ), patch.object(
+            handler, "_select_live_fallback_source"
+        ) as mock_select:
+            handler._serve_proxy(ctx)
+    finally:
+        sys.modules["xbmcaddon"].Addon.return_value = original_addon
+
+    # Never failed over: progressing AWAITING_DOWNLOAD stays on the primary.
+    mock_select.assert_not_called()
+    assert ctx["remote_url"] == "http://webdav/primary.mkv"
+
+
+def test_stuck_awaiting_download_fails_over_after_bound():
+    """A DEAD primary stuck on no-progress AWAITING_DOWNLOAD must eventually fail
+    over to a validated fallback once the no-progress bound is exceeded."""
+    import sys
+
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+    )
+
+    fallback = {
+        "nzo_id": "peer",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic f"},
+        "content_length": 10,
+        "validated": True,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 10,
+        "fallback_sources": [fallback],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+
+    mock_addon = MagicMock()
+    mock_addon.getSetting.side_effect = lambda key: {
+        "strict_contract_mode": "warn",
+        "density_breaker_enabled": "false",
+        "zero_fill_budget_enabled": "true",
+        "retry_ladder_enabled": "true",
+    }.get(key, "")
+    original_addon = sys.modules["xbmcaddon"].Addon.return_value
+    sys.modules["xbmcaddon"].Addon.return_value = mock_addon
+
+    from resources.lib.stream_proxy import _AWAITING_DOWNLOAD_NO_PROGRESS_MAX
+
+    def stream_range(stream_ctx, start, end, contract_mode=None):
+        del contract_mode
+        if stream_ctx["remote_url"] == "http://webdav/fallback.mkv":
+            handler.wfile.write(b"F" * (end - start + 1))
+            return _UPSTREAM_RANGE_OK, end - start + 1
+        # primary is dead: every read is a clean no-progress short read
+        return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0
+
+    # retry ladder never makes progress on the dead primary
+    def fake_retry(_ctx, current, _end, _mode, first_byte=False):
+        del first_byte
+        return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0, current
+
+    # Kodi forces Connection: close, so a stuck region reads as a clean short
+    # read on every fresh GET. The no-progress streak is session-persistent
+    # (ctx), so it accrues across reconnects until the bound triggers failover.
+    calls_before_switch = 0
+    try:
+        with patch.object(
+            handler, "_stream_upstream_range", side_effect=stream_range
+        ), patch.object(
+            handler, "_retry_original_range", side_effect=fake_retry
+        ), patch.object(
+            handler, "_select_live_fallback_source", return_value=fallback
+        ) as mock_select, patch(
+            "resources.lib.stream_proxy._notify"
+        ):
+            for _ in range(_AWAITING_DOWNLOAD_NO_PROGRESS_MAX + 5):
+                if ctx["remote_url"] == "http://webdav/fallback.mkv":
+                    break
+                calls_before_switch += 1
+                handler._serve_proxy(ctx)
+    finally:
+        sys.modules["xbmcaddon"].Addon.return_value = original_addon
+
+    # Did NOT fail over on the very first stuck request (preserves 58f3d4f's
+    # wait-on-primary), but DID eventually fail over once the bound was exceeded.
+    assert calls_before_switch > 1
+    mock_select.assert_called()
+    assert ctx["remote_url"] == "http://webdav/fallback.mkv"

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -1142,6 +1142,7 @@ def test_prepare_stream_uses_settings_snapshot_without_kodi_setting_reads():
         "retry_ladder_enabled": True,
         "send_200_no_range_enabled": False,
         "passthrough_stall_wait_seconds": 120,
+        "readahead_buffer_mb": 256,
     }
     assert "_passthrough_runtime_settings_thread" not in ctx
 

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -15821,3 +15821,33 @@ def test_serve_proxy_forward_stall_gives_up_after_budget_exhausted():
     assert mock_stream.call_count == 2
     assert wait_calls["n"] == 1
     mock_zeros.assert_not_called()  # skip-probe returned None -> recovery_exhausted
+
+
+def test_maybe_notify_stream_starvation_fires_on_forward_stall_exhaustion():
+    """A pure slow-backend give-up — the patient forward-stall wait exhausted
+    with NO 5xx outage recorded (download-lag only) — must still tell the user,
+    not fail silently. CFS-2: ctx['forward_stall_exhausted'] is the signal."""
+    from resources.lib import stream_proxy
+
+    ctx = {"upstream_unreachable_count": 0, "forward_stall_exhausted": True}
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        fired = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "recovery_exhausted", 5_000_000, 57740611174
+        )
+    assert fired is True
+    mock_notify.assert_called_once()
+    assert "keep up" in mock_notify.call_args[0][1].lower()
+
+
+def test_maybe_notify_stream_starvation_silent_on_density_breaker():
+    """The density breaker emits its own toast at its terminal branch; the
+    starvation guard must not add a redundant second one (REGRESS-RUNTIME-2)."""
+    from resources.lib import stream_proxy
+
+    ctx = {"upstream_unreachable_count": 3, "upstream_down_notified": True}
+    with patch("resources.lib.stream_proxy._notify") as mock_notify:
+        fired = stream_proxy._maybe_notify_stream_starvation(
+            None, ctx, "density_breaker_tripped", 5_000_000, 57740611174
+        )
+    assert fired is False
+    mock_notify.assert_not_called()

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -8052,10 +8052,13 @@ def test_serve_proxy_suppresses_pending_failure_toast_on_client_disconnect():
     NOTE: an EARLIER (F5) version of this test fed a BrokenPipeError on the
     candidate's FIRST read and asserted suppression on the false premise that
     "a client abort implies the candidate was serving bytes". The F11/F12 review
-    corrected that premise — a disconnect BEFORE any byte means the candidate
-    delivered nothing and IS a failure (see
-    test_serve_proxy_fallback_zero_bytes_then_disconnect_toasts_failure). This
-    test now exercises the genuinely-benign case: delivered THEN disconnected.
+    settled this: a zero-fill 'complete' before any byte IS a failure (Case (b),
+    test_serve_proxy_fallback_zero_bytes_then_complete_toasts_failure), but a
+    BrokenPipe classified as terminal_reason='client_disconnected' before any
+    byte is EXEMPTED per 4decdd4 (see
+    test_serve_proxy_fallback_zero_bytes_then_disconnect_suppresses_failure_toast).
+    This test now exercises the genuinely-benign case: delivered THEN
+    disconnected.
     """
     from resources.lib.stream_proxy import (
         _UPSTREAM_RANGE_OK,
@@ -14152,7 +14155,7 @@ def test_serve_proxy_fallback_zero_bytes_then_complete_toasts_failure():
     assert not any("successful" in m for m in msgs), msgs
 
 
-def test_serve_proxy_fallback_zero_bytes_then_disconnect_toasts_failure():
+def test_serve_proxy_fallback_zero_bytes_then_disconnect_suppresses_failure_toast():
     """Case (c) — 4decdd4's invariant: a client disconnect right after a
     fallback switch (terminal_reason="client_disconnected") must NOT toast the
     still-pending candidate as a failure. A BrokenPipeError yielding
@@ -14413,6 +14416,76 @@ def test_serve_proxy_bounded_exhaustion_stops_instead_of_looping(mock_xbmc):
     written = _collect_written(handler)
     # Stopped well before zero-filling the entire file.
     assert len(written) < content_length
+
+
+@patch("resources.lib.stream_proxy.xbmc")
+def test_serve_proxy_fallback_primary_recovers_on_final_retry_ladder(mock_xbmc):
+    """F4 cap symmetry: the cap-fire check runs AFTER the retry ladder, so a
+    primary with no validated fallback gets its FINAL retry-ladder attempt
+    spent before fallback_exhausted is declared. A primary that recovers on
+    the cap-th (3rd) retry ladder must complete the range with reason=complete
+    rather than being aborted with fallback_exhausted (matching the
+    no-fallback path, which always runs the ladder)."""
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_UPSTREAM_ERROR,
+    )
+
+    content_length = 1_000_000
+    ctx = {
+        "remote_url": "http://host/movie.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+        "fallback_sources": [{"nzo_id": "alt", "stream_url": "http://host/alt.mkv"}],
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes=0-{}".format(content_length - 1)
+    )
+
+    # The primary errors with zero bytes and the fallback never validates, so
+    # every iteration falls through and re-enters the retry ladder. The ladder
+    # makes no progress on attempts 1 and 2 (the fall-through count climbs to
+    # the cap), but on attempt 3 the primary's region has finally downloaded:
+    # the ladder writes the full remainder and finishes the range. Because the
+    # cap-fire check now runs AFTER the ladder + progress-reset (which clears
+    # the count on real bytes), the recovering primary completes instead of
+    # being condemned to fallback_exhausted.
+    retry_calls = {"n": 0}
+
+    def _stream(active_ctx, start, end, contract_mode=None):
+        return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0
+
+    def _fake_retry(active_ctx, start, end, contract_mode, first_byte=False):
+        retry_calls["n"] += 1
+        if retry_calls["n"] < 3:
+            return _UPSTREAM_RANGE_UPSTREAM_ERROR, 0, start
+        remaining = end - start + 1
+        handler.wfile.write(b"R" * remaining)
+        return _UPSTREAM_RANGE_OK, remaining, end + 1
+
+    def _skip(active_ctx, current, end):
+        return 4096
+
+    with patch.object(
+        handler, "_stream_upstream_range", side_effect=_stream
+    ), patch.object(
+        handler, "_select_live_fallback_source", return_value=None
+    ), patch.object(
+        handler, "_retry_original_range", side_effect=_fake_retry
+    ), patch.object(
+        handler, "_find_skip_offset", side_effect=_skip
+    ):
+        handler._serve_proxy(ctx)
+
+    # The primary got its FINAL (3rd) retry ladder before exhaustion.
+    assert retry_calls["n"] == 3
+    written = _collect_written(handler)
+    # The full range was delivered via the recovering ladder.
+    assert len(written) == content_length
+    logged = "\n".join(call.args[0] for call in mock_xbmc.log.call_args_list)
+    assert "reason=complete" in logged
+    assert "reason=fallback_exhausted" not in logged
 
 
 @patch("resources.lib.stream_proxy.xbmc")
@@ -15015,3 +15088,120 @@ def test_stuck_awaiting_download_fails_over_after_bound():
     assert calls_before_switch > 1
     mock_select.assert_called()
     assert ctx["remote_url"] == "http://webdav/fallback.mkv"
+
+
+def test_stuck_awaiting_fails_over_on_cap_th_read():
+    """The awaiting-stuck failover must fire on EXACTLY the cap-th consecutive
+    no-progress AWAITING_DOWNLOAD read (the `>=` boundary), not the cap+1-th.
+    A dead primary that returns a clean no-progress AWAITING read on every GET
+    must therefore cut over after _AWAITING_DOWNLOAD_NO_PROGRESS_MAX serve
+    passes — proving the cap-th-read boundary AND no first-request failover.
+    Under the old `>` this would have been cap+1 (off-by-one)."""
+    import sys
+
+    from resources.lib.stream_proxy import (
+        _AWAITING_DOWNLOAD_NO_PROGRESS_MAX,
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+    )
+
+    fallback = {
+        "nzo_id": "peer",
+        "stream_url": "http://webdav/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic f"},
+        "content_length": 10,
+        "validated": True,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": 10,
+        "fallback_sources": [fallback],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+
+    mock_addon = MagicMock()
+    mock_addon.getSetting.side_effect = lambda key: {
+        "strict_contract_mode": "warn",
+        "density_breaker_enabled": "false",
+        "zero_fill_budget_enabled": "true",
+        "retry_ladder_enabled": "true",
+    }.get(key, "")
+    original_addon = sys.modules["xbmcaddon"].Addon.return_value
+    sys.modules["xbmcaddon"].Addon.return_value = mock_addon
+
+    def stream_range(stream_ctx, start, end, contract_mode=None):
+        del contract_mode
+        if stream_ctx["remote_url"] == "http://webdav/fallback.mkv":
+            handler.wfile.write(b"F" * (end - start + 1))
+            return _UPSTREAM_RANGE_OK, end - start + 1
+        return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0
+
+    def fake_retry(_ctx, current, _end, _mode, first_byte=False):
+        del first_byte
+        return _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0, current
+
+    calls_before_switch = 0
+    try:
+        with patch.object(
+            handler, "_stream_upstream_range", side_effect=stream_range
+        ), patch.object(
+            handler, "_retry_original_range", side_effect=fake_retry
+        ), patch.object(
+            handler, "_select_live_fallback_source", return_value=fallback
+        ) as mock_select, patch(
+            "resources.lib.stream_proxy._notify"
+        ):
+            for _ in range(_AWAITING_DOWNLOAD_NO_PROGRESS_MAX + 5):
+                if ctx["remote_url"] == "http://webdav/fallback.mkv":
+                    break
+                calls_before_switch += 1
+                handler._serve_proxy(ctx)
+    finally:
+        sys.modules["xbmcaddon"].Addon.return_value = original_addon
+
+    # Fires on EXACTLY the cap-th read (>=), never on the first (no
+    # first-request failover), never on cap+1 (no off-by-one).
+    assert calls_before_switch == _AWAITING_DOWNLOAD_NO_PROGRESS_MAX
+    mock_select.assert_called()
+    assert ctx["remote_url"] == "http://webdav/fallback.mkv"
+
+
+def test_non_awaiting_read_resets_awaiting_streak():
+    """The no-progress AWAITING_DOWNLOAD streak must be STRICTLY consecutive: a
+    single non-AWAITING result resets it to 0, so an intervening RECOVERABLE
+    no-progress read clears the streak rather than letting it accrue toward the
+    failover bound. Pins the "strictly consecutive" invariant of
+    _bump_awaiting_no_progress."""
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+        _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE,
+    )
+
+    ctx = {}
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+
+    count = 0
+    count = handler._bump_awaiting_no_progress(
+        ctx, _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, count
+    )
+    assert count == 1
+    count = handler._bump_awaiting_no_progress(
+        ctx, _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, count
+    )
+    assert count == 2
+    # A non-AWAITING result resets the streak to 0.
+    count = handler._bump_awaiting_no_progress(
+        ctx, _UPSTREAM_RANGE_SHORT_READ_RECOVERABLE, count
+    )
+    assert count == 0
+    assert ctx["_awaiting_download_no_progress"] == 0
+    # The next AWAITING read starts a FRESH streak at 1, not 3.
+    count = handler._bump_awaiting_no_progress(
+        ctx, _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, count
+    )
+    assert count == 1
+    assert ctx["_awaiting_download_no_progress"] == 1

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -15184,6 +15184,83 @@ def test_stuck_inconclusive_source_is_abandoned_after_bound():
     assert source["failed"] is True
 
 
+def test_prevalidation_resets_transient_miss_streak(monkeypatch):
+    """Regression (id 3352749431): a still-downloading source that returned
+    INCONCLUSIVE on earlier live probes, then later PREVALIDATES, must have its
+    transient_miss_count reset so it is not abandoned at the abandon bound once
+    it is proven readable."""
+    from urllib.parse import urlsplit
+
+    from resources.lib import stream_proxy as sp
+
+    content_length = 8192
+    handler = _make_handler()
+    source = {
+        "nzo_id": "nzo-fallback",
+        "stream_url": "http://webdav/content/fallback.mkv",
+        "stream_headers": {"Authorization": "Basic fallback"},
+        "content_length": content_length,
+        "validated": False,
+        "failed": False,
+        # Carried-over streak from earlier still-downloading INCONCLUSIVE probes.
+        "transient_miss_count": sp._FALLBACK_SOURCE_TRANSIENT_MISS_MAX,
+    }
+    ctx = {
+        "remote_url": "http://webdav/content/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": content_length,
+        "_fallback_probe_bases": (urlsplit("http://webdav/content/"),),
+        "fallback_sources": [source],
+    }
+
+    with patch.object(handler, "_validate_fallback_fingerprint", return_value=True):
+        validated = handler._prevalidate_ready_fallback_sources(ctx)
+
+    assert validated == 1
+    assert source["validated"] is True
+    assert source["failed"] is not True
+    # Stale streak cleared: a subsequent single INCONCLUSIVE probe can no longer
+    # tip it over the abandon bound.
+    assert source.get("transient_miss_count", 0) == 0
+
+
+def test_fallback_source_matches_validated_resets_transient_streak():
+    """A source that returns MATCH from _fallback_source_matches after earlier
+    INCONCLUSIVE probes clears its transient streak as it becomes validated."""
+    from resources.lib import stream_proxy as sp
+
+    handler = _make_handler()
+    source = {
+        "nzo_id": "peer",
+        "stream_url": "http://webdav/fallback.mkv",
+        "content_length": 1000,
+        "validated": False,
+        "failed": False,
+        "transient_miss_count": sp._FALLBACK_SOURCE_TRANSIENT_MISS_MAX,
+    }
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic primary",
+        "content_length": 1000,
+        "fallback_sources": [source],
+    }
+
+    with patch.object(
+        handler, "_classify_fallback_fingerprint", return_value=sp._FALLBACK_MATCH
+    ), patch.object(handler, "_fallback_source_auth", return_value=None), patch.object(
+        handler, "_fallback_expected_content_length", return_value=1000
+    ), patch.object(
+        handler, "_fallback_source_content_length", return_value=1000
+    ), patch.object(
+        handler, "_fetch_fallback_current_range_digest", return_value=b"d" * 16
+    ):
+        result = handler._fallback_source_matches(ctx, source, 0, 4094)
+
+    assert result is sp._FALLBACK_MATCH
+    assert source["validated"] is True
+    assert source.get("transient_miss_count", 0) == 0
+
+
 # ---------------------------------------------------------------------------
 # F-route — bounded failover from a STUCK no-progress AWAITING_DOWNLOAD
 #

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -11165,6 +11165,60 @@ def test_fallback_range_probe_failure_reenters_retry_and_zero_fill_recovery():
     assert _collect_written(handler) == b""
 
 
+def test_serve_proxy_byte0_prefetch_keeps_short_first_byte_ladder():
+    """Regression (Interstellar 64KB-then-EOF on a huge pass-through MKV): a
+    byte-0 open serves a ~64KB prefetched prefix, which advances the serve cursor
+    to 65536. The retry ladder's first-byte detection must key on the ORIGINAL
+    request start (0), not the mutated cursor -- otherwise the player's real first
+    content read at byte 65536 takes the long (2,4,8)s wait-on-primary ladder,
+    stalls ~14s past Kodi's first-read patience, and the player disconnects with
+    only the 64KB prefix served (streamed=65536 then 0, client_disconnected).
+    """
+    from resources.lib.stream_proxy import (
+        _UPSTREAM_RANGE_OK,
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+    )
+
+    content_length = 102_700_000_000
+    ctx = {
+        "remote_url": "http://webdav/interstellar.mkv",
+        "auth_header": None,
+        "content_type": "video/x-matroska",
+        "content_length": content_length,
+        "fallback_sources": [],
+        "fallback_switch_count": 0,
+    }
+    handler = _make_handler_with_server(
+        ctx, range_header="bytes=0-{}".format(content_length - 1)
+    )
+    prefix = b"P" * 65536
+
+    def pop_prefix(_ctx, current, _end):
+        # Serve the cached 64KB prefix only for the genuine byte-0 open.
+        return prefix if current == 0 else b""
+
+    with patch.object(
+        handler, "_pop_cached_fallback_range", side_effect=pop_prefix
+    ), patch.object(
+        handler,
+        "_stream_upstream_range",
+        return_value=(_UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD, 0),
+    ), patch(
+        "resources.lib.stream_proxy._retry_ladder_enabled", return_value=True
+    ), patch.object(
+        handler,
+        "_retry_original_range",
+        # Complete the request so the serve loop exits after one ladder entry.
+        return_value=(_UPSTREAM_RANGE_OK, content_length - 65536, content_length),
+    ) as retry_original:
+        handler._serve_proxy(ctx)
+
+    retry_original.assert_called()
+    # The cursor is at 65536 by now, but the open began at byte 0, so the SHORT
+    # first-byte ladder must be selected.
+    assert retry_original.call_args.kwargs.get("first_byte") is True
+
+
 def test_fallback_cutover_parallelizes_fingerprint_probes_before_first_byte():
     """Fallback switch should not serially probe every fingerprint range."""
     from resources.lib.stream_proxy import (

--- a/tests/test_stream_proxy_readahead.py
+++ b/tests/test_stream_proxy_readahead.py
@@ -338,6 +338,45 @@ def test_run_readahead_prefetch_fills_then_stops_at_eof():
     assert buf.read_prefix(0, 0) == b"Y"
 
 
+def test_run_readahead_prefetch_repoints_to_url_after_fallback_cutover():
+    """A live fallback cutover mutates ctx['remote_url']/['auth_header'];
+    the daemon must pick up the NEW source on the next iteration instead of
+    hammering the dead primary. (QA pass #2 finding: the URL was hoisted into
+    a thread-local once at start, so post-cutover prefetch stalled.)"""
+    proxy = _make_proxy()
+    content_length = 200_000
+    buf = ReadAheadBuffer(cap_bytes=10 * 1024 * 1024, content_length=content_length)
+    ctx = {
+        "remote_url": "http://webdav/primary.mkv",
+        "auth_header": "Basic PRIMARY",
+        "content_length": content_length,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+
+    seen = []
+
+    def fake_fetch(url, auth, start, end, _clen):
+        seen.append((url, auth))
+        # Simulate the live cutover after the first chunk: the serve path has
+        # repointed the session to the fallback source.
+        if len(seen) == 1:
+            ctx["remote_url"] = "http://webdav/fallback.mkv"
+            ctx["auth_header"] = "Basic FALLBACK"
+        return b"Y" * (end - start + 1)
+
+    monitor = _FakeMonitor()
+    with patch("xbmc.Monitor", return_value=monitor), patch.object(
+        _StreamHandler, "_fetch_primary_range_bytes", staticmethod(fake_fetch)
+    ):
+        proxy._run_readahead_prefetch(ctx)
+
+    # First fetch hit the primary; every fetch after the cutover used the
+    # fallback URL + its auth header (not the stale primary).
+    assert seen[0] == ("http://webdav/primary.mkv", "Basic PRIMARY")
+    assert all(s == ("http://webdav/fallback.mkv", "Basic FALLBACK") for s in seen[1:])
+    assert len(seen) > 1  # it kept prefetching from the new source
+
+
 def test_run_readahead_prefetch_bounded_by_cap():
     proxy = _make_proxy()
     content_length = 50 * 1024 * 1024

--- a/tests/test_stream_proxy_readahead.py
+++ b/tests/test_stream_proxy_readahead.py
@@ -114,11 +114,32 @@ def test_free_behind_idempotent_for_old_offset():
     assert buf.read_prefix(4, 9) == b"EFGHIJ"
 
 
-def test_note_seek_in_window_keeps_data():
+def test_note_seek_in_window_trims_prefix_and_serves_lead():
+    """Regression (id 3365909885): an in-window FORWARD seek must rebase the
+    window to the seek target so read_prefix (which only serves at base_offset)
+    serves the still-buffered lead from memory instead of missing and refetching
+    bytes already held. The consumed prefix [old base, new_start) is dropped and
+    the forward lead [new_start, window_end) is kept (next_fetch_offset stays)."""
     buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
     buf.append(0, b"ABCDEFGHIJ")
-    buf.note_seek(3)  # inside [0, 10)
-    assert buf.read_prefix(0, 9) == b"ABCDEFGHIJ"
+    buf.note_seek(3)  # inside [0, 10): forward seek into the buffered lead
+    # The lead from the seek target is served straight from memory...
+    assert buf.read_prefix(3, 9) == b"DEFGHIJ"
+    # ...the consumed prefix is gone (read_prefix only serves at base_offset)...
+    assert buf.read_prefix(0, 9) == b""
+    # ...and the buffered lead was preserved, not discarded for a refetch.
+    assert buf.next_fetch_offset() == 10
+
+
+def test_note_seek_to_window_end_trims_all_and_resumes_forward():
+    """Boundary: a seek to exactly window_end consumes the whole lead -- data
+    empties, base rebases to the target, and the prefetch resumes forward from
+    there (no negative slice / off-by-one)."""
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")  # window [0, 10)
+    buf.note_seek(10)  # exactly window_end
+    assert buf.read_prefix(10, 12) == b""
+    assert buf.next_fetch_offset() == 10
 
 
 def test_note_seek_outside_window_discards_and_repoints():

--- a/tests/test_stream_proxy_readahead.py
+++ b/tests/test_stream_proxy_readahead.py
@@ -194,6 +194,22 @@ def test_served_high_water_within_window_keeps_forward_lead():
     assert buf.next_fetch_offset() == 10
 
 
+def test_served_high_water_in_window_trims_prefix_keeps_lead():
+    """Regression: an IN-WINDOW direct serve (base < offset < window_end) -- a
+    read-ahead miss served upstream while the prefetch already filled bytes from
+    the old base -- must trim the consumed prefix [base, offset) and advance
+    base_offset to the served offset, while KEEPING the forward lead so the
+    prefetch extends ahead instead of refilling behind the play head."""
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")  # window [0, 10)
+    buf.update_served_high_water(4)  # in-window: base 0 < 4 < window_end 10
+    # Consumed prefix dropped; base rebased to the served offset.
+    assert buf.read_prefix(4, 9) == b"EFGHIJ"
+    assert buf.read_prefix(0, 9) == b""
+    # Forward lead preserved -- not refetched.
+    assert buf.next_fetch_offset() == 10
+
+
 def test_served_high_water_discards_stale_behind_data():
     """A miss served past stale buffered bytes drops the now-behind data and
     repoints the base to the served offset."""

--- a/tests/test_stream_proxy_readahead.py
+++ b/tests/test_stream_proxy_readahead.py
@@ -147,6 +147,42 @@ def test_is_full_and_space_remaining():
     assert buf.space_remaining() == 0
 
 
+def test_served_high_water_past_window_advances_next_fetch_offset():
+    """Regression (id 3352749425): a direct upstream serve on a read-ahead
+    MISS must advance next_fetch_offset past the served bytes so the prefetch
+    daemon builds a forward lead instead of re-fetching from offset 0."""
+    buf = ReadAheadBuffer(cap_bytes=256 * 1024 * 1024, content_length=10_000_000)
+    # Startup miss: nothing buffered, base still at 0.
+    assert buf.next_fetch_offset() == 0
+    served_end = 4_000_000
+    buf.update_served_high_water(served_end)
+    # Buffer now knows the play head; prefetch resumes AHEAD of it.
+    assert buf.next_fetch_offset() >= served_end
+    assert buf.next_fetch_offset() == served_end
+
+
+def test_served_high_water_within_window_keeps_forward_lead():
+    """A high-water at/behind the buffered window (hit path, post free_behind)
+    must NOT discard the forward lead the prefetch daemon already built."""
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")
+    buf.free_behind(5)  # hit path consumes ABCDE; base=5, data=FGHIJ
+    buf.update_served_high_water(5)
+    # Forward lead preserved.
+    assert buf.read_prefix(5, 9) == b"FGHIJ"
+    assert buf.next_fetch_offset() == 10
+
+
+def test_served_high_water_discards_stale_behind_data():
+    """A miss served past stale buffered bytes drops the now-behind data and
+    repoints the base to the served offset."""
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDE")  # stale prefetch at offset 0
+    buf.update_served_high_water(500)  # played far past the stale bytes
+    assert buf.read_prefix(0, 4) == b""
+    assert buf.next_fetch_offset() == 500
+
+
 def test_never_buffers_past_content_length_via_next_fetch_offset():
     buf = ReadAheadBuffer(cap_bytes=1024, content_length=3)
     buf.append(0, b"ABC")
@@ -291,6 +327,52 @@ def test_stream_upstream_range_no_buffer_unchanged():
     ):
         handler._stream_upstream_range(ctx, 0, 99)
     mock_urlopen.assert_called_once()
+
+
+def _mock_range_response(chunks, status=206, headers=None):
+    resp = MagicMock()
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    resp.read = MagicMock(side_effect=list(chunks) + [b""])
+    resp.status = status
+    resp.getcode = MagicMock(return_value=status)
+    header_map = {str(k).lower(): v for k, v in (headers or {}).items()}
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default=None: header_map.get(str(key).lower(), default)
+    )
+    resp.close = MagicMock()
+    return resp
+
+
+def test_stream_upstream_range_miss_updates_served_high_water():
+    """Regression (id 3352749425): on a read-ahead MISS the bytes are served
+    directly from upstream; after the write the buffer must be told the served
+    position so next_fetch_offset advances past it (forward lead, not re-fetch
+    from 0)."""
+    handler = _make_handler()
+    content_length = 10_000_000
+    buf = ReadAheadBuffer(cap_bytes=256 * 1024 * 1024, content_length=content_length)
+    # Startup: nothing buffered -> read_prefix MISS, served straight upstream.
+    assert buf.next_fetch_offset() == 0
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": content_length,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+    payload = b"Z" * 100
+    resp = _mock_range_response(
+        [payload],
+        headers={"Content-Range": "bytes 0-99/{}".format(content_length)},
+    )
+    with patch.object(stream_proxy, "urlopen", return_value=resp), patch.object(
+        handler, "_pop_cached_fallback_range", return_value=b""
+    ), patch.object(handler, "_wait_for_initial_range_prefetch"):
+        result, written = handler._stream_upstream_range(ctx, 0, 99)
+    assert result == _UPSTREAM_RANGE_OK
+    assert written == 100
+    served_end = 0 + written
+    assert buf.next_fetch_offset() >= served_end
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stream_proxy_readahead.py
+++ b/tests/test_stream_proxy_readahead.py
@@ -1,0 +1,549 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Unit tests for the per-session read-ahead prefetch cache.
+
+The read-ahead layer is ADDITIVE in front of the hardened miss/recovery
+path. These tests pin: the ReadAheadBuffer contiguous-prefix invariant,
+free-behind / seek-repoint, the setting reader + snapshot wiring, the
+serve-from-window helper, the additive _stream_upstream_range consult,
+the bounded daemon prefetch run-loop, and lifecycle/teardown.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from resources.lib import stream_proxy
+from resources.lib.stream_proxy import (
+    _DEFAULT_READAHEAD_BUFFER_MB,
+    _READAHEAD_BUFFER_KEY,
+    _READAHEAD_BUFFER_MB_MAX,
+    _READAHEAD_THREAD_KEY,
+    _UPSTREAM_RANGE_OK,
+    ReadAheadBuffer,
+    _StreamHandler,
+)
+
+
+def _make_handler():
+    handler = _StreamHandler.__new__(_StreamHandler)
+    handler.wfile = MagicMock()
+    return handler
+
+
+def _make_proxy():
+    """A bare StreamProxy for the spawn / run-loop methods (no real Kodi)."""
+    return stream_proxy.StreamProxy.__new__(stream_proxy.StreamProxy)
+
+
+# ---------------------------------------------------------------------------
+# ReadAheadBuffer
+# ---------------------------------------------------------------------------
+
+
+def test_read_prefix_empty_returns_blank():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    assert buf.read_prefix(0, 99) == b""
+
+
+def test_append_and_read_prefix_contiguous():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    assert buf.append(0, b"ABCDEFGHIJ") is True
+    # Exact contiguous prefix from base.
+    assert buf.read_prefix(0, 4) == b"ABCDE"
+    # Capped to what is present.
+    assert buf.read_prefix(0, 100) == b"ABCDEFGHIJ"
+
+
+def test_read_prefix_requires_exact_base_match():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")
+    # A request starting inside-but-not-at base is a gap/non-prefix -> miss.
+    assert buf.read_prefix(3, 9) == b""
+
+
+def test_read_prefix_never_exceeds_requested_or_content_length():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=5)
+    # Only 5 bytes valid even if appended more is rejected past content_length.
+    assert buf.append(0, b"ABCDEFGHIJ") is True
+    assert len(buf.read_prefix(0, 100)) <= 5
+    assert buf.read_prefix(0, 2) == b"ABC"
+
+
+def test_append_rejects_out_of_order():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDE")
+    # Non-contiguous (gap) append is ignored.
+    assert buf.append(10, b"ZZZ") is False
+    assert buf.read_prefix(0, 100) == b"ABCDE"
+
+
+def test_append_truncates_at_content_length():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=8)
+    buf.append(0, b"ABCDE")
+    # Would exceed content_length=8; only 3 more bytes accepted.
+    buf.append(5, b"FGHIJ")
+    body = buf.read_prefix(0, 100)
+    assert body == b"ABCDEFGH"
+    assert buf.next_fetch_offset() == 8
+
+
+def test_append_respects_cap():
+    buf = ReadAheadBuffer(cap_bytes=8, content_length=10_000)
+    buf.append(0, b"ABCDE")
+    buf.append(5, b"FGHIJ")  # would overflow cap of 8
+    assert len(buf.read_prefix(0, 100)) == 8
+    assert buf.is_full() is True
+    assert buf.space_remaining() == 0
+
+
+def test_free_behind_advances_base_and_shrinks():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")
+    buf.free_behind(4)
+    assert buf.read_prefix(0, 9) == b""  # old base no longer valid
+    assert buf.read_prefix(4, 9) == b"EFGHIJ"
+    assert buf.next_fetch_offset() == 10
+
+
+def test_free_behind_idempotent_for_old_offset():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")
+    buf.free_behind(4)
+    buf.free_behind(2)  # behind current base -> no-op
+    assert buf.read_prefix(4, 9) == b"EFGHIJ"
+
+
+def test_note_seek_in_window_keeps_data():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")
+    buf.note_seek(3)  # inside [0, 10)
+    assert buf.read_prefix(0, 9) == b"ABCDEFGHIJ"
+
+
+def test_note_seek_outside_window_discards_and_repoints():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")
+    buf.note_seek(5_000)  # forward past the lead
+    assert buf.read_prefix(0, 9) == b""
+    assert buf.read_prefix(5_000, 5_010) == b""  # nothing yet at new base
+    assert buf.next_fetch_offset() == 5_000
+
+
+def test_note_seek_backward_discards():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(100, b"ABCDE")  # base offset moved up first
+    # backward seek before base
+    buf.note_seek(0)
+    assert buf.next_fetch_offset() == 0
+
+
+def test_is_full_and_space_remaining():
+    buf = ReadAheadBuffer(cap_bytes=10, content_length=10_000)
+    assert buf.is_full() is False
+    assert buf.space_remaining() == 10
+    buf.append(0, b"ABCDEFGHIJ")
+    assert buf.is_full() is True
+    assert buf.space_remaining() == 0
+
+
+def test_never_buffers_past_content_length_via_next_fetch_offset():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=3)
+    buf.append(0, b"ABC")
+    assert buf.next_fetch_offset() == 3
+    # Further append at content_length is rejected (nothing past EOF).
+    assert buf.append(3, b"D") is False
+
+
+def test_stop_and_should_stop():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10)
+    assert buf.should_stop() is False
+    buf.stop()
+    assert buf.should_stop() is True
+
+
+# ---------------------------------------------------------------------------
+# _get_readahead_buffer_mb + snapshot/live wiring
+# ---------------------------------------------------------------------------
+
+
+def _patch_setting(value):
+    return patch.object(stream_proxy, "_get_addon_setting", return_value=value)
+
+
+def test_readahead_setting_default_when_blank():
+    with _patch_setting(""):
+        assert stream_proxy._get_readahead_buffer_mb() == _DEFAULT_READAHEAD_BUFFER_MB
+    with _patch_setting(None):
+        assert stream_proxy._get_readahead_buffer_mb() == _DEFAULT_READAHEAD_BUFFER_MB
+
+
+def test_readahead_setting_parses_int():
+    with _patch_setting("128"):
+        assert stream_proxy._get_readahead_buffer_mb() == 128
+
+
+def test_readahead_setting_zero_disables():
+    with _patch_setting("0"):
+        assert stream_proxy._get_readahead_buffer_mb() == 0
+
+
+def test_readahead_setting_clamps():
+    with _patch_setting("-5"):
+        assert stream_proxy._get_readahead_buffer_mb() == 0
+    with _patch_setting(str(_READAHEAD_BUFFER_MB_MAX + 1000)):
+        assert stream_proxy._get_readahead_buffer_mb() == _READAHEAD_BUFFER_MB_MAX
+
+
+def test_readahead_setting_non_numeric_falls_back():
+    with _patch_setting("garbage"):
+        assert stream_proxy._get_readahead_buffer_mb() == _DEFAULT_READAHEAD_BUFFER_MB
+
+
+def test_snapshot_wiring_includes_readahead():
+    snap = {"readahead_buffer_mb": "64"}
+    out = stream_proxy._passthrough_runtime_settings_from_snapshot(snap)
+    assert out["readahead_buffer_mb"] == 64
+
+
+def test_snapshot_wiring_default_when_absent():
+    out = stream_proxy._passthrough_runtime_settings_from_snapshot({})
+    assert out["readahead_buffer_mb"] == _DEFAULT_READAHEAD_BUFFER_MB
+
+
+def test_live_runtime_settings_includes_readahead():
+    with _patch_setting("32"):
+        out = stream_proxy._read_passthrough_runtime_settings()
+    assert out["readahead_buffer_mb"] == 32
+
+
+# ---------------------------------------------------------------------------
+# _serve_from_readahead
+# ---------------------------------------------------------------------------
+
+
+def test_serve_from_readahead_no_buffer_returns_zero():
+    handler = _make_handler()
+    assert handler._serve_from_readahead({}, 0, 99) == 0
+    handler.wfile.write.assert_not_called()
+
+
+def test_serve_from_readahead_hit_writes_and_frees():
+    handler = _make_handler()
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")
+    ctx = {_READAHEAD_BUFFER_KEY: buf}
+    n = handler._serve_from_readahead(ctx, 0, 4)
+    assert n == 5
+    handler.wfile.write.assert_called_once_with(b"ABCDE")
+    # free-behind advanced the base so the served bytes are dropped.
+    assert buf.read_prefix(0, 4) == b""
+    assert buf.read_prefix(5, 9) == b"FGHIJ"
+
+
+def test_serve_from_readahead_miss_returns_zero():
+    handler = _make_handler()
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDE")
+    ctx = {_READAHEAD_BUFFER_KEY: buf}
+    # request at non-base offset -> miss
+    assert handler._serve_from_readahead(ctx, 100, 200) == 0
+    handler.wfile.write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _stream_upstream_range additive consult
+# ---------------------------------------------------------------------------
+
+
+def test_stream_upstream_range_window_hit_skips_urlopen():
+    handler = _make_handler()
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"X" * 100)
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": 10_000,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+    with patch.object(stream_proxy, "urlopen") as mock_urlopen:
+        result, written = handler._stream_upstream_range(ctx, 0, 99)
+    assert result == _UPSTREAM_RANGE_OK
+    assert written == 100
+    mock_urlopen.assert_not_called()
+    handler.wfile.write.assert_called_once_with(b"X" * 100)
+
+
+def test_stream_upstream_range_no_buffer_unchanged():
+    """With no read-ahead buffer the path must reach the upstream urlopen."""
+    handler = _make_handler()
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": 10_000,
+    }
+    # urlopen raising a benign OSError keeps us out of the heavy branches but
+    # proves the buffer consult did NOT short-circuit the upstream attempt.
+    with patch.object(
+        stream_proxy, "urlopen", side_effect=OSError("boom")
+    ) as mock_urlopen, patch.object(
+        handler, "_pop_cached_fallback_range", return_value=b""
+    ):
+        handler._stream_upstream_range(ctx, 0, 99)
+    mock_urlopen.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Prefetch run-loop
+# ---------------------------------------------------------------------------
+
+
+class _FakeMonitor:
+    def __init__(self, abort_after=None):
+        self._calls = 0
+        self._abort_after = abort_after
+
+    def waitForAbort(self, _timeout=0.0):
+        self._calls += 1
+        if self._abort_after is not None and self._calls >= self._abort_after:
+            return True
+        return False
+
+    def abortRequested(self):
+        return self._abort_after is not None and self._calls >= self._abort_after
+
+
+def test_run_readahead_prefetch_fills_then_stops_at_eof():
+    proxy = _make_proxy()
+    content_length = 200_000
+    buf = ReadAheadBuffer(cap_bytes=10 * 1024 * 1024, content_length=content_length)
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": content_length,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+
+    def fake_fetch(_url, _auth, start, end, _clen):
+        return b"Y" * (end - start + 1)
+
+    monitor = _FakeMonitor()
+    with patch("xbmc.Monitor", return_value=monitor), patch.object(
+        _StreamHandler, "_fetch_primary_range_bytes", staticmethod(fake_fetch)
+    ):
+        proxy._run_readahead_prefetch(ctx)
+
+    # Filled exactly up to content_length, never past.
+    assert buf.next_fetch_offset() == content_length
+    assert buf.read_prefix(0, 0) == b"Y"
+
+
+def test_run_readahead_prefetch_bounded_by_cap():
+    proxy = _make_proxy()
+    content_length = 50 * 1024 * 1024
+    cap = 256 * 1024  # small cap
+    buf = ReadAheadBuffer(cap_bytes=cap, content_length=content_length)
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": content_length,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+
+    def fake_fetch(_url, _auth, start, end, _clen):
+        return b"Y" * (end - start + 1)
+
+    # Abort quickly so the throttle loop does not spin forever once full.
+    monitor = _FakeMonitor(abort_after=200)
+    with patch("xbmc.Monitor", return_value=monitor), patch.object(
+        _StreamHandler, "_fetch_primary_range_bytes", staticmethod(fake_fetch)
+    ):
+        proxy._run_readahead_prefetch(ctx)
+
+    assert buf.is_full() is True
+    assert len(buf.read_prefix(0, cap * 2)) == cap
+
+
+def test_run_readahead_prefetch_error_does_not_raise_or_touch_recovery():
+    proxy = _make_proxy()
+    content_length = 200_000
+    buf = ReadAheadBuffer(cap_bytes=10 * 1024 * 1024, content_length=content_length)
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": content_length,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+
+    calls = {"n": 0}
+
+    def fake_fetch(_url, _auth, start, end, _clen):
+        calls["n"] += 1
+        if calls["n"] <= 3:
+            return None  # best-effort upstream error / awaiting download
+        return b"Y" * (end - start + 1)
+
+    monitor = _FakeMonitor()
+    with patch("xbmc.Monitor", return_value=monitor), patch.object(
+        _StreamHandler, "_fetch_primary_range_bytes", staticmethod(fake_fetch)
+    ):
+        # Must not raise.
+        proxy._run_readahead_prefetch(ctx)
+
+    # It backed off and ultimately filled to EOF.
+    assert buf.next_fetch_offset() == content_length
+
+
+def test_run_readahead_prefetch_swallows_exceptions():
+    proxy = _make_proxy()
+    content_length = 200_000
+    buf = ReadAheadBuffer(cap_bytes=10 * 1024 * 1024, content_length=content_length)
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": content_length,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+
+    def boom(*_a, **_k):
+        raise RuntimeError("kaboom")
+
+    # Abort after a couple loops so the swallowed exception path returns.
+    monitor = _FakeMonitor(abort_after=3)
+    with patch("xbmc.Monitor", return_value=monitor), patch.object(
+        _StreamHandler, "_fetch_primary_range_bytes", staticmethod(boom)
+    ):
+        proxy._run_readahead_prefetch(ctx)  # must not raise
+
+
+def test_run_readahead_prefetch_stops_on_stop_event():
+    proxy = _make_proxy()
+    content_length = 200_000
+    buf = ReadAheadBuffer(cap_bytes=10 * 1024 * 1024, content_length=content_length)
+    buf.stop()  # pre-signalled
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": content_length,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+
+    fetch = MagicMock(return_value=b"Y")
+    monitor = _FakeMonitor()
+    with patch("xbmc.Monitor", return_value=monitor), patch.object(
+        _StreamHandler, "_fetch_primary_range_bytes", staticmethod(fetch)
+    ):
+        proxy._run_readahead_prefetch(ctx)
+    fetch.assert_not_called()
+
+
+def test_run_readahead_prefetch_aborts_on_waitforabort():
+    proxy = _make_proxy()
+    content_length = 50 * 1024 * 1024
+    cap = 256 * 1024
+    buf = ReadAheadBuffer(cap_bytes=cap, content_length=content_length)
+    ctx = {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": content_length,
+        _READAHEAD_BUFFER_KEY: buf,
+    }
+
+    def fake_fetch(_url, _auth, start, end, _clen):
+        return b"Y" * (end - start + 1)
+
+    monitor = _FakeMonitor(abort_after=1)  # abort immediately
+    with patch("xbmc.Monitor", return_value=monitor), patch.object(
+        _StreamHandler, "_fetch_primary_range_bytes", staticmethod(fake_fetch)
+    ):
+        proxy._run_readahead_prefetch(ctx)
+    # Aborted on the first loop guard -> nothing buffered.
+    assert buf.next_fetch_offset() == 0
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: _start_readahead_prefetch + _cleanup_session teardown
+# ---------------------------------------------------------------------------
+
+
+def _prefetchable_ctx(content_length=1_000_000, mb=256):
+    return {
+        "remote_url": "http://webdav/x.mkv",
+        "auth_header": None,
+        "content_length": content_length,
+        stream_proxy._PASSTHROUGH_RUNTIME_SETTINGS_KEY: {
+            "readahead_buffer_mb": mb,
+        },
+    }
+
+
+def test_start_readahead_prefetch_disabled_when_zero():
+    proxy = _make_proxy()
+    ctx = _prefetchable_ctx(mb=0)
+    proxy._start_readahead_prefetch(ctx)
+    assert _READAHEAD_BUFFER_KEY not in ctx
+    assert _READAHEAD_THREAD_KEY not in ctx
+
+
+def test_start_readahead_prefetch_gated_off_for_remux():
+    proxy = _make_proxy()
+    ctx = _prefetchable_ctx(mb=256)
+    ctx["remux"] = True
+    proxy._start_readahead_prefetch(ctx)
+    assert _READAHEAD_BUFFER_KEY not in ctx
+
+
+def test_start_readahead_prefetch_spawns_daemon():
+    proxy = _make_proxy()
+    ctx = _prefetchable_ctx(mb=256)
+    # Prevent the real loop from running upstream fetches.
+    with patch.object(
+        stream_proxy.StreamProxy, "_run_readahead_prefetch", lambda self, c: None
+    ):
+        proxy._start_readahead_prefetch(ctx)
+        thread = ctx.get(_READAHEAD_THREAD_KEY)
+        assert isinstance(ctx.get(_READAHEAD_BUFFER_KEY), ReadAheadBuffer)
+        assert isinstance(thread, threading.Thread)
+        assert thread.daemon is True
+        thread.join(2.0)
+
+
+def test_start_readahead_prefetch_runtimeerror_pops_keys():
+    proxy = _make_proxy()
+    ctx = _prefetchable_ctx(mb=256)
+    with patch.object(
+        threading.Thread, "start", side_effect=RuntimeError("no threads")
+    ):
+        proxy._start_readahead_prefetch(ctx)
+    assert _READAHEAD_BUFFER_KEY not in ctx
+    assert _READAHEAD_THREAD_KEY not in ctx
+
+
+def test_cleanup_session_stops_readahead_buffer():
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10)
+    ctx = {_READAHEAD_BUFFER_KEY: buf}
+    stream_proxy.StreamProxy._cleanup_session(ctx, wait_for_process=False)
+    assert buf.should_stop() is True
+
+
+def test_cleanup_session_no_buffer_is_noop():
+    # Should not raise when there is no read-ahead buffer attached.
+    stream_proxy.StreamProxy._cleanup_session({}, wait_for_process=False)
+
+
+# ---------------------------------------------------------------------------
+# Seek correctness end-to-end (handler level)
+# ---------------------------------------------------------------------------
+
+
+def test_post_seek_window_returns_blank_until_repoint():
+    handler = _make_handler()
+    buf = ReadAheadBuffer(cap_bytes=1024, content_length=10_000)
+    buf.append(0, b"ABCDEFGHIJ")
+    ctx = {_READAHEAD_BUFFER_KEY: buf}
+    # A real seek outside the window discards the stale window.
+    buf.note_seek(5_000)
+    # The first post-seek read must MISS (so it falls through to upstream),
+    # never feeding stale wrong-offset bytes.
+    assert handler._serve_from_readahead(ctx, 5_000, 5_099) == 0
+    handler.wfile.write.assert_not_called()

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1207,6 +1207,94 @@ def test_find_video_file_prefers_dir_tagged_episode_over_larger_sibling(
 
 @patch("resources.lib.webdav._get_settings")
 @patch("resources.lib.webdav.urlopen")
+def test_find_video_file_nearest_dir_tag_not_masked_by_ancestor_pack(
+    mock_urlopen, mock_settings
+):
+    """When the NEAREST parent dir carries its OWN episode tag it is
+    authoritative -- an ancestor pack folder (Show.S01E02.Pack) must NOT
+    rescue a wrong nearer subfolder (Show.S01E03). The real S01E02 sibling
+    wins, not the larger S01E03."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Show.S01E02.Pack/", True, None),
+            ("/content/Show.S01E02.Pack/Show.S01E02/", True, None),
+            ("/content/Show.S01E02.Pack/Show.S01E03/", True, None),
+        ]
+    )
+    e02 = _propfind_listing(
+        [
+            ("/content/Show.S01E02.Pack/Show.S01E02/", True, None),
+            ("/content/Show.S01E02.Pack/Show.S01E02/video.mkv", False, 1000000000),
+        ]
+    )
+    e03 = _propfind_listing(
+        [
+            ("/content/Show.S01E02.Pack/Show.S01E03/", True, None),
+            ("/content/Show.S01E02.Pack/Show.S01E03/video.mkv", False, 5000000000),
+        ]
+    )
+
+    def propfind(req, **_kw):
+        u = req.full_url
+        if u.endswith("/Show.S01E02.Pack/"):
+            return _webdav_response(parent)
+        if u.endswith("/Show.S01E02/"):
+            return _webdav_response(e02)
+        if u.endswith("/Show.S01E03/"):
+            return _webdav_response(e03)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(u))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file(
+        "/content/Show.S01E02.Pack/", title_hint="Show.S01E02.1080p.WEB-DL"
+    )
+
+    # NOT the larger S01E03: the nearest dir's own tag rules it out even
+    # though the ancestor pack (Show.S01E02.Pack) covers the requested E02.
+    assert path == "/content/Show.S01E02.Pack/Show.S01E02/video.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_grandparent_tag_matches_when_nearest_dir_generic(
+    mock_urlopen, mock_settings
+):
+    """When the nearest dir is generic ("1080p") with no tag of its own, the
+    fallback widens to the full ancestor path so a grandparent's episode tag
+    (Show.S01E02) still supplies the match -- locks in the widen branch."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Show.S01E02/", True, None),
+            ("/content/Show.S01E02/1080p/", True, None),
+        ]
+    )
+    nested = _propfind_listing(
+        [
+            ("/content/Show.S01E02/1080p/", True, None),
+            ("/content/Show.S01E02/1080p/video.mkv", False, 1000000000),
+        ]
+    )
+
+    def propfind(req, **_kw):
+        u = req.full_url
+        if u.endswith("/Show.S01E02/"):
+            return _webdav_response(parent)
+        if u.endswith("/1080p/"):
+            return _webdav_response(nested)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(u))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Show.S01E02/", title_hint="Show.S01E02.1080p")
+
+    assert path == "/content/Show.S01E02/1080p/video.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
 def test_find_video_file_basename_episode_overrides_parent_range_dir(
     mock_urlopen, mock_settings
 ):
@@ -1396,6 +1484,48 @@ def test_episode_tags_expands_episode_ranges():
     # Over-match guard: resolutions/codecs/season ranges do NOT register.
     assert _episode_tags("Movie.2019.1920x1080.x265.mkv") == frozenset()
     assert _episode_tags("Show.S01-S03.Complete.1080p.mkv") == frozenset()
+
+
+def test_episode_tags_expands_nxn_ranges():
+    from resources.lib.webdav import _episode_tags
+
+    # NxN range notation ("1x01-03", "1x01-1x03") covers the middle episode,
+    # mirroring the SxxExx range expansion.
+    assert _episode_tags("Show.1x01-03.mkv") == frozenset({(1, 1), (1, 2), (1, 3)})
+    assert _episode_tags("Show.1x01-1x03.mkv") == frozenset({(1, 1), (1, 2), (1, 3)})
+    assert _episode_tags("Show.10x01-10x12.mkv") == frozenset(
+        {(10, e) for e in range(1, 13)}
+    )
+    # Single NxN unchanged; resolutions/codecs still excluded.
+    assert _episode_tags("Show.1x02.mkv") == frozenset({(1, 2)})
+    assert _episode_tags("Movie.1920x1080.mkv") == frozenset()
+    assert _episode_tags("Movie.1280x720.x264.mkv") == frozenset()
+    assert _episode_tags("Movie.3840x2160.mkv") == frozenset()
+    # Adjacent dot-separated NxN tags must NOT collapse into a range (the
+    # range regex requires a literal '-').
+    assert _episode_tags("Doctor.Who.2x05.2x06.mkv") == frozenset({(2, 5), (2, 6)})
+    # Reversed / cross-season spans: literal endpoints survive via the
+    # standalone NxN loop, no explosion.
+    assert _episode_tags("Show.1x05-1x02.mkv") == frozenset({(1, 2), (1, 5)})
+    assert _episode_tags("Show.1x10-2x02.mkv") == frozenset({(1, 10), (2, 2)})
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_matches_nxn_episode_in_range_pack(mock_urlopen, mock_settings):
+    """A request for a middle episode (1x02) must pick the NxN range pack that
+    covers it (1x01-03) over a larger non-covering range pack (1x04-06)."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.1x01-03.mkv", False, 8000000000),
+            ("/content/Show/Show.1x04-06.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+    path = find_video_file("/content/Show/", title_hint="Show 1x02")
+    assert path == "/content/Show/Show.1x01-03.mkv"
 
 
 @patch("resources.lib.webdav._get_settings")

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1273,3 +1273,130 @@ def test_find_video_stream_for_folder_passes_title_hint(mock_urlopen, mock_setti
 
     assert video_path == "/content/Show/Show.S02E05.1080p.mkv"
     assert stream_url.endswith("/content/Show/Show.S02E05.1080p.mkv")
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_recurses_past_generic_nonepisode_at_current_level(
+    mock_urlopen, mock_settings
+):
+    """A generic current-level video that shares show tokens but carries NO
+    SxxExx tag scores non-negative and would be returned before scanning
+    subdirs. With an episode hint, recurse first so the requested episode
+    living in a subfolder is found instead of the loose token match."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Pack/", True, None),
+            # Generic (no SxxExx) video at the CURRENT level. It shares show
+            # tokens with the hint, so it scores >= 0 and the old gate (which
+            # only recursed on a confirmed wrong-episode < 0 score) returned it
+            # immediately, never scanning E05/.
+            ("/content/Pack/Show.Sample.1080p.WEB-DL.mkv", False, 50000000),
+            ("/content/Pack/E05/", True, None),
+        ]
+    )
+    e05 = _propfind_listing(
+        [
+            ("/content/Pack/E05/", True, None),
+            ("/content/Pack/E05/Show.S02E05.1080p.WEB-DL.mkv", False, 2000000000),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Pack/"):
+            return _webdav_response(parent)
+        if url.endswith("/E05/"):
+            return _webdav_response(e05)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+
+    assert path == "/content/Pack/E05/Show.S02E05.1080p.WEB-DL.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_movie_hint_keeps_largest_over_token_heavy_extra(
+    mock_urlopen, mock_settings
+):
+    """For a movie hint (no SxxExx tag) the large feature must win over a
+    small, token-rich extra/trailer. Splitting the score so raw token overlap
+    ranks BELOW size keeps the feature from being hijacked by a featurette
+    that happens to share more tokens with the release name."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Dune/", True, None),
+            ("/content/Dune/Dune.mkv", False, 80_000_000_000),
+            (
+                "/content/Dune/Dune.Part.Two.2024.Behind.The.Scenes.2160p.mkv",
+                False,
+                300_000_000,
+            ),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file(
+        "/content/Dune/",
+        title_hint="Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX-FraMeSToR",
+    )
+
+    assert path == "/content/Dune/Dune.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_movie_hint_keeps_largest_across_sibling_subfolders(
+    mock_urlopen, mock_settings
+):
+    """The same size-over-token-overlap rule must hold across sibling
+    subfolders (covers the _find_video_file_in_subdirs key change): the large
+    feature in Movie/ beats the small token-heavy extra in Extras/."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Dune/", True, None),
+            ("/content/Dune/Movie/", True, None),
+            ("/content/Dune/Extras/", True, None),
+        ]
+    )
+    movie = _propfind_listing(
+        [
+            ("/content/Dune/Movie/", True, None),
+            ("/content/Dune/Movie/Dune.mkv", False, 80_000_000_000),
+        ]
+    )
+    extras = _propfind_listing(
+        [
+            ("/content/Dune/Extras/", True, None),
+            (
+                "/content/Dune/Extras/Dune.Part.Two.2024.Behind.The.Scenes.2160p.mkv",
+                False,
+                300_000_000,
+            ),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Dune/"):
+            return _webdav_response(parent)
+        if url.endswith("/Movie/"):
+            return _webdav_response(movie)
+        if url.endswith("/Extras/"):
+            return _webdav_response(extras)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file(
+        "/content/Dune/",
+        title_hint="Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX-FraMeSToR",
+    )
+
+    assert path == "/content/Dune/Movie/Dune.mkv"

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1047,3 +1047,229 @@ def test_check_file_in_folder_returns_not_found_when_missing(mock_find):
     path, err = check_file_in_folder("/content/Missing/")
     assert path is None
     assert err == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# F8: episode-hint preference for multi-episode packs
+# ---------------------------------------------------------------------------
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_prefers_title_hint_over_largest(mock_urlopen, mock_settings):
+    """With a requested episode hint, the name-matching video wins even when a
+    different episode in the same pack is larger."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S02E05.1080p.mkv", False, 2000000000),
+            ("/content/Show/Show.S02E06.1080p.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file("/content/Show/", title_hint="Show.S02E05.1080p.WEB-DL")
+
+    assert path == "/content/Show/Show.S02E05.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_without_hint_keeps_largest(mock_urlopen, mock_settings):
+    """No hint -> preserve the existing largest-video behavior."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S02E05.1080p.mkv", False, 2000000000),
+            ("/content/Show/Show.S02E06.1080p.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file("/content/Show/")
+
+    assert path == "/content/Show/Show.S02E06.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_hint_no_match_falls_back_to_largest(
+    mock_urlopen, mock_settings
+):
+    """A hint that matches no sibling video still returns the largest video."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S02E05.1080p.mkv", False, 2000000000),
+            ("/content/Show/Show.S02E06.1080p.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file("/content/Show/", title_hint="Show.S05E99.1080p.WEB-DL")
+
+    assert path == "/content/Show/Show.S02E06.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_prefers_hint_across_sibling_subfolders(
+    mock_urlopen, mock_settings
+):
+    """The episode hint must steer selection across sibling subfolders, not
+    just files within one folder."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Pack/", True, None),
+            ("/content/Pack/E05/", True, None),
+            ("/content/Pack/E06/", True, None),
+        ]
+    )
+    e05 = _propfind_listing(
+        [
+            ("/content/Pack/E05/", True, None),
+            ("/content/Pack/E05/Show.S02E05.1080p.mkv", False, 2000000000),
+        ]
+    )
+    e06 = _propfind_listing(
+        [
+            ("/content/Pack/E06/", True, None),
+            ("/content/Pack/E06/Show.S02E06.1080p.mkv", False, 9000000000),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Pack/"):
+            return _webdav_response(parent)
+        if url.endswith("/E05/"):
+            return _webdav_response(e05)
+        if url.endswith("/E06/"):
+            return _webdav_response(e06)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+
+    assert path == "/content/Pack/E05/Show.S02E05.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_recurses_past_wrong_episode_at_current_level(
+    mock_urlopen, mock_settings
+):
+    """When the only video at the current level is an explicit episode MISMATCH
+    and a hint was given, prefer recursing into siblings that may hold the
+    requested episode before falling back to the wrong-episode file."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Pack/", True, None),
+            # A wrong-episode video sits at the CURRENT level (would normally be
+            # returned immediately, blocking the descent into Extras/).
+            ("/content/Pack/Show.S02E06.1080p.mkv", False, 9000000000),
+            ("/content/Pack/Extras/", True, None),
+        ]
+    )
+    extras = _propfind_listing(
+        [
+            ("/content/Pack/Extras/", True, None),
+            ("/content/Pack/Extras/Show.S02E05.1080p.mkv", False, 2000000000),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Pack/"):
+            return _webdav_response(parent)
+        if url.endswith("/Extras/"):
+            return _webdav_response(extras)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+
+    assert path == "/content/Pack/Extras/Show.S02E05.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_keeps_wrong_episode_when_siblings_have_no_match(
+    mock_urlopen, mock_settings
+):
+    """If recursion finds no matching episode, fall back to the current-level
+    (mismatched) video rather than returning nothing."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Pack/", True, None),
+            ("/content/Pack/Show.S02E06.1080p.mkv", False, 9000000000),
+            ("/content/Pack/Empty/", True, None),
+        ]
+    )
+    empty = _propfind_listing([("/content/Pack/Empty/", True, None)])
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Pack/"):
+            return _webdav_response(parent)
+        if url.endswith("/Empty/"):
+            return _webdav_response(empty)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+
+    assert path == "/content/Pack/Show.S02E06.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_matches_middle_episode_of_multi_ep_tag(
+    mock_urlopen, mock_settings
+):
+    """A multi-episode file like S01E01E02E03 must match a request for a middle
+    episode (E02), not only the first listed episode."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S01E01E02E03.1080p.mkv", False, 2000000000),
+            ("/content/Show/Show.S01E04.1080p.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+
+    assert path == "/content/Show/Show.S01E01E02E03.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_stream_for_folder_passes_title_hint(mock_urlopen, mock_settings):
+    """find_video_stream_for_folder threads the hint into find_video_file."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S02E05.1080p.mkv", False, 2000000000),
+            ("/content/Show/Show.S02E06.1080p.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    video_path, stream_url, _headers = find_video_stream_for_folder(
+        "/content/Show/", title_hint="Show.S02E05.1080p.WEB-DL"
+    )
+
+    assert video_path == "/content/Show/Show.S02E05.1080p.mkv"
+    assert stream_url.endswith("/content/Show/Show.S02E05.1080p.mkv")

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1095,6 +1095,48 @@ def test_find_video_file_without_hint_keeps_largest(mock_urlopen, mock_settings)
 
 @patch("resources.lib.webdav._get_settings")
 @patch("resources.lib.webdav.urlopen")
+def test_find_video_file_without_hint_recurses_past_sizeless_top_level_video(
+    mock_urlopen, mock_settings
+):
+    """A top-level video with a missing getcontentlength (size 0) must NOT
+    pre-empt recursion on the no-hint path. main kept best_size=0 with a
+    strict ``size > best_size``, so a size-0 file was never adopted and the
+    function recursed into the subdir holding the real feature. The
+    hinted-selection rewrite must reproduce that EXACTLY (deliberate decision
+    f12b3c3); otherwise a top-level placeholder/teaser lacking a content
+    length is played instead of the real movie in the subfolder."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Movie/", True, None),
+            ("/content/Movie/teaser.mkv", False, None),  # no getcontentlength
+            ("/content/Movie/Disc1/", True, None),
+        ]
+    )
+    disc1 = _propfind_listing(
+        [
+            ("/content/Movie/Disc1/", True, None),
+            ("/content/Movie/Disc1/feature.mkv", False, 9000000000),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Movie/"):
+            return _webdav_response(parent)
+        if url.endswith("/Disc1/"):
+            return _webdav_response(disc1)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Movie/")
+
+    assert path == "/content/Movie/Disc1/feature.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
 def test_find_video_file_hint_no_match_falls_back_to_largest(
     mock_urlopen, mock_settings
 ):

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1161,6 +1161,109 @@ def test_find_video_file_prefers_hint_across_sibling_subfolders(
 
 @patch("resources.lib.webdav._get_settings")
 @patch("resources.lib.webdav.urlopen")
+def test_find_video_file_prefers_dir_tagged_episode_over_larger_sibling(
+    mock_urlopen, mock_settings
+):
+    """When the SxxExx tag is on the DIRECTORY and the file is generically
+    named, the requested episode's folder must win over a larger wrong-episode
+    sibling -- the basename carries no tag, so the parent dir supplies it."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S01E02.1080p/", True, None),
+            ("/content/Show/Show.S01E03.1080p/", True, None),
+        ]
+    )
+    e02 = _propfind_listing(
+        [
+            ("/content/Show/Show.S01E02.1080p/", True, None),
+            ("/content/Show/Show.S01E02.1080p/video.mkv", False, 1000000000),
+        ]
+    )
+    e03 = _propfind_listing(
+        [
+            ("/content/Show/Show.S01E03.1080p/", True, None),
+            ("/content/Show/Show.S01E03.1080p/video.mkv", False, 5000000000),
+        ]
+    )
+
+    def propfind(req, **_kw):
+        u = req.full_url
+        if u.endswith("/Show/"):
+            return _webdav_response(parent)
+        if u.endswith("/Show.S01E02.1080p/"):
+            return _webdav_response(e02)
+        if u.endswith("/Show.S01E03.1080p/"):
+            return _webdav_response(e03)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(u))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+
+    assert path == "/content/Show/Show.S01E02.1080p/video.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_basename_episode_overrides_parent_range_dir(
+    mock_urlopen, mock_settings
+):
+    """Regression guard for layered-not-union: a matching DIRECTORY range tag
+    must NOT mask a wrong-episode FILENAME. The basename's own tag is
+    authoritative, so the larger wrong-episode file stays rejected."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show.S02E01-E10.Pack/", True, None),
+            (
+                "/content/Show.S02E01-E10.Pack/Show.S02E07.1080p.mkv",
+                False,
+                9000000000,
+            ),
+            (
+                "/content/Show.S02E01-E10.Pack/Show.S02E05.1080p.mkv",
+                False,
+                2000000000,
+            ),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file(
+        "/content/Show.S02E01-E10.Pack/", title_hint="Show.S02E05.1080p.WEB-DL"
+    )
+
+    # NOT the larger E07: its own basename tag rules it out even though the
+    # parent dir range (S02E01-E10) covers the requested E05.
+    assert path == "/content/Show.S02E01-E10.Pack/Show.S02E05.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_season_complete_parent_does_not_falsely_match(
+    mock_urlopen, mock_settings
+):
+    """Boundary: a season-complete parent folder (no episode tag) must not
+    falsely supply an episode tag to generic videos -- largest-wins holds."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show.S01.Complete/", True, None),
+            ("/content/Show.S01.Complete/part1.mkv", False, 2000000000),
+            ("/content/Show.S01.Complete/part2.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file("/content/Show.S01.Complete/", title_hint="Show.S01E02")
+
+    assert path == "/content/Show.S01.Complete/part2.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
 def test_find_video_file_recurses_past_wrong_episode_at_current_level(
     mock_urlopen, mock_settings
 ):
@@ -1261,6 +1364,18 @@ def test_episode_tags_recognizes_nxnn_and_ignores_resolution():
     assert _episode_tags("Movie.1920x1080.mkv") == frozenset()
     assert _episode_tags("Movie.2160p.x265.mkv") == frozenset()
     assert _episode_tags("Show.S02E05.mkv") == frozenset({(2, 5)})  # unchanged
+    # Adjacent NxNN tags must ALL register: a consuming boundary ate the
+    # separator between neighbours and dropped the second (and the middle of
+    # a 3-pack). Zero-width digit lookarounds keep every tag.
+    assert _episode_tags("Show.1x01.1x02.mkv") == frozenset({(1, 1), (1, 2)})
+    assert _episode_tags("Doctor.Who.2x05.2x06.mkv") == frozenset({(2, 5), (2, 6)})
+    assert _episode_tags("Pack.1x01.1x02.1x03.mkv") == frozenset(
+        {(1, 1), (1, 2), (1, 3)}
+    )
+    # Exclusions must still hold under the lookaround (the \d{1,2} season cap
+    # is what excludes resolutions/codecs, not the boundary).
+    assert _episode_tags("Movie.1920x1080.mkv") == frozenset()
+    assert _episode_tags("Movie.2160p.x265.mkv") == frozenset()
 
 
 def test_episode_tags_expands_episode_ranges():
@@ -1319,6 +1434,26 @@ def test_find_video_file_matches_nxnn_episode_notation(mock_urlopen, mock_settin
     path = find_video_file("/content/Show/", title_hint="Show 2x05")
 
     assert path == "/content/Show/Show.2x05.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_matches_nxnn_multi_episode_pack(mock_urlopen, mock_settings):
+    """A folder whose only/largest file is an adjacent-NxNN multi-episode pack
+    (2x05.2x06) must be returned for a hint covering one of its episodes,
+    guarding the +1000 scoring short-circuit (not just the regex)."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Doctor.Who.2x05.2x06.mkv", False, 5000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file("/content/Show/", title_hint="Doctor Who 2x06")
+
+    assert path == "/content/Show/Doctor.Who.2x05.2x06.mkv"
 
 
 @patch("resources.lib.webdav._get_settings")

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1263,6 +1263,44 @@ def test_episode_tags_recognizes_nxnn_and_ignores_resolution():
     assert _episode_tags("Show.S02E05.mkv") == frozenset({(2, 5)})  # unchanged
 
 
+def test_episode_tags_expands_episode_ranges():
+    from resources.lib.webdav import _episode_tags
+
+    # SxxEaa-Ebb and SxxEaa-bb both cover the middle episode.
+    assert _episode_tags("Show.S01E01-E03.1080p.mkv") == frozenset(
+        {(1, 1), (1, 2), (1, 3)}
+    )
+    assert _episode_tags("Show.S01E01-03.1080p.mkv") == frozenset(
+        {(1, 1), (1, 2), (1, 3)}
+    )
+    # Single episode is unchanged (no over-expansion).
+    assert _episode_tags("Show.S01E02.mkv") == frozenset({(1, 2)})
+    # Absurd / reversed ranges do not explode; literal endpoints survive.
+    assert _episode_tags("Show.S01E01-E999.mkv") == frozenset({(1, 1), (1, 999)})
+    assert _episode_tags("Show.S01E05-E01.mkv") == frozenset({(1, 1), (1, 5)})
+    # Over-match guard: resolutions/codecs/season ranges do NOT register.
+    assert _episode_tags("Movie.2019.1920x1080.x265.mkv") == frozenset()
+    assert _episode_tags("Show.S01-S03.Complete.1080p.mkv") == frozenset()
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_matches_episode_in_range_pack(mock_urlopen, mock_settings):
+    """A request for a middle episode (E02) must pick the range pack that
+    covers it (S01E01-E03) over a larger non-covering range pack."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S01E01-E03.1080p.mkv", False, 8000000000),
+            ("/content/Show/Show.S01E04-E06.1080p.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+    assert path == "/content/Show/Show.S01E01-E03.1080p.mkv"
+
+
 @patch("resources.lib.webdav._get_settings")
 @patch("resources.lib.webdav.urlopen")
 def test_find_video_file_matches_nxnn_episode_notation(mock_urlopen, mock_settings):

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1812,3 +1812,152 @@ def test_find_video_file_movie_hint_keeps_largest_across_sibling_subfolders(
     )
 
     assert path == "/content/Dune/Movie/Dune.mkv"
+
+
+def test_episode_tags_ignores_aspect_ratio_nxn_tokens():
+    """Aspect-ratio NxN tokens (16x9, 4x3, 21x9, ...) must NOT register as
+    episodes, while real un-padded NxN episodes (2x3, 1x9) still do."""
+    from resources.lib.webdav import _episode_tags
+
+    # Well-known aspect ratios yield no episode tag.
+    assert _episode_tags("video.16x9.mkv") == frozenset()
+    assert _episode_tags("video.4x3.mkv") == frozenset()
+    assert _episode_tags("video.21x9.mkv") == frozenset()
+    assert _episode_tags("video.16x10.mkv") == frozenset()
+    # Real episodes -- including the un-padded forms -- still register.
+    assert _episode_tags("Show.2x3.mkv") == frozenset({(2, 3)})
+    assert _episode_tags("Show.1x9.mkv") == frozenset({(1, 9)})
+    assert _episode_tags("Show.2x05.mkv") == frozenset({(2, 5)})
+    assert _episode_tags("Show.10x01.mkv") == frozenset({(10, 1)})
+    assert _episode_tags("Show.1x02.mkv") == frozenset({(1, 2)})
+    assert _episode_tags("Show.12x05.mkv") == frozenset({(12, 5)})
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_aspect_ratio_file_does_not_beat_real_episode(
+    mock_urlopen, mock_settings
+):
+    """An aspect-ratio-named file (video.16x9.mkv) under the requested
+    episode's folder must NOT be mis-parsed as episode (16, 9). Under the bug
+    its basename tag (16, 9) was treated as authoritative and never fell back
+    to the parent's real S01E02, so the file scored a wrong-episode -1000 and a
+    larger wrong-episode sibling (S01E03) wrongly won. After the fix the 16x9
+    basename carries no tag, falls back to the parent S01E02, and wins."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S01E02/", True, None),
+            ("/content/Show/Show.S01E03/", True, None),
+        ]
+    )
+    e02 = _propfind_listing(
+        [
+            ("/content/Show/Show.S01E02/", True, None),
+            ("/content/Show/Show.S01E02/video.16x9.mkv", False, 2000000000),
+        ]
+    )
+    e03 = _propfind_listing(
+        [
+            ("/content/Show/Show.S01E03/", True, None),
+            ("/content/Show/Show.S01E03/video.mkv", False, 9000000000),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Show/"):
+            return _webdav_response(parent)
+        if url.endswith("/Show.S01E02/"):
+            return _webdav_response(e02)
+        if url.endswith("/Show.S01E03/"):
+            return _webdav_response(e03)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+
+    assert path == "/content/Show/Show.S01E02/video.16x9.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_movie_hint_recurses_past_zero_size_token_file(
+    mock_urlopen, mock_settings
+):
+    """A movie hint (no episode tags) must not adopt a zero-size token-matching
+    placeholder at the current level; recursion finds the real large feature in
+    a subfolder. Token overlap must not outrank size."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Dune/", True, None),
+            ("/content/Dune/Dune.Part.Two.teaser.mkv", False, None),
+            ("/content/Dune/Feature/", True, None),
+        ]
+    )
+    feature = _propfind_listing(
+        [
+            ("/content/Dune/Feature/", True, None),
+            ("/content/Dune/Feature/Dune.Part.Two.2024.mkv", False, 9000000000),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Dune/"):
+            return _webdav_response(parent)
+        if url.endswith("/Feature/"):
+            return _webdav_response(feature)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file(
+        "/content/Dune/", title_hint="Dune.Part.Two.2024.2160p.BluRay"
+    )
+
+    assert path == "/content/Dune/Feature/Dune.Part.Two.2024.mkv"
+
+
+def test_episode_tags_expands_repeated_season_ranges():
+    """The repeated-season range form S01E01-S01E03 must expand to the full
+    inclusive span, same as S01E01-E03."""
+    from resources.lib.webdav import _episode_tags
+
+    assert _episode_tags("Show.S01E01-S01E03.1080p.mkv") == frozenset(
+        {(1, 1), (1, 2), (1, 3)}
+    )
+    # A wider repeated-season range still expands.
+    assert _episode_tags("Show.S02E01-S02E05.mkv") == frozenset(
+        {(2, 1), (2, 2), (2, 3), (2, 4), (2, 5)}
+    )
+    # Cross-season range keeps only the literal endpoints (backref forces the
+    # same season, so the repeated-season expansion does not apply).
+    assert _episode_tags("Show.S01E10-S02E02.mkv") == frozenset({(1, 10), (2, 2)})
+    # Resolutions / codecs still register nothing.
+    assert _episode_tags("Movie.1920x1080.x265.mkv") == frozenset()
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_repeated_season_pack_covers_middle_episode(
+    mock_urlopen, mock_settings
+):
+    """A hint for a covered middle episode (S01E02) must select the
+    repeated-season pack S01E01-S01E03 over a larger non-covering sibling."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.S01E01-S01E03.1080p.mkv", False, 2000000000),
+            ("/content/Show/Show.S01E05.1080p.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+
+    assert path == "/content/Show/Show.S01E01-S01E03.1080p.mkv"

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1253,6 +1253,73 @@ def test_find_video_file_matches_middle_episode_of_multi_ep_tag(
     assert path == "/content/Show/Show.S01E01E02E03.1080p.mkv"
 
 
+def test_episode_tags_recognizes_nxnn_and_ignores_resolution():
+    from resources.lib.webdav import _episode_tags
+
+    assert _episode_tags("Show.2x05.mkv") == frozenset({(2, 5)})
+    assert _episode_tags("Show.02x05.1080p.mkv") == frozenset({(2, 5)})
+    assert _episode_tags("Movie.1920x1080.mkv") == frozenset()
+    assert _episode_tags("Movie.2160p.x265.mkv") == frozenset()
+    assert _episode_tags("Show.S02E05.mkv") == frozenset({(2, 5)})  # unchanged
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_matches_nxnn_episode_notation(mock_urlopen, mock_settings):
+    """A request whose title uses NxNN notation (2x05) must pick the requested
+    episode, not the larger sibling -- same guarantee as SxxExx."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    listing = _propfind_listing(
+        [
+            ("/content/Show/", True, None),
+            ("/content/Show/Show.2x05.1080p.mkv", False, 1000000000),
+            ("/content/Show/Show.2x06.1080p.mkv", False, 9000000000),
+        ]
+    )
+    mock_urlopen.return_value = _webdav_response(listing)
+
+    path = find_video_file("/content/Show/", title_hint="Show 2x05")
+
+    assert path == "/content/Show/Show.2x05.1080p.mkv"
+
+
+@patch("resources.lib.webdav._get_settings")
+@patch("resources.lib.webdav.urlopen")
+def test_find_video_file_keeps_larger_current_level_over_smaller_equalscore_sibling(
+    mock_urlopen, mock_settings
+):
+    """A deferred current-level fallback (generic, ep_score 0) must not be
+    replaced by a SMALLER sibling that merely ties on episode score."""
+    mock_settings.return_value = _SETTINGS_WITH_AUTH
+    parent = _propfind_listing(
+        [
+            ("/content/Pack/", True, None),
+            ("/content/Pack/Show.Complete.1080p.BIG.mkv", False, 9000000000),
+            ("/content/Pack/Extras/", True, None),
+        ]
+    )
+    extras = _propfind_listing(
+        [
+            ("/content/Pack/Extras/", True, None),
+            ("/content/Pack/Extras/blooper.SMALL.mkv", False, 1000000),
+        ]
+    )
+
+    def propfind(req, **_kwargs):
+        url = req.full_url
+        if url.endswith("/Pack/"):
+            return _webdav_response(parent)
+        if url.endswith("/Extras/"):
+            return _webdav_response(extras)
+        raise AssertionError("unexpected PROPFIND URL: {}".format(url))
+
+    mock_urlopen.side_effect = propfind
+
+    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+
+    assert path == "/content/Pack/Show.Complete.1080p.BIG.mkv"
+
+
 @patch("resources.lib.webdav._get_settings")
 @patch("resources.lib.webdav.urlopen")
 def test_find_video_stream_for_folder_passes_title_hint(mock_urlopen, mock_settings):


### PR DESCRIPTION
## Overview

Hardens `plugin.video.nzbdav` pass-through streaming end-to-end: tiered same-release fallback matching, recovery that holds the connection through transient backend trouble instead of black-screening, a background read-ahead so pausing actually builds a buffer, and picker fixes for same-name release disambiguation. 27 commits, all signed/verified.

`24 files changed, +7,643 / −261`. Full suite **1815 passed / 3 skipped**, ruff+black clean, pylint **10.00/10**, Python 3.8-safe, no new deps.

---

### 1. Read-ahead prefetch — *pausing now builds a real lead*
nzbdav is on-demand: it only fetches Usenet articles for byte ranges Kodi actively reads, so a pause never pre-buffers and a momentary bitrate peak above the fetch rate starves the decoder.
- **`9d368c6`** — per-session `ReadAheadBuffer` + `nzbdav-readahead` daemon that pulls ahead of the play head *independent of Kodi demand* (incl. while paused) into a bounded window. Reads consult the window first and fall through to the existing recovery path on a miss (purely additive). Gated on a new `readahead_buffer_mb` setting (default 256, 0=off, clamp 0–4096).
- **`bb12246`** — daemon re-reads `remote_url`/`auth_header` each iteration so a live fallback cutover repoints the prefetch to the new source instead of hammering the dead primary.

### 2. Black-screen / starvation / recovery hardening
- **`6bbb8cb`** — *patient forward-stall wait*: hold the client connection through a recoverable outage (AWAITING/UPSTREAM_ERROR) instead of closing → Kodi reading the close as demuxer EOF. Bounded by a budget that resets on genuine progress; new `passthrough_stall_wait` setting (default 120, clamp 0–600).
- **`6e9e5eb` / `a6b2425` / `b0a58a7`** — graceful-starvation guard: turn a silent black screen on a sub-bitrate backend into an explained "can't keep up" toast; gated on outage recency; covers the pure-slow give-up and suppresses a double toast.
- **`3c42e5b`** — mark Kodi-shutdown-during-forward-stall as a benign `client_disconnected` exit (was defaulting to "unknown" → spurious failure toast).
- **`7bd9eb4`** — keep the short first-byte retry ladder after the byte-0 prefetch prefix (a 64KB prefix had been flipping the first real read onto the long mid-file ladder → premature close).

### 3. Mid-stream upstream 404 → awaiting-download
- **`6920c25`** — nzbdav returns HTTP 404 for ranges past its download high-water; this was classified as a terminal client error → hard abort. Now an established-read 404 (`start>0`) reclassifies as awaiting-download → retry ladder + forward-stall wait + fallback cutover. Byte-0 404 and 401/403 stay terminal. **`1ebe744`** locks the written-prefix RECOVERABLE branch.

### 4. Tiered same-release fallback matching + content-identity gates
- **`ab5976b`** + review rounds **`3df171f` `39b372c` `088fefe` `5cbc3ec` `3fd77ac`** — tiered same-release matching, bounded recovery exhaustion, content-identity gate fail-closed holes (part-vs-bare, empty-token, subtitled-sequel), webdav episode title-hint selection.
- **`7634d38`** — require **same release group** for a fallback (a different group's encode can't byte-match for a seamless cutover) + defer backup submission to 2 min into *playback* (not submission).
- **`71801d6` / `d72dd49`** — configurable submit defer, fail-closed same-resolution gate, exact-filename preference on the ranking path.
- **`bf7b615`** — corroborate disjoint-tail title overlap (rejects franchise siblings like *Fallout* vs *Dead Reckoning*) + test hygiene.
- **`2530644`** — webdav: a size-0 top-level video must not pre-empt recursion to the real feature in a subdir.

### 5. Picker — same-name release disambiguation
- **`bcbaaff` / `72f6ff6`** — disambiguate the "DL"/cached-stream match by **size**, not filename alone (incl. the RunScript completed re-fetch path).
- **`767fe0b`** — disambiguate same-name releases by **Usenet post-date** (age), persisted at submit, so "release X age 1d" ≠ "release X age 2d".

### 6. Release / config
- **`ae1369d` / `984e813`** — bump addon to v1.2.5, changelog hygiene.

---

## Testing & QA
- Full gate green: **1815 passed / 3 skipped**, lint 10.00/10 exit 0, py3.8-safe.
- Read-ahead validated through a 3-pass adversarial QA loop (review dimensions → per-finding adversarial verify → completeness critic). Pass 1 clean; pass 2 surfaced the cutover-staleness defect → fixed in `bb12246`; pass 3 clean → converged.

## Live validation (CoreELEC box)
Root-caused the user-reported pausing-on-a-fast-backend: nzbdav was using a **single NNTP connection** (~47 Mbit avg fetch, below the ~75 Mbit 4K-REMUX need) despite a 500 Mbit upstream. Raising nzbdav connections (1→75) lifted measured fetch to ~226 Mbit avg / 442 Mbit peak — above bitrate, pausing resolved. The read-ahead change is the addon-side complement (banks a lead, keeps fetching while paused). Addon deployed to the box (full rsync, md5-verified 40/40 files).


---

## 7. Dead-candidate exclusion + active-source invariant (`d2f5d57..038051a`)
Follow-up after a live blackscreen at ~89% of a 4K REMUX: nzbdav returned HTTP 500 for an article range (post incomplete on Usenet), and the fallback never validated because the two adopted standbys had **already failed as primary picker attempts** (article-not-found / invalid-NNTP) yet were still re-adopted as fallbacks.

- **`d2f5d57`** — new `resources/lib/dead_candidates.py`: `DeadCandidates` set (keyed by `nzb_url` + `nzo_id`) and `is_provably_dead_submit_error` (only `status=="timeout"` is *not* dead; everything else, incl. unknown, is dead).
- **`eb380c3` / `6be57be` / `4bb9257`** — resolver records primary terminal failures (`_poll_until_ready`) into a per-resolve dead-set, threads it + the primary `nzb_url` into the fallback submit worker, which **skips dead candidates and the primary's own release** before re-submitting and records provable submit errors.
- **`d7e95c8`** — `_playback_fallback_sources_for_stream` / `_arm_live_fallback_push` drop dead entries from the live push.
- **`0899a77` / `5c8e2f4`** — `stream_proxy._activate_fallback_source` re-adds the demoted previously-active source to the **end** of the pool (last resort), marked `validated=True` so the prevalidation warmer doesn't redundantly re-fingerprint it.
- **`038051a`** — de-flake of a pre-existing racy test (`test_prevalidated_fallback_reuses_current_probe`): replaced a wall-clock + global `call_count` assertion (which a leaked sibling read-ahead daemon could bump) with a deterministic behavioral assertion (zero stream-opens target the fallback URL).

**Goals:** dead releases never (re)enter the pool (timeouts stay eligible); the active primary is never its own backup until a cutover demotes it; honest prevalidation count.

**QA:** 3 adversarial review workflows + an opus code review, two consecutive clean passes. Gate: **1830 passed / 3 skipped / 13 deselected**, lint 10.00/10 exit 0, py3.8-safe.
