### PR TITLE
⚡ Bolt: [performance improvement] Pre-compile regexes at module level

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -76,6 +76,8 @@ def _no_redirect_urlopen(req, timeout):
 urlopen = _NO_REDIRECT_OPENER.open  # noqa: F811
 
 _SAFE_JOB_RE = re.compile(r"^[A-Za-z0-9._ \[\]-]+$")
+_INVALID_JOB_CHAR_RE = re.compile(r"[^A-Za-z0-9._ -]+")
+_NON_WORD_RE = re.compile(r"[\W_]+")
 _CONTENT_RANGE_RE = re.compile(r"^bytes\s+(\d+)-(\d+)/(\d+|\*)$")
 _FINGERPRINT_SAMPLE_COUNT = 100
 _FINGERPRINT_SMALL_SAMPLE_COUNT = 20
@@ -404,7 +406,7 @@ def _normalize_title(value):
     """Normalize release titles for conservative duplicate grouping."""
     if not isinstance(value, str):
         return ""
-    normalized = re.sub(r"[\W_]+", " ", value.lower())
+    normalized = _NON_WORD_RE.sub(" ", value.lower())
     return " ".join(normalized.split())
 
 
@@ -2263,7 +2265,7 @@ def _rank_fallback_candidates(target, candidates):
 def build_fallback_job_name(title, nzb_url, index):
     """Return a stable, traceable nzbdav job name for a fallback candidate."""
     clean_title = title if isinstance(title, str) else ""
-    clean_title = re.sub(r"[^A-Za-z0-9._ -]+", " ", clean_title)
+    clean_title = _INVALID_JOB_CHAR_RE.sub(" ", clean_title)
     clean_title = " ".join(clean_title.split())[:180].strip()
     if not clean_title:
         clean_title = "fallback"
@@ -2271,7 +2273,7 @@ def build_fallback_job_name(title, nzb_url, index):
     digest = hashlib.sha256(str(nzb_url).encode("utf-8")).hexdigest()[:8]
     job_name = "{} [fallback-{}-{}]".format(clean_title, index, digest)
     if not _SAFE_JOB_RE.match(job_name):
-        job_name = re.sub(r"[^A-Za-z0-9._ -]+", " ", job_name)
+        job_name = _INVALID_JOB_CHAR_RE.sub(" ", job_name)
         job_name = " ".join(job_name.split())
     return job_name
 

--- a/repo/plugin.video.nzbdav/resources/lib/indexer_presets.py
+++ b/repo/plugin.video.nzbdav/resources/lib/indexer_presets.py
@@ -9,6 +9,9 @@ DIRECT_FALLBACK_HOSTS = ("dognzb", "nzbplanet", "nzbgeek", "6box")
 DOGNZB_TVSEARCH_FALLBACK_HOSTS = ("dognzb",)
 RATE_LIMITED_CAPS_HOSTS = ("nzb.su", "nzb.life")
 
+_NON_ALPHANUM_RE = re.compile(r"[^A-Za-z0-9]+")
+_MULTI_UNDERSCORE_RE = re.compile(r"_+")
+
 _PRESETS = (
     ("abnzb", "abNZB", "https://abnzb.com/"),
     ("althub", "altHUB", "https://api.althub.co.za"),
@@ -36,8 +39,8 @@ _PRESETS = (
 
 
 def slugify_preset_id(name):
-    value = re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").lower()
-    return re.sub(r"_+", "_", value)
+    value = _NON_ALPHANUM_RE.sub("_", name).strip("_").lower()
+    return _MULTI_UNDERSCORE_RE.sub("_", value)
 
 
 def _preset(indexer_id, name, api_url):

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -88,12 +88,14 @@ _EPISODE_NXN_RANGE_RE = re.compile(
     re.IGNORECASE,
 )
 
+_NON_WORD_RE = re.compile(r"[\W_]+")
+
 
 def _hint_tokens(value):
     """Return lowercased alphanumeric tokens for loose name matching."""
     if not isinstance(value, str) or not value:
         return frozenset()
-    cleaned = re.sub(r"[\W_]+", " ", value.lower())
+    cleaned = _NON_WORD_RE.sub(" ", value.lower())
     return frozenset(token for token in cleaned.split() if token)
 
 


### PR DESCRIPTION
💡 What: Extracted several inline `re.sub` string regular expressions into pre-compiled `re.compile()` objects at the module level across `fallback_streams.py`, `indexer_presets.py`, and `webdav.py`.
🎯 Why: Regular expressions like `r"[\W_]+"` were being compiled dynamically repeatedly inside functions like `_normalize_title` and `_hint_tokens` which are called frequently (often inside loops handling many fallback candidates or search results). Pre-compiling them avoids runtime overhead.
📊 Impact: Minor performance improvement to string sanitization and manifest tokenization CPU overhead by moving regex compilation from per-call to module load time.
🔬 Measurement: Verify tests still pass via `pytest tests/test_fallback_streams.py tests/test_indexer_presets.py tests/test_webdav.py`.

---
*PR created automatically by Jules for task [12579297874837371440](https://jules.google.com/task/12579297874837371440) started by @xbmc4lyfe*