### PR TITLE
🎨 Palette: Add explicit keyboard navigation between list and scrollbar

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,7 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +234,7 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onleft>50</onleft>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
This commit fixes an accessibility issue in the Kodi interface (`results-dialog.xml`) where the scrollbar could not be accessed using directional keys (e.g. keyboard arrows or TV remote). Because Kodi doesn't automatically infer adjacent controls for navigation, explicit `<onright>` and `<onleft>` tags were added to enable fluid horizontal navigation between the main list and its associated scrollbar.

This improvement addresses a critical micro-UX issue for list navigation.

---
*PR created automatically by Jules for task [5081002209426934133](https://jules.google.com/task/5081002209426934133) started by @xbmc4lyfe*