### PR TITLE
🎨 Palette: Add keyboard navigation support to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,7 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +234,7 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onleft>50</onleft>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
### 💡 What:
Added explicit directional navigation tags (`<onright>`, `<onleft>`) to the results list (`id="50"`) and scrollbar (`id="60"`) in the `results-dialog.xml` Kodi skin file.

### 🎯 Why:
Kodi does not automatically infer horizontal navigation paths between custom UI controls. Previously, users could not easily tab or use a remote's right directional key to jump from the search results list to the scrollbar to quickly scroll through many results.

### ♿ Accessibility:
Ensures keyboard and remote-control accessibility by fully linking the primary list focus with its adjacent scrollbar element, allowing users to scroll efficiently without a pointing device and cleanly return to the list when done.

Also added a journal entry to `.Jules/palette.md` noting the requirement to manually map explicit directional navigation tags (`<onleft>`, `<onright>`, `<onup>`, `<ondown>`) in Kodi XML skins.

---
*PR created automatically by Jules for task [605887866316136052](https://jules.google.com/task/605887866316136052) started by @xbmc4lyfe*