### PR TITLE
🎨 Palette: Improve keyboard navigation in results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,7 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +234,7 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onleft>50</onleft>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
💡 **What:** Added `<onright>60</onright>` to the results list (`id="50"`) and `<onleft>50</onleft>` to the scrollbar (`id="60"`) in the Kodi skin XML `results-dialog.xml`.
🎯 **Why:** Kodi does not automatically infer horizontal or vertical navigation paths between custom UI controls. Users who rely on keyboard or remote D-pad could not navigate to the scrollbar to skip through long lists quickly.
♿ **Accessibility:** This directly improves keyboard accessibility and remote D-pad usability by explicitly linking these adjacent controls.

---
*PR created automatically by Jules for task [4064845733909087826](https://jules.google.com/task/4064845733909087826) started by @xbmc4lyfe*