### PR TITLE
⚡ Bolt: Pre-compile regex in nzb_manifest.py loops

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/nzb_manifest.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzb_manifest.py
@@ -29,6 +29,8 @@ _METADATA_EXTENSION_RE = re.compile(
     r"\.(par2?|nfo|sfv|jpg|jpeg|png|gif|txt|url|lnk|srt|sub|idx|md5|sha\d*)\b",
     re.I,
 )
+# Pre-compile regex for performance in frequently called loops
+_NON_ALPHANUMERIC_RE = re.compile(r"[\W_]+")
 _DOMINANT_BLOB_THRESHOLD_FRACTION = 0.80
 _SPLIT_PAYLOAD_MIN_FILE_COUNT = 10
 _SPLIT_PAYLOAD_MAX_SIZE_RATIO = 5
@@ -68,9 +70,9 @@ def normalize_video_filename(value):
         return ""
     if "." in value:
         stem, ext = value.rsplit(".", 1)
-        stem = re.sub(r"[\W_]+", " ", stem.lower())
+        stem = _NON_ALPHANUMERIC_RE.sub(" ", stem.lower())
         return "{}.{}".format(" ".join(stem.split()), ext.lower())
-    return " ".join(re.sub(r"[\W_]+", " ", value.lower()).split())
+    return " ".join(_NON_ALPHANUMERIC_RE.sub(" ", value.lower()).split())
 
 
 def _strip_namespace(tag):
@@ -120,7 +122,7 @@ def _find_archive_base(subject):
     if not match:
         return ""
     base = match.group(1).strip().strip('"').strip("'")
-    base = re.sub(r"[\W_]+", " ", base.lower())
+    base = _NON_ALPHANUMERIC_RE.sub(" ", base.lower())
     return " ".join(base.split())
 
 


### PR DESCRIPTION
💡 **What:** The optimization implemented is moving an inline string regex `re.sub(r"[\W_]+", ...)` to a pre-compiled, module-level `re.Pattern` object in `repo/plugin.video.nzbdav/resources/lib/nzb_manifest.py`.
🎯 **Why:** To prevent repeated evaluation and dictionary lookups of the regex cache inside functions (`normalize_video_filename` and `_find_archive_base`) which are called frequently in a loop when parsing NZB files with many items.
📊 **Impact:** Reduces regex compilation and cache lookup overhead inside parser loops.
🔬 **Measurement:** Code execution is strictly functionally identical. Verified by full pass of `tests/test_nzb_manifest.py`.

---
*PR created automatically by Jules for task [16141119390713357095](https://jules.google.com/task/16141119390713357095) started by @xbmc4lyfe*