### PR TITLE
feat(nzbget): pre-cached "DL" picker tag + completed-file reuse on selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **NZBGet mode: pre-cached "DL" indicator in the NZB picker.** With the
+  NZBGet backend enabled, the results picker now tags releases that are
+  already completed in NZBGet's history with the same green `DL` chip the
+  nzbdav cached-stream tag uses. Matching reuses the established identity
+  gates (exact name, ±15% size tolerance, recorded Usenet post-date), and the
+  NZBGet path now records each completed download's post-date in the shared
+  download ledger so a same-name repost from a different day is not mistaken
+  for the cached file. The history lookup is bounded at 10s and fails soft —
+  an unreachable NZBGet just renders an untagged picker.
+
+### Fixed
+
+- **NZBGet mode: replaying an already-downloaded pick no longer fails.**
+  Selecting a `DL`-tagged result now plays the completed files straight from
+  the SMB share instead of re-submitting the NZB — NZBGet's duplicate check
+  (`DupeCheck=yes` default) dupe-deletes a re-submission of a successful
+  download, which previously surfaced as a spurious "Download failed". If the
+  files are gone from the share, the normal submit flow runs as before.
+- **NZBGet mode: script auto-select no longer queries nzbdav.** The RunScript
+  auto-select path skipped the new suppression and could stall on a stale
+  nzbdav config before handing off to NZBGet.
+
 ## [1.2.4] — 2026-05-31
 
 > **Startup playback and live-fallback hardening.** This release closes the

--- a/repo/plugin.video.nzbdav/resources/lib/nzbget_api.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzbget_api.py
@@ -231,6 +231,109 @@ def history_status(nzbid, settings_getter=None):
     return {"present": False, "success": False, "status": "", "dest_dir": ""}
 
 
+class _CompletedHistory(dict):
+    """Name-keyed SUCCESS history mapping, marked when the lookup succeeded.
+
+    Mirrors nzbdav_api's completed-jobs marker: ``router._completed_lookup_was_done``
+    tells "lookup ran and found nothing" (skip per-selection re-lookups) apart
+    from "lookup failed" via the ``_lookup_done`` attribute.
+    """
+
+    def __init__(self, *args, **kwargs):
+        lookup_done = kwargs.pop("lookup_done", False)
+        super().__init__(*args, **kwargs)
+        self._lookup_done = bool(lookup_done)
+
+
+def _history_item_bytes(item):
+    """Best-effort byte size of a history item, or None when unknown.
+
+    Prefers the exact FileSizeHi/FileSizeLo 64-bit pair, falling back to the
+    rounded FileSizeMB; tolerates str/None fields like the other parsers. A
+    None return makes the picker's size gate fail open (name-only match)
+    instead of treating the row as a zero-byte mismatch.
+    """
+    size = int(_as_number(item.get("FileSizeHi"))) * 4294967296 + int(
+        _as_number(item.get("FileSizeLo"))
+    )
+    if size > 0:
+        return size
+    size_mb = int(_as_number(item.get("FileSizeMB")))
+    if size_mb > 0:
+        return size_mb * 1048576
+    return None
+
+
+# Picker-render RPC bound: ``completed_history`` runs synchronously right
+# before the results dialog opens, so cap the wait the way the nzbdav picker
+# path does (nzbdav_api._API_READ_TIMEOUT = 10, "prevent dialog freeze")
+# instead of the resolver-path _RPC_TIMEOUT — a silently-unreachable NZBGet
+# box must not freeze the picker for 30s.
+_PICKER_RPC_TIMEOUT = 10
+
+
+def completed_history(settings_getter=None):
+    """Fetch NZBGet's SUCCESS/* history keyed by job name.
+
+    Powers the picker's "DL" tag in NZBGet mode: a result whose title matches
+    a SUCCESS history row already has its finished files on disk, and the
+    resolver reuses that row's ``dest_dir`` over SMB on selection instead of
+    re-submitting (NZBGet's duplicate check would dupe-delete a re-submission
+    of a SUCCESS item, failing the resolve). Values carry the same
+    ``name``/``bytes`` shape as nzbdav completed jobs so the router reuses
+    its size gate. Returns a lookup_done-marked mapping on RPC success (even
+    when empty) and a plain empty dict on any failure — never raises (the
+    picker render path has no try/except around tagging). One ``history`` RPC
+    per call — same visible-only view as ``history_status``; avoid calling in
+    tight loops.
+    """
+    try:
+        hist, error = _rpc_call(
+            "history",
+            [False],
+            settings_getter=settings_getter,
+            timeout=_PICKER_RPC_TIMEOUT,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        # _rpc_call reads settings before its own try block; a raising
+        # injected getter (or an early-startup Addon read) must degrade to
+        # "no tags", not crash the picker render.
+        xbmc.log(
+            "NZB-DAV: NZBGet completed_history failed: {}".format(
+                _redact_text(str(exc))
+            ),
+            xbmc.LOGDEBUG,
+        )
+        return {}
+    if error is not None or not isinstance(hist, list):
+        return {}
+    jobs = _CompletedHistory(lookup_done=True)
+    for item in hist:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("Status") or "")
+        if not status.startswith("SUCCESS"):
+            continue
+        name = item.get("Name")
+        if not name:
+            continue
+        # History is newest-first; for same-name SUCCESS rows keep the newest
+        # one — that's the row a replay's dupe handling would land on.
+        if name in jobs:
+            continue
+        jobs[name] = {
+            "name": name,
+            "status": status,
+            "bytes": _history_item_bytes(item),
+            "nzbid": item.get("NZBID"),
+            # Where the finished files live. FinalDir preferred over DestDir
+            # like history_status, so a post-processing-script move is
+            # followed to the file's final location.
+            "dest_dir": (item.get("FinalDir") or item.get("DestDir") or ""),
+        }
+    return jobs
+
+
 def completed_base_dir(settings_getter=None):
     """Return NZBGet's configured global completed DestDir (absolute), or None.
 

--- a/repo/plugin.video.nzbdav/resources/lib/nzbget_resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzbget_resolver.py
@@ -17,6 +17,7 @@ import xbmcplugin
 import xbmcvfs
 
 from resources.lib import nzbget_api
+from resources.lib.download_ledger import record_download
 from resources.lib.http_util import notify as _notify
 from resources.lib.http_util import redact_text as _redact_text
 from resources.lib.i18n import addon_name as _addon_name
@@ -257,6 +258,12 @@ _DEFAULT_TIMEOUT = 3600
 _TIMEOUT_MIN = 60
 _TIMEOUT_MAX = 86400
 
+# Probe budget when reusing an already-completed job's folder: the files are
+# either visible now or the history row is stale — a short window absorbs a
+# share waking up without delaying the fallback submit the way the
+# post-download 60s settle budget would.
+_SMB_REUSE_PROBE_BUDGET = 3.0
+
 _DEFAULT_POLL_INTERVAL = 1
 _POLL_INTERVAL_MIN = 1
 _POLL_INTERVAL_MAX = 60
@@ -323,8 +330,17 @@ def _resolve_failure(handle, message=None):
     xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
 
 
-def _run_nzbget_backend(nzb_url, title, settings_getter, on_success, on_failure):
-    """Shared NZBGet flow: submit -> poll -> resolve over SMB.
+def _run_nzbget_backend(
+    nzb_url,
+    title,
+    settings_getter,
+    on_success,
+    on_failure,
+    download_pubdate=None,
+    download_size=None,
+    completed_job=None,
+):
+    """Shared NZBGet flow: reuse completed files, else submit -> poll -> SMB.
 
     Calls ``on_success(video_url)`` exactly once on success, or
     ``on_failure(message)`` exactly once on any failure (``message`` is
@@ -332,6 +348,15 @@ def _run_nzbget_backend(nzb_url, title, settings_getter, on_success, on_failure)
     the handle path vs ``xbmc.Player().play`` for the handle-less
     ``resolve_and_play`` path — is the caller's concern; this core
     guarantees a single terminal callback and owns the progress dialog.
+
+    ``download_pubdate``/``download_size`` carry the selected result's
+    advertised Usenet post-date and size; a completed download records them
+    in the download ledger so the picker's NZBGet-mode "DL" tag can tell this
+    upload apart from a same-name repost (same gate as the nzbdav path).
+
+    ``completed_job`` is the picker's corroborated NZBGet history match
+    (``_nzbget_completed_job``): when its ``dest_dir`` still holds a playable
+    video over SMB, that file is played directly and nothing is submitted.
     """
     dialog = None
     nzbid = None
@@ -358,15 +383,37 @@ def _run_nzbget_backend(nzb_url, title, settings_getter, on_success, on_failure)
         dialog = xbmcgui.DialogProgress()
         dialog.create(_addon_name(), _string(30218))
 
-        # Always submit the NZB the user actually selected. We deliberately do
-        # NOT reuse an existing NZBGet job (completed history *or* in-queue) by
-        # name: unlike the nzbdav completed-cache, a name match has no
-        # size/pubdate/indexer corroboration (and that selected-result metadata
-        # isn't available on the handle-based entry path), so a same-named
-        # repost or a different indexer's result could attach to / play the
-        # wrong job instead of the one the user chose. NZBGet's own dupe
-        # handling deals with re-submitting a still-in-flight same-name job on a
-        # quick retry.
+        # Corroborated picker reuse: the router tagged this selection against
+        # a SUCCESS history row (exact name + size/pubdate gates), so play the
+        # already-completed files instead of re-submitting — NZBGet's
+        # duplicate check (DupeCheck=yes by default) dupe-deletes a
+        # re-submission of a SUCCESS item, which would fail the resolve. A
+        # probe miss (files cleaned up / share moved) falls through to the
+        # normal submit flow.
+        if isinstance(completed_job, dict) and completed_job.get("dest_dir"):
+            reuse_folder = nzbget_smb_target(
+                smb_root, completed_job["dest_dir"], category, completed_base
+            )
+            if reuse_folder:
+                video_url = resolve_smb_video(
+                    reuse_folder,
+                    dialog=dialog,
+                    interval=interval,
+                    budget=_SMB_REUSE_PROBE_BUDGET,
+                )
+                if video_url:
+                    on_success(video_url)
+                    return
+
+        # Submit the NZB the user actually selected. Beyond the corroborated
+        # reuse above, we deliberately do NOT reuse an existing NZBGet job
+        # (completed history *or* in-queue) by name: a bare name match has no
+        # size/pubdate/indexer corroboration (and that selected-result
+        # metadata isn't available on the handle-based entry path), so a
+        # same-named repost or a different indexer's result could attach to /
+        # play the wrong job instead of the one the user chose. NZBGet's own
+        # dupe handling deals with re-submitting a still-in-flight same-name
+        # job on a quick retry.
         nzbid, error = nzbget_api.append_nzb(
             nzb_url, title, settings_getter=settings_getter
         )
@@ -398,6 +445,11 @@ def _run_nzbget_backend(nzb_url, title, settings_getter, on_success, on_failure)
         if outcome == "failed":
             on_failure(_string(30220))
             return
+
+        # The download completed (it is now SUCCESS history): remember the
+        # selected result's post-date before the SMB mapping, which can still
+        # fail without un-completing the download. Fail-soft inside.
+        record_download(title, download_pubdate, download_size)
 
         smb_folder = nzbget_smb_target(
             smb_root, result["dest_dir"], category, completed_base
@@ -464,7 +516,16 @@ def resolve_and_play_nzbget(handle, params, settings_getter=None, resume_seconds
     def on_failure(message):
         _resolve_failure(handle, message)
 
-    _run_nzbget_backend(nzb_url, title, settings_getter, on_success, on_failure)
+    _run_nzbget_backend(
+        nzb_url,
+        title,
+        settings_getter,
+        on_success,
+        on_failure,
+        download_pubdate=params.get("_download_pubdate"),
+        download_size=params.get("_download_size"),
+        completed_job=params.get("_nzbget_completed_job"),
+    )
 
 
 def play_nzbget(nzb_url, title, params=None, settings_getter=None, resume_seconds=0.0):
@@ -476,8 +537,9 @@ def play_nzbget(nzb_url, title, params=None, settings_getter=None, resume_second
     mirroring the nzbdav ``resolve_and_play`` "no setResolvedUrl" contract.
     ``resume_seconds`` carries the scrubbed bookmark's resume position.
     """
+    resolve_params = params or {}
     if settings_getter is None:
-        settings_getter = (params or {}).get("_settings_getter")
+        settings_getter = resolve_params.get("_settings_getter")
 
     def on_success(video_url):
         listitem = xbmcgui.ListItem(path=video_url)
@@ -488,4 +550,13 @@ def play_nzbget(nzb_url, title, params=None, settings_getter=None, resume_second
         if message:
             _notify(_addon_name(), message, 5000)
 
-    _run_nzbget_backend(nzb_url, title, settings_getter, on_success, on_failure)
+    _run_nzbget_backend(
+        nzb_url,
+        title,
+        settings_getter,
+        on_success,
+        on_failure,
+        download_pubdate=resolve_params.get("_download_pubdate"),
+        download_size=resolve_params.get("_download_size"),
+        completed_job=resolve_params.get("_nzbget_completed_job"),
+    )

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -495,6 +495,12 @@ def _attach_selected_result_metadata(resolver_params, selected):
     size = selected.get("size")
     if size:
         resolver_params["_download_size"] = size
+    # NZBGet-mode reuse hint set at picker-tag time (_tag_available_nzbget):
+    # lets the NZBGet resolver play the already-completed files instead of
+    # re-submitting into NZBGet's duplicate check.
+    nzbget_job = selected.get("_nzbget_completed_job")
+    if nzbget_job:
+        resolver_params["_nzbget_completed_job"] = nzbget_job
 
 
 def _selection_pool_with_peer_first(selected, results, first_peer):
@@ -945,9 +951,59 @@ def _result_pubdate_consistent_with_downloads(result):
     )
 
 
+class _LookupDoneJobs(dict):
+    """Empty mapping that still reports a finished completed-history lookup.
+
+    ``_completed_lookup_was_done`` keys on the ``_lookup_done`` attribute, so
+    returning this from a tagging path tells selection not to re-query history.
+    """
+
+    _lookup_done = True
+
+
+def _nzbget_mode_enabled(settings_getter=None):
+    """Return whether the NZBGet backend toggle is on (resolver's reader)."""
+    from resources.lib.resolver import _nzbget_enabled
+
+    return _nzbget_enabled(settings_getter)
+
+
+def _tag_available_nzbget(results, settings_getter=None):
+    """Mark results already completed in NZBGet history (NZBGet-mode "DL").
+
+    A release still in NZBGet's history as SUCCESS already has its finished
+    files on the SMB share, so the picker shows the same "DL" chip the nzbdav
+    cached-stream tag uses, gated by the same name+size(+recorded pubdate)
+    identity checks. The matched row is attached as ``_nzbget_completed_job``
+    so the NZBGet resolver plays the row's completed files directly instead
+    of re-submitting — NZBGet's duplicate check (DupeCheck=yes by default)
+    would dupe-delete a re-submission of a SUCCESS item and fail the resolve.
+    Deliberately does NOT attach ``_completed_job``: that hint is the nzbdav
+    cached-stream reuse contract. Always returns a lookup-done mapping — even
+    when the history RPC fails — because the per-selection nzbdav history
+    fallback it would otherwise trigger is meaningless on the NZBGet path.
+    """
+    from resources.lib import nzbget_api
+
+    completed = nzbget_api.completed_history(settings_getter=settings_getter)
+    for result in results:
+        completed_job = completed.get(result.get("title"))
+        if (
+            completed_job
+            and _completed_job_matches_result(result, completed_job)
+            and _result_pubdate_consistent_with_downloads(result)
+        ):
+            result["_available"] = True
+            result["_nzbget_completed_job"] = completed_job
+    if completed_jobs_lookup_done(completed):
+        return completed
+    return _LookupDoneJobs()
+
+
 def _tag_available(results, settings_getter=None):
     """
-    Mark result entries that already exist in nzbdav by setting the `_available` flag.
+    Mark result entries that already exist in the active download backend by
+    setting the `_available` flag.
 
     Parameters:
         results (list[dict]): Iterable of result dictionaries; entries whose
@@ -956,9 +1012,14 @@ def _tag_available(results, settings_getter=None):
             modified in-place with `result["_available"] = True`. The size gate
             stops distinct uploads that merely share a filename from being
             collapsed onto one cached stream.
+
+    In NZBGet mode the completed-name source is NZBGet's own SUCCESS history
+    instead of nzbdav's (see ``_tag_available_nzbget``); nzbdav is not queried.
     """
     if not results:
         return {}
+    if _nzbget_mode_enabled(settings_getter):
+        return _tag_available_nzbget(results, settings_getter=settings_getter)
     completed = get_completed_jobs(settings_getter=settings_getter)
     if not completed:
         return completed
@@ -1486,7 +1547,7 @@ def _handle_play(handle, params):
         )
         return
 
-    # Tag results already downloaded in nzbdav
+    # Tag results already downloaded in the active backend (nzbdav / NZBGet)
     completed_jobs = _tag_available(filtered)
 
     # Show custom results dialog
@@ -1673,7 +1734,7 @@ def _handle_search(handle, params):
         xbmcplugin.endOfDirectory(handle, succeeded=False)
         return
 
-    # Tag results already downloaded in nzbdav
+    # Tag results already downloaded in the active backend (nzbdav / NZBGet)
     completed_jobs = _tag_available(filtered)
 
     # Show custom results dialog
@@ -1862,7 +1923,13 @@ def _handle_script_play(params):
                 best, filtered, settings_getter=_get_script_setting
             )
             resolver_params["_fallback_candidate_loader"] = fallback_loader
-            completed_job = _script_completed_job_for_selection(best)
+            completed_job = None
+            if not _nzbget_mode_enabled(_get_script_setting):
+                # In NZBGet mode the nzbdav completed-history hint is dead
+                # weight (resolve_and_play delegates to NZBGet before reading
+                # it) — skip the lookup instead of stalling on a stale nzbdav
+                # config.
+                completed_job = _script_completed_job_for_selection(best)
             if completed_job:
                 resolver_params["_completed_job"] = completed_job
             else:

--- a/tests/test_nzbget_api.py
+++ b/tests/test_nzbget_api.py
@@ -8,6 +8,7 @@ from resources.lib.nzbget_api import (
     _rpc_url,
     append_nzb,
     cancel_job,
+    completed_history,
     group_status,
     history_status,
 )
@@ -386,3 +387,109 @@ def test_append_nzb_returns_error_when_rpc_errors():
         nzbid, error = append_nzb("http://i/x.nzb", "X", settings_getter=getter)
     assert nzbid is None
     assert error == "401 auth"
+
+
+def test_completed_history_keys_success_items_by_name():
+    getter = _getter({"nzbget_url": "http://box:6789"})
+    hist = [
+        {
+            "NZBID": 1,
+            "Name": "Movie.mkv",
+            "Status": "SUCCESS/UNPACK",
+            "FileSizeHi": 1,
+            "FileSizeLo": 5,
+            "DestDir": "/dl/intermediate/Movie",
+            "FinalDir": "/dl/movies/Movie",
+        },
+        {"NZBID": 2, "Name": "Failed.mkv", "Status": "FAILURE/PAR"},
+        {"NZBID": 3, "Name": "Dupe.mkv", "Status": "DELETED/DUPE"},
+        {"NZBID": 4, "Name": "Warn.mkv", "Status": "WARNING/HEALTH"},
+        "junk",
+        {"NZBID": 5, "Status": "SUCCESS/ALL"},  # nameless -> skipped
+    ]
+    with patch("resources.lib.nzbget_api._rpc_call", return_value=(hist, None)) as rpc:
+        jobs = completed_history(settings_getter=getter)
+
+    # Only SUCCESS/* rows are "pre-cached": only their completed files can be
+    # reused on selection, so they're the only ones the picker may tag DL.
+    assert set(jobs) == {"Movie.mkv"}
+    assert jobs["Movie.mkv"]["status"] == "SUCCESS/UNPACK"
+    # Exact 64-bit size from the Hi/Lo pair.
+    assert jobs["Movie.mkv"]["bytes"] == (1 << 32) + 5
+    assert jobs["Movie.mkv"]["name"] == "Movie.mkv"
+    assert jobs["Movie.mkv"]["nzbid"] == 1
+    # FinalDir wins over DestDir (post-processing-script move), same
+    # preference as history_status.
+    assert jobs["Movie.mkv"]["dest_dir"] == "/dl/movies/Movie"
+    # Successful lookup is marked done even after filtering.
+    assert getattr(jobs, "_lookup_done", False) is True
+    # Visible history only, same shape history_status uses.
+    assert rpc.call_args[0][0] == "history"
+    assert rpc.call_args[0][1] == [False]
+    # Picker-render path: bounded like nzbdav's 10s picker timeout, not the
+    # 30s resolver-path _RPC_TIMEOUT.
+    assert rpc.call_args.kwargs.get("timeout") == 10
+
+
+def test_completed_history_never_raises_on_broken_settings_getter():
+    # _tag_available's plugin call sites have no try/except; a raising
+    # injected getter must degrade to "no tags", not crash the picker.
+    def broken_getter(key, default=""):
+        raise ValueError("corrupt settings")
+
+    jobs = completed_history(settings_getter=broken_getter)
+    assert jobs == {}
+    assert getattr(jobs, "_lookup_done", False) is False
+
+
+def test_completed_history_falls_back_to_mb_and_tolerates_strings():
+    getter = _getter({"nzbget_url": "http://box:6789"})
+    hist = [
+        {
+            "Name": "Movie.mkv",
+            "Status": "SUCCESS/ALL",
+            "FileSizeHi": "0",
+            "FileSizeLo": None,
+            "FileSizeMB": "2048",
+        }
+    ]
+    with patch("resources.lib.nzbget_api._rpc_call", return_value=(hist, None)):
+        jobs = completed_history(settings_getter=getter)
+    assert jobs["Movie.mkv"]["bytes"] == 2048 * 1048576
+
+
+def test_completed_history_unknown_size_is_none():
+    # No size fields at all -> bytes None, so the router's size gate fails
+    # open (name-only match) instead of treating it as a zero-byte mismatch.
+    getter = _getter({"nzbget_url": "http://box:6789"})
+    hist = [{"Name": "Movie.mkv", "Status": "SUCCESS/ALL"}]
+    with patch("resources.lib.nzbget_api._rpc_call", return_value=(hist, None)):
+        jobs = completed_history(settings_getter=getter)
+    assert jobs["Movie.mkv"]["bytes"] is None
+
+
+def test_completed_history_rpc_failure_returns_unmarked_empty():
+    getter = _getter({"nzbget_url": "http://box:6789"})
+    with patch("resources.lib.nzbget_api._rpc_call", return_value=(None, "401")):
+        jobs = completed_history(settings_getter=getter)
+    assert jobs == {}
+    assert getattr(jobs, "_lookup_done", False) is False
+
+    # A non-list result is malformed, not an empty history.
+    with patch("resources.lib.nzbget_api._rpc_call", return_value=({"x": 1}, None)):
+        jobs = completed_history(settings_getter=getter)
+    assert jobs == {}
+    assert getattr(jobs, "_lookup_done", False) is False
+
+
+def test_completed_history_keeps_newest_same_name_entry():
+    # NZBGet returns history newest-first; for same-name SUCCESS rows the
+    # newest row is what a replay would land on, so keep its size.
+    getter = _getter({"nzbget_url": "http://box:6789"})
+    hist = [
+        {"Name": "Movie.mkv", "Status": "SUCCESS/ALL", "FileSizeMB": 100},
+        {"Name": "Movie.mkv", "Status": "SUCCESS/ALL", "FileSizeMB": 999},
+    ]
+    with patch("resources.lib.nzbget_api._rpc_call", return_value=(hist, None)):
+        jobs = completed_history(settings_getter=getter)
+    assert jobs["Movie.mkv"]["bytes"] == 100 * 1048576

--- a/tests/test_nzbget_resolver.py
+++ b/tests/test_nzbget_resolver.py
@@ -674,3 +674,261 @@ def test_play_nzbget_failure_does_not_clear_playlist():
         play_nzbget("http://i/x.nzb", "X", settings_getter=_settings({}))
     player.play.assert_not_called()
     xbmc_mod.PlayList.return_value.clear.assert_not_called()
+
+
+_PUBDATE = "Wed, 15 Dec 2021 12:00:00 +0000"
+
+
+def test_resolve_success_records_download_pubdate_in_ledger():
+    # The picker's NZBGet-mode DL tag uses the same download-ledger pubdate
+    # gate as the nzbdav path, so a completed NZBGet download must record the
+    # selected result's pubdate under the job title.
+    plugin = sys.modules["xbmcplugin"]
+    plugin.setResolvedUrl = MagicMock()
+    with patch(
+        "resources.lib.nzbget_resolver.nzbget_api.append_nzb",
+        return_value=(42, None),
+    ), patch(
+        "resources.lib.nzbget_resolver.poll_nzbget_job",
+        return_value={"outcome": "success", "dest_dir": "/dl/movies/The.Movie"},
+    ), patch(
+        "resources.lib.nzbget_resolver.resolve_smb_video",
+        return_value="smb://host/completed/The.Movie/movie.mkv",
+    ), patch(
+        "resources.lib.nzbget_resolver.record_download"
+    ) as record:
+        resolve_and_play_nzbget(
+            7,
+            {
+                "nzburl": "http://i/x.nzb",
+                "title": "The.Movie",
+                "_download_pubdate": _PUBDATE,
+                "_download_size": 123456,
+            },
+            settings_getter=_full_settings(),
+        )
+    record.assert_called_once_with("The.Movie", _PUBDATE, 123456)
+    assert plugin.setResolvedUrl.call_args[0][1] is True
+
+
+def test_resolve_records_ledger_even_when_smb_resolve_fails():
+    # NZBGet completed the download (it IS in history as SUCCESS, so the
+    # picker will tag it DL); a later SMB-mapping failure must not lose the
+    # pubdate record.
+    plugin = sys.modules["xbmcplugin"]
+    plugin.setResolvedUrl = MagicMock()
+    with patch(
+        "resources.lib.nzbget_resolver.nzbget_api.append_nzb",
+        return_value=(42, None),
+    ), patch(
+        "resources.lib.nzbget_resolver.poll_nzbget_job",
+        return_value={"outcome": "success", "dest_dir": "/dl/movies/The.Movie"},
+    ), patch(
+        "resources.lib.nzbget_resolver.resolve_smb_video", return_value=None
+    ), patch(
+        "resources.lib.nzbget_resolver.record_download"
+    ) as record:
+        resolve_and_play_nzbget(
+            7,
+            {
+                "nzburl": "http://i/x.nzb",
+                "title": "The.Movie",
+                "_download_pubdate": _PUBDATE,
+            },
+            settings_getter=_full_settings(),
+        )
+    record.assert_called_once_with("The.Movie", _PUBDATE, None)
+    assert plugin.setResolvedUrl.call_args[0][1] is False
+
+
+def test_resolve_failed_outcome_does_not_record_ledger():
+    # A failed/dupe-deleted job downloaded nothing under this pubdate.
+    plugin = sys.modules["xbmcplugin"]
+    plugin.setResolvedUrl = MagicMock()
+    with patch(
+        "resources.lib.nzbget_resolver.nzbget_api.append_nzb",
+        return_value=(42, None),
+    ), patch(
+        "resources.lib.nzbget_resolver.poll_nzbget_job",
+        return_value={"outcome": "failed", "status": "DELETED/DUPE"},
+    ), patch(
+        "resources.lib.nzbget_resolver.record_download"
+    ) as record:
+        resolve_and_play_nzbget(
+            7,
+            {
+                "nzburl": "http://i/x.nzb",
+                "title": "The.Movie",
+                "_download_pubdate": _PUBDATE,
+            },
+            settings_getter=_full_settings(),
+        )
+    record.assert_not_called()
+    assert plugin.setResolvedUrl.call_args[0][1] is False
+
+
+def test_play_nzbget_records_ledger_from_params():
+    # The handle-less picker/script path threads the selected result's
+    # pubdate the same way.
+    player = MagicMock()
+    with patch.object(
+        sys.modules["xbmc"], "Player", MagicMock(return_value=player)
+    ), patch(
+        "resources.lib.nzbget_resolver.nzbget_api.append_nzb",
+        return_value=(42, None),
+    ), patch(
+        "resources.lib.nzbget_resolver.poll_nzbget_job",
+        return_value={"outcome": "success", "dest_dir": "/dl/movies/The.Movie"},
+    ), patch(
+        "resources.lib.nzbget_resolver.resolve_smb_video",
+        return_value="smb://host/completed/The.Movie/movie.mkv",
+    ), patch(
+        "resources.lib.nzbget_resolver.record_download"
+    ) as record:
+        play_nzbget(
+            "http://i/x.nzb",
+            "The.Movie",
+            params={"_download_pubdate": _PUBDATE, "_download_size": 9},
+            settings_getter=_full_settings(),
+        )
+    record.assert_called_once_with("The.Movie", _PUBDATE, 9)
+    player.play.assert_called_once()
+
+
+_COMPLETED_JOB = {
+    "name": "The.Movie",
+    "status": "SUCCESS/UNPACK",
+    "bytes": 60_000_000_000,
+    "nzbid": 7,
+    "dest_dir": "/dl/movies/The.Movie",
+}
+
+
+def test_resolve_reuses_completed_job_without_resubmitting():
+    # A picker-corroborated SUCCESS history match plays the already-completed
+    # files; re-submitting would hit NZBGet's duplicate check (DupeCheck=yes
+    # default), get dupe-deleted, and fail the resolve.
+    plugin = sys.modules["xbmcplugin"]
+    plugin.setResolvedUrl = MagicMock()
+    captured = {}
+
+    def fake_resolve_smb(folder, **kwargs):
+        captured["folder"] = folder
+        captured["budget"] = kwargs.get("budget")
+        return folder + "/movie.mkv"
+
+    with patch("resources.lib.nzbget_resolver.nzbget_api.append_nzb") as append, patch(
+        "resources.lib.nzbget_resolver.nzbget_api.completed_base_dir",
+        return_value="/dl",
+    ), patch(
+        "resources.lib.nzbget_resolver.resolve_smb_video",
+        side_effect=fake_resolve_smb,
+    ), patch(
+        "resources.lib.nzbget_resolver.record_download"
+    ) as record:
+        resolve_and_play_nzbget(
+            7,
+            {
+                "nzburl": "http://i/x.nzb",
+                "title": "The.Movie",
+                "_nzbget_completed_job": _COMPLETED_JOB,
+            },
+            settings_getter=_full_settings(),
+        )
+
+    append.assert_not_called()
+    # Reuse is not a download: the ledger entry was written by the original
+    # download, mirroring the nzbdav cache-hit no-record behavior.
+    record.assert_not_called()
+    # dest_dir mapped onto the SMB root relative to the completed base.
+    assert captured["folder"] == "smb://host/completed/movies/The.Movie"
+    # Short probe budget: stale rows must not delay the fallback submit.
+    assert captured["budget"] is not None and captured["budget"] <= 10
+    assert plugin.setResolvedUrl.call_args[0][1] is True
+
+
+def test_resolve_reuse_probe_miss_falls_back_to_submit():
+    # History row exists but the files are gone from the share (cleanup):
+    # fall through to the normal submit flow.
+    plugin = sys.modules["xbmcplugin"]
+    plugin.setResolvedUrl = MagicMock()
+    smb_results = iter([None, "smb://host/completed/The.Movie/movie.mkv"])
+
+    with patch(
+        "resources.lib.nzbget_resolver.nzbget_api.append_nzb",
+        return_value=(42, None),
+    ) as append, patch(
+        "resources.lib.nzbget_resolver.nzbget_api.completed_base_dir",
+        return_value="/dl",
+    ), patch(
+        "resources.lib.nzbget_resolver.poll_nzbget_job",
+        return_value={"outcome": "success", "dest_dir": "/dl/movies/The.Movie"},
+    ), patch(
+        "resources.lib.nzbget_resolver.resolve_smb_video",
+        side_effect=lambda *a, **k: next(smb_results),
+    ):
+        resolve_and_play_nzbget(
+            7,
+            {
+                "nzburl": "http://i/x.nzb",
+                "title": "The.Movie",
+                "_nzbget_completed_job": _COMPLETED_JOB,
+            },
+            settings_getter=_full_settings(),
+        )
+
+    append.assert_called_once()
+    assert plugin.setResolvedUrl.call_args[0][1] is True
+
+
+def test_play_nzbget_reuses_completed_job():
+    # Handle-less picker/script path: same reuse, playback via xbmc.Player.
+    player = MagicMock()
+    with patch.object(
+        sys.modules["xbmc"], "Player", MagicMock(return_value=player)
+    ), patch("resources.lib.nzbget_resolver.nzbget_api.append_nzb") as append, patch(
+        "resources.lib.nzbget_resolver.nzbget_api.completed_base_dir",
+        return_value="/dl",
+    ), patch(
+        "resources.lib.nzbget_resolver.resolve_smb_video",
+        return_value="smb://host/completed/movies/The.Movie/movie.mkv",
+    ):
+        play_nzbget(
+            "http://i/x.nzb",
+            "The.Movie",
+            params={"_nzbget_completed_job": _COMPLETED_JOB},
+            settings_getter=_full_settings(),
+        )
+    append.assert_not_called()
+    player.play.assert_called_once()
+    assert (
+        player.play.call_args[0][0] == "smb://host/completed/movies/The.Movie/movie.mkv"
+    )
+
+
+def test_resolve_reuse_applies_resume_offset():
+    # Replaying a tagged result must resume where the user left off.
+    plugin = sys.modules["xbmcplugin"]
+    plugin.setResolvedUrl = MagicMock()
+    li = MagicMock()
+    with patch.object(sys.modules["xbmcgui"], "ListItem", return_value=li), patch(
+        "resources.lib.nzbget_resolver.nzbget_api.append_nzb"
+    ) as append, patch(
+        "resources.lib.nzbget_resolver.nzbget_api.completed_base_dir",
+        return_value="/dl",
+    ), patch(
+        "resources.lib.nzbget_resolver.resolve_smb_video",
+        return_value="smb://host/completed/movies/The.Movie/movie.mkv",
+    ):
+        resolve_and_play_nzbget(
+            7,
+            {
+                "nzburl": "http://i/x.nzb",
+                "title": "The.Movie",
+                "_nzbget_completed_job": _COMPLETED_JOB,
+            },
+            settings_getter=_full_settings(),
+            resume_seconds=137.0,
+        )
+    append.assert_not_called()
+    li.setProperty.assert_called_with("StartOffset", "137.0")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3306,6 +3306,19 @@ def test_attach_selected_result_metadata_omits_absent_fields():
     assert "_download_pubdate" not in params
     assert "_download_size" not in params
     assert "_selected_indexer" not in params
+    assert "_nzbget_completed_job" not in params
+
+
+def test_attach_selected_result_metadata_threads_nzbget_completed_job():
+    """The picker's NZBGet reuse hint must reach the resolver params, so the
+    NZBGet path can play the completed files instead of re-submitting."""
+    from resources.lib.router import _attach_selected_result_metadata
+
+    job = {"name": "x", "dest_dir": "/dl/movies/x", "bytes": 1}
+    params = {}
+    selected = {"title": "x", "_nzbget_completed_job": job}
+    _attach_selected_result_metadata(params, selected)
+    assert params["_nzbget_completed_job"] == job
 
 
 @patch("resources.lib.router.downloaded_pubdate_epochs")
@@ -3395,6 +3408,199 @@ def test_tag_available_fails_open_when_result_pubdate_missing(
     result = {"title": "Movie.mkv", "size": "1000"}  # no pubdate
     _tag_available([result])
     assert result.get("_available") is True
+
+
+class _NzbgetDoneHistory(dict):
+    """Stand-in for nzbget_api's lookup_done-marked completed-history dict."""
+
+    _lookup_done = True
+
+
+def _nzbget_mode_getter(extra=None):
+    values = {"nzbget_enabled": "true"}
+    values.update(extra or {})
+    return lambda key, default="": values.get(key, default)
+
+
+@patch("resources.lib.router.get_completed_jobs")
+@patch("resources.lib.nzbget_api.completed_history")
+def test_tag_available_nzbget_mode_tags_from_nzbget_history(
+    mock_nzbget_history, mock_nzbdav_completed
+):
+    """In NZBGet mode the DL tag must come from NZBGet's SUCCESS history (the
+    backend that answers 'will picking this re-download?'), never from nzbdav
+    history — and it must NOT attach the nzbdav ``_completed_job`` cached-stream
+    hint, because the NZBGet path always re-submits."""
+    from resources.lib.router import _tag_available
+
+    getter = _nzbget_mode_getter()
+    job = {
+        "name": "Movie.mkv",
+        "status": "SUCCESS/UNPACK",
+        "bytes": 60_000_000_000,
+        "nzbid": 7,
+        "dest_dir": "/dl/movies/Movie.mkv",
+    }
+    mock_nzbget_history.return_value = _NzbgetDoneHistory({"Movie.mkv": job})
+    cached = {"title": "Movie.mkv", "size": "60500000000"}
+    other = {"title": "Other.mkv", "size": "60500000000"}
+    completed = _tag_available([cached, other], settings_getter=getter)
+
+    assert cached.get("_available") is True
+    # The corroborated match is attached for selection-time reuse (play the
+    # completed files instead of re-submitting into NZBGet's dupe check)...
+    assert cached.get("_nzbget_completed_job") == job
+    # ...but never as the nzbdav cached-stream hint.
+    assert "_completed_job" not in cached
+    assert "_available" not in other
+    assert "_nzbget_completed_job" not in other
+    mock_nzbget_history.assert_called_once_with(settings_getter=getter)
+    mock_nzbdav_completed.assert_not_called()
+    # The picker-time lookup ran, so selection must not re-query history.
+    from resources.lib.router import _completed_lookup_was_done
+
+    assert _completed_lookup_was_done(completed) is True
+
+
+@patch("resources.lib.router.get_completed_jobs")
+@patch("resources.lib.nzbget_api.completed_history")
+def test_tag_available_nzbget_mode_requires_size_match(
+    mock_nzbget_history, mock_nzbdav_completed
+):
+    """NZBGet history is name-keyed like nzbdav's, so the same size gate must
+    keep a clearly-different same-name release from being marked DL."""
+    from resources.lib.router import _tag_available
+
+    mock_nzbget_history.return_value = _NzbgetDoneHistory(
+        {
+            "Movie.mkv": {
+                "name": "Movie.mkv",
+                "status": "SUCCESS/UNPACK",
+                "bytes": 60_000_000_000,
+            }
+        }
+    )
+    diff = {"title": "Movie.mkv", "size": "10000000000"}
+    unknown = {"title": "Movie.mkv"}  # no size -> fail open
+    _tag_available([diff, unknown], settings_getter=_nzbget_mode_getter())
+
+    assert "_available" not in diff
+    assert unknown.get("_available") is True
+    mock_nzbdav_completed.assert_not_called()
+
+
+@patch("resources.lib.router.downloaded_pubdate_epochs")
+@patch("resources.lib.router.get_completed_jobs")
+@patch("resources.lib.nzbget_api.completed_history")
+def test_tag_available_nzbget_mode_requires_pubdate_match(
+    mock_nzbget_history, mock_nzbdav_completed, mock_epochs
+):
+    """The download-ledger pubdate gate applies in NZBGet mode too: a same-name
+    same-size repost posted on a different day must not be marked DL."""
+    from resources.lib.router import _tag_available
+
+    mock_nzbget_history.return_value = _NzbgetDoneHistory(
+        {
+            "Movie.mkv": {
+                "name": "Movie.mkv",
+                "status": "SUCCESS/UNPACK",
+                "bytes": 60_000_000_000,
+            }
+        }
+    )
+    mock_epochs.return_value = [1639569600]
+    same_age = {"title": "Movie.mkv", "size": "60000000000", "pubdate": _PUBDATE_A}
+    diff_age = {"title": "Movie.mkv", "size": "60000000000", "pubdate": _PUBDATE_B}
+    _tag_available([same_age, diff_age], settings_getter=_nzbget_mode_getter())
+
+    assert same_age.get("_available") is True
+    assert "_available" not in diff_age
+    mock_nzbdav_completed.assert_not_called()
+
+
+@patch("resources.lib.router.get_completed_jobs")
+@patch("resources.lib.nzbget_api.completed_history")
+def test_tag_available_nzbget_mode_marks_lookup_done_even_on_rpc_failure(
+    mock_nzbget_history, mock_nzbdav_completed
+):
+    """When the NZBGet history RPC fails, no result can be tagged — but the
+    return value must still read as 'lookup done' so selection skips the
+    per-name nzbdav history fallback, which is meaningless on the NZBGet
+    path (the resolver always re-submits to NZBGet)."""
+    from resources.lib.router import _completed_lookup_was_done, _tag_available
+
+    mock_nzbget_history.return_value = {}  # unmarked = RPC failure
+    result = {"title": "Movie.mkv", "size": "1000"}
+    completed = _tag_available([result], settings_getter=_nzbget_mode_getter())
+
+    assert "_available" not in result
+    assert _completed_lookup_was_done(completed) is True
+    mock_nzbdav_completed.assert_not_called()
+
+
+@patch("resources.lib.router.get_completed_jobs")
+@patch("resources.lib.nzbget_api.completed_history")
+def test_tag_available_nzbdav_mode_never_queries_nzbget(
+    mock_nzbget_history, mock_nzbdav_completed
+):
+    """With the NZBGet toggle off, tagging must stay on the nzbdav path."""
+    from resources.lib.router import _tag_available
+
+    mock_nzbdav_completed.return_value = {}
+    _tag_available(
+        [{"title": "Movie.mkv"}],
+        settings_getter=lambda key, default="": default,
+    )
+
+    mock_nzbget_history.assert_not_called()
+    mock_nzbdav_completed.assert_called_once()
+
+
+@patch(
+    "resources.lib.router._get_script_setting",
+    side_effect=lambda key, default="": (
+        "true" if key in ("auto_select_best", "nzbget_enabled") else default
+    ),
+)
+@patch("xbmcplugin.endOfDirectory")
+@patch("xbmcplugin.setResolvedUrl")
+@patch("resources.lib.resolver.resolve_and_play")
+@patch("resources.lib.results_dialog.show_results_dialog")
+@patch("resources.lib.filter.filter_results")
+@patch("resources.lib.router._search_all_providers")
+@patch("resources.lib.router._script_completed_job_for_selection")
+@patch("resources.lib.cache.set_cached")
+@patch("resources.lib.cache.get_cached", return_value=None)
+def test_handle_script_play_auto_select_nzbget_mode_skips_nzbdav_lookup(
+    mock_cache,
+    mock_set_cache,
+    mock_script_completed,
+    mock_search,
+    mock_filter,
+    mock_dialog,
+    mock_resolve_and_play,
+    mock_set_resolved,
+    mock_end,
+    mock_script_setting,
+):
+    """The RunScript auto-select branch never runs _tag_available, so it needs
+    its own NZBGet-mode gate: the per-selection nzbdav history lookup is dead
+    weight there (resolve_and_play delegates to NZBGet before reading the
+    hint) and can stall for its full read timeout on a stale nzbdav config."""
+    from resources.lib.router import _handle_script_play
+
+    chosen = {"title": "The.Odyssey.2026.mkv", "link": "http://hydra/nzb/odyssey"}
+    mock_search.return_value = ([chosen], None)
+    mock_filter.return_value = ([chosen], [chosen])
+
+    _handle_script_play({"type": "movie", "title": "The Odyssey", "year": "2026"})
+
+    mock_script_completed.assert_not_called()
+    mock_dialog.assert_not_called()
+    mock_resolve_and_play.assert_called_once()
+    resolver_params = mock_resolve_and_play.call_args.kwargs["params"]
+    assert resolver_params.get("_completed_job_lookup_done") is True
+    assert "_completed_job" not in resolver_params
 
 
 @patch("resources.lib.router.downloaded_pubdate_epochs")


### PR DESCRIPTION
## What

With the NZBGet backend enabled, the results picker now tags releases that are already completed in NZBGet's history with the same green **DL** chip the nzbdav cached-stream tag uses — and selecting a tagged result plays the completed files straight from the SMB share instead of re-submitting the NZB.

## Why

Two problems, one root cause:

1. There was no way to see at the picker which releases are pre-cached in NZBGet mode (the existing DL tag only consulted nzbdav history).
2. Replaying an already-downloaded title was structurally broken on default NZBGet config: `append` sends `DupeKey="" DupeScore=0 DupeMode=SCORE`, so with `DupeCheck=yes` NZBGet dupe-deletes a re-submission of a SUCCESS history item (`DELETED/DUPE`/`DELETED/COPY`), which the addon reported as **"Download failed in NZBGet"** despite the playable file sitting on the share. A DL tag without a reuse path would have highlighted exactly the items guaranteed to fail.

## How

- **`nzbget_api.completed_history()`** — one `history` JSON-RPC; `SUCCESS/*` rows keyed by name with exact Hi/Lo byte size (MB fallback), NZBID, and FinalDir-preferred `dest_dir`. Bounded at a 10s picker-path timeout (mirrors nzbdav's "prevent dialog freeze" convention, not the 30s resolver timeout); never raises; lookup-done-marked on success so an empty-but-successful lookup is distinguishable from an RPC failure.
- **`router._tag_available`** branches on the NZBGet toggle. The NZBGet branch never queries nzbdav, applies the established identity gates (exact name, 0.15 size tolerance fail-open, download-ledger pubdate gate fail-open), attaches the corroborated row as `_nzbget_completed_job` (never `_completed_job` — that's the nzbdav cached-stream contract), and always reports lookup-done so selection skips the pointless per-name nzbdav fallback.
- **`nzbget_resolver`** — a picker-corroborated completed job is probed over SMB (short 3s budget) and played directly before any append; a probe miss (files cleaned off the share) falls through to the normal submit flow. Resume offset (`StartOffset`) carries through the reuse path. Completed downloads now record their Usenet post-date in the shared download ledger so a same-name repost from a different day is not tagged as cached.
- **Script auto-select** skips the nzbdav completed-history lookup in NZBGet mode instead of stalling on a stale nzbdav config.

## Validation

- `just lint` clean (ruff, black, pylint 10.00/10); full suite green: **1993 passed, 3 skipped**.
- 19 new tests: history parsing (size pairs, status filtering, dedup, fail-soft, timeout), router tagging in both modes (size/pubdate gates, no cross-backend queries, lookup-done semantics), reuse/fallback/resume/ledger paths.
- Changeset reviewed by a 12-agent adversarial workflow (3 lenses, per-finding verification); all confirmed findings fixed in this PR: dupe-delete replay failure (high), 30s picker-freeze timeout (medium), auto-select nzbdav stall (low), unguarded settings-read path (low).

## Known residuals (deliberate scope cuts)

- `auto_select_best=true` bypasses the picker, so no tag and no reuse there — replay on that path still hits the pre-existing dupe-delete failure.
- Exact-name matching misses NZBGet job-name sanitization (`\/:*?"<>|` → `_`), so such titles never get the tag — fail-safe direction (missing tag, never a wrong one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)