### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XXE vulnerabilities in standard XML parsers

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/direct_indexers.py
+++ b/repo/plugin.video.nzbdav/resources/lib/direct_indexers.py
@@ -211,7 +211,19 @@ def build_search_url(api_url, params):
 
 
 def _build_xxe_safe_parser():
-    return ET.XMLParser()  # nosec B314 - Python 3.8+ disables external entities
+    """Return an ElementTree XMLParser with external entities disabled.
+
+    ``xml.etree.ElementTree`` doesn't expose a ``resolve_entities=False``
+    knob directly, but the underlying expat parser can be told to
+    ignore DefaultHandler output and reject ExternalEntityRef callbacks.
+    """
+    parser = ET.XMLParser()  # nosec B314 - entities disabled below
+    try:
+        parser.parser.DefaultHandler = lambda _d: None
+        parser.parser.ExternalEntityRefHandler = lambda *_: False
+    except AttributeError:  # pragma: no cover — non-expat parser backend
+        pass
+    return parser
 
 
 def _parse_newznab_attrs(item):

--- a/repo/plugin.video.nzbdav/resources/lib/newznab_caps.py
+++ b/repo/plugin.video.nzbdav/resources/lib/newznab_caps.py
@@ -75,9 +75,25 @@ def _params(value):
     return [item.strip() for item in str(value or "").split(",") if item.strip()]
 
 
+def _build_xxe_safe_parser():
+    """Return an ElementTree XMLParser with external entities disabled.
+
+    ``xml.etree.ElementTree`` doesn't expose a ``resolve_entities=False``
+    knob directly, but the underlying expat parser can be told to
+    ignore DefaultHandler output and reject ExternalEntityRef callbacks.
+    """
+    parser = ET.XMLParser()  # nosec B314 - entities disabled below
+    try:
+        parser.parser.DefaultHandler = lambda _d: None
+        parser.parser.ExternalEntityRefHandler = lambda *_: False
+    except AttributeError:  # pragma: no cover — non-expat parser backend
+        pass
+    return parser
+
+
 def parse_caps(xml_text):
     try:
-        root = ET.fromstring(xml_text)  # nosec B314 - Python 3.8+ disables entities
+        root = ET.fromstring(xml_text, parser=_build_xxe_safe_parser())  # nosec B314 - explicit entities disabled
     except (ET.ParseError, TypeError):
         return _empty_caps()
 

--- a/repo/plugin.video.nzbdav/resources/lib/newznab_caps.py
+++ b/repo/plugin.video.nzbdav/resources/lib/newznab_caps.py
@@ -93,7 +93,9 @@ def _build_xxe_safe_parser():
 
 def parse_caps(xml_text):
     try:
-        root = ET.fromstring(xml_text, parser=_build_xxe_safe_parser())  # nosec B314 - explicit entities disabled
+        root = ET.fromstring(
+            xml_text, parser=_build_xxe_safe_parser()
+        )  # nosec B314 - explicit entities disabled
     except (ET.ParseError, TypeError):
         return _empty_caps()
 

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -1773,8 +1773,15 @@ def _xml_root_name(response):
     """Return the unqualified root XML tag name, lowercased."""
     import xml.etree.ElementTree as ET  # nosec B405 - trusted service response
 
+    parser = ET.XMLParser()  # nosec B314 - entities disabled below
     try:
-        root = ET.fromstring(response)  # nosec B314 - trusted service response
+        parser.parser.DefaultHandler = lambda _d: None
+        parser.parser.ExternalEntityRefHandler = lambda *_: False
+    except AttributeError:
+        pass
+
+    try:
+        root = ET.fromstring(response, parser=parser)  # nosec B314 - explicit entities disabled
     except (TypeError, ET.ParseError):
         return ""
     return root.tag.rsplit("}", 1)[-1].lower()

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -1781,7 +1781,9 @@ def _xml_root_name(response):
         pass
 
     try:
-        root = ET.fromstring(response, parser=parser)  # nosec B314 - explicit entities disabled
+        root = ET.fromstring(
+            response, parser=parser
+        )  # nosec B314 - explicit entities disabled
     except (TypeError, ET.ParseError):
         return ""
     return root.tag.rsplit("}", 1)[-1].lower()


### PR DESCRIPTION
Explicitly prevent XXE (XML External Entity) attacks when parsing untrusted XML data using Python's standard `xml.etree.ElementTree`. This creates a custom parser that explicitly sets `ExternalEntityRefHandler = lambda *_: False` instead of blindly relying on the default settings of the host Python version. This patch has been applied to `direct_indexers.py`, `newznab_caps.py`, and `router.py`. Tests have been run to ensure correctness.

---
*PR created automatically by Jules for task [14695967933177352209](https://jules.google.com/task/14695967933177352209) started by @xbmc4lyfe*