### PR TITLE
⚡ Bolt: pre-compile regexes for performance

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -76,6 +76,8 @@ urlopen = _NO_REDIRECT_OPENER.open  # noqa: F811
 
 _SAFE_JOB_RE = re.compile(r"^[A-Za-z0-9._ \[\]-]+$")
 _CONTENT_RANGE_RE = re.compile(r"^bytes\s+(\d+)-(\d+)/(\d+|\*)$")
+_NON_WORD_RE = re.compile(r"[\W_]+")
+_JOB_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._ -]+")
 _FINGERPRINT_SAMPLE_COUNT = 100
 _FINGERPRINT_SMALL_SAMPLE_COUNT = 20
 _FINGERPRINT_DENSE_SAMPLE_MIN_BYTES = 1024 * 1024 * 1024
@@ -397,7 +399,7 @@ def _normalize_title(value):
     """Normalize release titles for conservative duplicate grouping."""
     if not isinstance(value, str):
         return ""
-    normalized = re.sub(r"[\W_]+", " ", value.lower())
+    normalized = _NON_WORD_RE.sub(" ", value.lower())
     return " ".join(normalized.split())
 
 
@@ -1663,7 +1665,7 @@ def attach_fallback_candidates_for_selection(selected, results, fallback_setting
 def build_fallback_job_name(title, nzb_url, index):
     """Return a stable, traceable nzbdav job name for a fallback candidate."""
     clean_title = title if isinstance(title, str) else ""
-    clean_title = re.sub(r"[^A-Za-z0-9._ -]+", " ", clean_title)
+    clean_title = _JOB_UNSAFE_RE.sub(" ", clean_title)
     clean_title = " ".join(clean_title.split())[:180].strip()
     if not clean_title:
         clean_title = "fallback"
@@ -1671,7 +1673,7 @@ def build_fallback_job_name(title, nzb_url, index):
     digest = hashlib.sha256(str(nzb_url).encode("utf-8")).hexdigest()[:8]
     job_name = "{} [fallback-{}-{}]".format(clean_title, index, digest)
     if not _SAFE_JOB_RE.match(job_name):
-        job_name = re.sub(r"[^A-Za-z0-9._ -]+", " ", job_name)
+        job_name = _JOB_UNSAFE_RE.sub(" ", job_name)
         job_name = " ".join(job_name.split())
     return job_name
 

--- a/repo/plugin.video.nzbdav/resources/lib/indexer_presets.py
+++ b/repo/plugin.video.nzbdav/resources/lib/indexer_presets.py
@@ -5,6 +5,9 @@
 
 import re
 
+_NON_ALPHANUMERIC_RE = re.compile(r"[^A-Za-z0-9]+")
+_UNDERSCORE_RE = re.compile(r"_+")
+
 DIRECT_FALLBACK_HOSTS = ("dognzb", "nzbplanet", "nzbgeek", "6box")
 DOGNZB_TVSEARCH_FALLBACK_HOSTS = ("dognzb",)
 RATE_LIMITED_CAPS_HOSTS = ("nzb.su", "nzb.life")
@@ -36,8 +39,8 @@ _PRESETS = (
 
 
 def slugify_preset_id(name):
-    value = re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").lower()
-    return re.sub(r"_+", "_", value)
+    value = _NON_ALPHANUMERIC_RE.sub("_", name).strip("_").lower()
+    return _UNDERSCORE_RE.sub("_", value)
 
 
 def _preset(indexer_id, name, api_url):

--- a/repo/plugin.video.nzbdav/resources/lib/nzb_manifest.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzb_manifest.py
@@ -33,6 +33,7 @@ _DOMINANT_BLOB_THRESHOLD_FRACTION = 0.80
 _SPLIT_PAYLOAD_MIN_FILE_COUNT = 10
 _SPLIT_PAYLOAD_MAX_SIZE_RATIO = 5
 _SYNTHETIC_VIDEO_MIN_PAYLOAD_BYTES = 100 * 1024 * 1024
+_NON_WORD_RE = re.compile(r"[\W_]+")
 
 
 def make_empty_manifest(reason, skipped_candidates=None):
@@ -68,9 +69,9 @@ def normalize_video_filename(value):
         return ""
     if "." in value:
         stem, ext = value.rsplit(".", 1)
-        stem = re.sub(r"[\W_]+", " ", stem.lower())
+        stem = _NON_WORD_RE.sub(" ", stem.lower())
         return "{}.{}".format(" ".join(stem.split()), ext.lower())
-    return " ".join(re.sub(r"[\W_]+", " ", value.lower()).split())
+    return " ".join(_NON_WORD_RE.sub(" ", value.lower()).split())
 
 
 def _strip_namespace(tag):
@@ -120,7 +121,7 @@ def _find_archive_base(subject):
     if not match:
         return ""
     base = match.group(1).strip().strip('"').strip("'")
-    base = re.sub(r"[\W_]+", " ", base.lower())
+    base = _NON_WORD_RE.sub(" ", base.lower())
     return " ".join(base.split())
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -64,6 +64,10 @@ from resources.lib.http_util import HTTP_USER_AGENT
 from resources.lib.http_util import notify as _notify
 from resources.lib.http_util import redact_text as _redact_text
 
+_FFMPEG_DURATION_RE = re.compile(r"Duration:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?")
+_SEGMENT_NORMALIZE_RE = re.compile(r"seg_0*(\d+)\.(m4s|ts)")
+_CONTENT_RANGE_BYTES_RE = re.compile(r"^bytes\s+0-0/(\d+)$")
+
 # Singleton proxy instance
 _proxy = None
 _proxy_lock = threading.Lock()
@@ -1436,7 +1440,7 @@ def _parse_ffmpeg_duration(stderr_text):
 
     Returns duration in seconds as a float, or None if not found.
     """
-    match = re.search(r"Duration:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?", stderr_text)
+    match = _FFMPEG_DURATION_RE.search(stderr_text)
     if not match:
         return None
     hours, minutes, seconds, frac = match.groups()
@@ -5207,7 +5211,7 @@ class HlsProducer:
         def _normalize_segment(match):
             return "seg_{}.{}".format(int(match.group(1)), match.group(2))
 
-        text = re.sub(r"seg_0*(\d+)\.(m4s|ts)", _normalize_segment, text)
+        text = _SEGMENT_NORMALIZE_RE.sub(_normalize_segment, text)
         return text.encode("utf-8")
 
     def _segment_complete(self, seg_n):
@@ -7624,7 +7628,7 @@ class StreamProxy:
                     status = getattr(resp, "status", None)
                     if status is None:
                         status = resp.getcode()
-                    match = re.match(r"^bytes\s+0-0/(\d+)$", cr.strip())
+                    match = _CONTENT_RANGE_BYTES_RE.match(cr.strip())
                     stream_length = int(match.group(1)) if match else 0
                     if status == 206 and stream_length == content_length_hint:
                         return content_length_hint


### PR DESCRIPTION
💡 What: Extracted several inline regular expressions (from `re.sub()`, `re.search()`, and `re.match()` calls) and pre-compiled them at the module level using `re.compile()` in `fallback_streams.py`, `indexer_presets.py`, `nzb_manifest.py`, and `stream_proxy.py`.
🎯 Why: To prevent the repeated overhead of compiling (or cache lookups for) regular expressions that are heavily used within tight loops or frequent function calls, such as those involved in title normalization or result filtering.
📊 Impact: Expected to yield a slight but consistent reduction in CPU overhead during heavy result filtering or log parsing, making operations measurably faster.
🔬 Measurement: Verify by running profiling tools or using `timeit` on the affected functions (like `_normalize_title` in `fallback_streams.py` or `slugify_preset_id` in `indexer_presets.py`) before and after the change; expect noticeable performance improvements under heavy loop loads.

---
*PR created automatically by Jules for task [11292716806344707024](https://jules.google.com/task/11292716806344707024) started by @xbmc4lyfe*