### PR TITLE
🎨 Palette: Add explicit navigation tags for Kodi list and scrollbar accessibility

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,7 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +234,7 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onleft>50</onleft>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
💡 What: Added explicit directional navigation tags `<onright>60</onright>` to the main list control (id="50") and `<onleft>50</onleft>` to the scrollbar control (id="60") in `results-dialog.xml`.
🎯 Why: Kodi does not automatically infer horizontal navigation paths between custom UI controls. Previously the scrollbar (id="60") was unreachable by keyboard/D-pad — only the list was focusable. These symmetric tags let users move focus from the results list onto the scrollbar and back, so the scrollbar can be grabbed directly to page through long result sets.
♿ Accessibility: Makes the custom scrollbar reachable via keyboard and remote. Navigation is symmetric (list ⇄ scrollbar) so focus can always return to the list, and `[Esc]` still closes the dialog from any control.

---
*PR created automatically by Jules for task [11438894729613780321](https://jules.google.com/task/11438894729613780321) started by @xbmc4lyfe*