### PR TITLE
fix(proxy): scope AWAITING streak to byte offset + tolerate transient zero-length standby probe

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -3304,7 +3304,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
         return cmd
 
     @staticmethod
-    def _bump_awaiting_no_progress(ctx, result, current_count):
+    def _bump_awaiting_no_progress(ctx, result, current_count, current_byte=None):
         """Advance the session-persistent no-progress AWAITING_DOWNLOAD count.
 
         Only a clean download-high-water short read (AWAITING_DOWNLOAD) that
@@ -3312,12 +3312,26 @@ class _StreamHandler(BaseHTTPRequestHandler):
         (keeping the streak strictly consecutive AWAITING reads). The count
         lives in ctx so it survives Kodi's Connection: close reconnects (a dead
         region reads as a clean short read on every fresh GET). See F-route.
+
+        The streak is also scoped to the failing byte offset: a single session
+        issues many ranges (startup tail probe, reconnects, seeks), and a
+        no-progress AWAITING at one offset must not advance a streak begun at an
+        unrelated offset. When current_byte differs from the offset that last
+        advanced the streak, the count resets first so only CONSECUTIVE
+        no-progress reads of the SAME stuck region escalate to failover.
         """
+        if current_byte is not None:
+            last_byte = ctx.get("_awaiting_download_no_progress_byte")
+            if last_byte is not None and last_byte != current_byte:
+                current_count = 0
         if result == _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD:
             current_count += 1
             ctx["_awaiting_download_no_progress"] = current_count
+            if current_byte is not None:
+                ctx["_awaiting_download_no_progress_byte"] = current_byte
             return current_count
         ctx["_awaiting_download_no_progress"] = 0
+        ctx.pop("_awaiting_download_no_progress_byte", None)
         return 0
 
     def _activate_fallback_source(self, ctx, fallback, current, stuck_awaiting=False):
@@ -3371,6 +3385,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
         # (dead) primary's stuck count must not carry over and prematurely
         # escalate the healthy peer.
         ctx["_awaiting_download_no_progress"] = 0
+        ctx.pop("_awaiting_download_no_progress_byte", None)
         ctx["fallback_switch_count"] = int(ctx.get("fallback_switch_count", 0) or 0) + 1
         try:
             ctx["fallback_active_index"] = ctx.get("fallback_sources", []).index(
@@ -3770,7 +3785,17 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 expected_length = 0
         else:
             expected_length = self._fallback_expected_content_length(ctx)
-        if expected_length > 0 and content_length != expected_length:
+        # Only a POSITIVE, different length is a provable mismatch. A
+        # transient HEAD probe (5xx/timeout) makes fetch_content_length
+        # return 0; coercing that to a "mismatch" would permanently fail an
+        # otherwise-valid standby fallback for the rest of the session over a
+        # momentary WebDAV blip. Leave length 0 INCONCLUSIVE and fall through
+        # so fingerprint validation can gate usability on a later pass.
+        if (
+            expected_length > 0
+            and content_length > 0
+            and content_length != expected_length
+        ):
             source["failed"] = True
             return False
         ctx["_fallback_source_content_length_hint"] = (id(source), content_length)
@@ -5155,7 +5180,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                     forward_stall_t0 = None
                 else:
                     awaiting_download_no_progress = self._bump_awaiting_no_progress(
-                        ctx, result, awaiting_download_no_progress
+                        ctx, result, awaiting_download_no_progress, current
                     )
                 awaiting_stuck = (
                     not progressed_this_iter

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -2833,11 +2833,17 @@ def test_prevalidated_fallback_reuses_current_probe_for_first_fallback_bytes():
     # behavior directly (zero fallback stream-opens) rather than via a global
     # call_count or wall-clock timing: a stray background read-ahead open from a
     # leaked sibling-test daemon, or scheduler jitter under parallel suite load,
-    # would otherwise flake this without indicating any real regression.
+    # would otherwise flake this without indicating any real regression. Match on
+    # this test's unique fallback auth header (not just the URL): a leaked sibling
+    # daemon read-ahead also targets a "/fallback.mkv" URL through the same patched
+    # module-level urlopen, but carries a different Authorization, so a bare URL
+    # filter miscounts it as our open.
     fallback_stream_opens = sum(
         1
         for call in stream_open.call_args_list
-        if call.args and call.args[0].full_url.endswith("/fallback.mkv")
+        if call.args
+        and call.args[0].full_url.endswith("/fallback.mkv")
+        and _request_header(call.args[0], "Authorization") == "Basic fallback"
     )
     assert fallback_stream_opens == 0
 
@@ -9523,6 +9529,93 @@ def test_live_fallback_selection_reuses_expected_length_for_standby_refresh():
     assert expected_length.call_count == 1
 
 
+def test_standby_refresh_transient_zero_length_does_not_fail_source():
+    """A transient HEAD probe (length 0) must not permanently fail a standby.
+
+    fetch_content_length() coerces a 5xx/timeout to 0. With an expected
+    length of 1000, the old guard treated 0 != 1000 as a mismatch and set
+    ``failed = True``, dropping an otherwise-valid fallback for the rest of
+    the session. Length 0 is now INCONCLUSIVE: the source stays usable and
+    fingerprint validation gates it on a later pass.
+    """
+    handler = _make_handler()
+    standby = {
+        "nzo_id": "nzo-standby",
+        "stream_url": "",
+        "stream_headers": {},
+        "content_length": 0,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/content/primary.mkv",
+        "auth_header": None,
+        "content_length": 1000,
+        "fallback_sources": [standby],
+    }
+
+    with patch(
+        "resources.lib.nzbdav_api.get_job_history",
+        return_value={
+            "status": "Completed",
+            "storage": "/mnt/nzbdav/completed-symlinks/movies/Standby",
+        },
+    ), patch(
+        "resources.lib.webdav.find_video_file",
+        return_value="/content/movies/Standby/fallback.mkv",
+    ), patch(
+        "resources.lib.webdav.get_webdav_stream_url_for_path",
+        return_value=("http://webdav/content/fallback.mkv", {}),
+    ), patch(
+        "resources.lib.fallback_streams.fetch_content_length", return_value=0
+    ), patch.object(
+        handler, "_fallback_source_matches", return_value=True
+    ):
+        source = handler._select_live_fallback_source(ctx, 100, 999)
+
+    assert source is standby
+    assert standby["failed"] is False
+
+
+def test_standby_refresh_positive_length_mismatch_still_fails_source():
+    """A positive, different probed length is still a provable mismatch."""
+    handler = _make_handler()
+    standby = {
+        "nzo_id": "nzo-standby",
+        "stream_url": "",
+        "stream_headers": {},
+        "content_length": 0,
+        "validated": False,
+        "failed": False,
+    }
+    ctx = {
+        "remote_url": "http://webdav/content/primary.mkv",
+        "auth_header": None,
+        "content_length": 1000,
+        "fallback_sources": [standby],
+    }
+
+    with patch(
+        "resources.lib.nzbdav_api.get_job_history",
+        return_value={
+            "status": "Completed",
+            "storage": "/mnt/nzbdav/completed-symlinks/movies/Standby",
+        },
+    ), patch(
+        "resources.lib.webdav.find_video_file",
+        return_value="/content/movies/Standby/fallback.mkv",
+    ), patch(
+        "resources.lib.webdav.get_webdav_stream_url_for_path",
+        return_value=("http://webdav/content/fallback.mkv", {}),
+    ), patch(
+        "resources.lib.fallback_streams.fetch_content_length", return_value=2000
+    ):
+        refreshed = handler._refresh_standby_fallback_source(ctx, standby)
+
+    assert refreshed is False
+    assert standby["failed"] is True
+
+
 def test_live_fallback_selection_reuses_standby_length_for_match_validation():
     """Completed standby validation should reuse the freshly probed source length."""
     handler = _make_handler()
@@ -15567,6 +15660,53 @@ def test_non_awaiting_read_resets_awaiting_streak():
     )
     assert count == 1
     assert ctx["_awaiting_download_no_progress"] == 1
+
+
+def test_awaiting_streak_scoped_to_failing_byte_offset():
+    """A session-wide AWAITING_DOWNLOAD streak must not accrue across unrelated
+    byte offsets. A single session issues many ranges (startup tail probe,
+    reconnects, seeks); a no-progress AWAITING read at one offset must not
+    advance a streak begun at a different offset. Only CONSECUTIVE no-progress
+    reads of the SAME stuck region escalate toward failover. Pins the per-byte
+    scoping of _bump_awaiting_no_progress (CR-2c)."""
+    from resources.lib.stream_proxy import (
+        _AWAITING_DOWNLOAD_NO_PROGRESS_MAX,
+        _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD,
+    )
+
+    ctx = {}
+    handler = _make_handler_with_server(ctx, range_header="bytes=0-9")
+
+    awaiting = _UPSTREAM_RANGE_SHORT_READ_AWAITING_DOWNLOAD
+    count = 0
+    # A no-progress AWAITING read at offset 100 starts the streak.
+    count = handler._bump_awaiting_no_progress(ctx, awaiting, count, 100)
+    assert count == 1
+    count = handler._bump_awaiting_no_progress(ctx, awaiting, count, 100)
+    assert count == 2
+    # A read at a DIFFERENT offset (e.g. a seek / tail probe) must reset the
+    # streak to a fresh 1, NOT advance to 3 and trip a false "stuck" failover.
+    count = handler._bump_awaiting_no_progress(ctx, awaiting, count, 999999)
+    assert count == 1
+    assert ctx["_awaiting_download_no_progress"] == 1
+    assert ctx["_awaiting_download_no_progress_byte"] == 999999
+    # Mixed offsets never let the streak reach the failover cap; only the SAME
+    # offset repeatedly stuck does.
+    assert _AWAITING_DOWNLOAD_NO_PROGRESS_MAX >= 2
+    count = 0
+    ctx2 = {}
+    last = 0
+    for _ in range(_AWAITING_DOWNLOAD_NO_PROGRESS_MAX + 2):
+        last += 1000
+        count = handler._bump_awaiting_no_progress(ctx2, awaiting, count, last)
+        assert count == 1
+    # The Nth CONSECUTIVE no-progress read of the SAME offset DOES reach the cap
+    # (the genuinely-dead-region case that must fail over).
+    count = 0
+    ctx3 = {}
+    for _ in range(_AWAITING_DOWNLOAD_NO_PROGRESS_MAX):
+        count = handler._bump_awaiting_no_progress(ctx3, awaiting, count, 4242)
+    assert count >= _AWAITING_DOWNLOAD_NO_PROGRESS_MAX
 
 
 def test_standby_refresh_threads_source_title_as_find_video_file_hint():


### PR DESCRIPTION
## Summary

Two failover-correctness follow-ups to the proxy/fallback work from #238, in their own branch/PR.

- **Per-byte AWAITING streak scoping (CR-2c):** `_bump_awaiting_no_progress` now keys the session-persistent no-progress streak on the failing byte offset. A session issues many ranges (startup tail probe, reconnects, seeks); a no-progress AWAITING read at one offset must not advance a streak begun at an unrelated offset. The count resets when the offset changes, so only *consecutive* no-progress reads of the *same* stuck region escalate to failover.

- **Transient zero-length standby probe is inconclusive:** `_refresh_standby_fallback_source` treats a probed content length of `0` (a 5xx/timeout → `fetch_content_length` returns 0) as inconclusive rather than a mismatch. The old guard coerced `0 != expected` into a mismatch and permanently failed an otherwise-valid standby for the rest of the session over a momentary WebDAV blip. Only a positive, different length is a provable mismatch; length 0 falls through to fingerprint validation on a later pass.

## Tests

- `test_awaiting_streak_scoped_to_failing_byte_offset`
- `test_standby_refresh_transient_zero_length_does_not_fail_source`
- `test_standby_refresh_positive_length_mismatch_still_fails_source`

All three pass on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)