### PR TITLE
⚡ Bolt: [performance improvement] Pre-compile regexes in stream_proxy.py

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -612,6 +612,9 @@ _PROP_PROXY_TOKEN = "nzbdav.proxy_token"  # nosec B105 — settings key, not a s
 # a live session whose /prepare snapshot was taken before the fallback worker
 # finished adopting them (the cutover-never-fires race).
 _FALLBACK_UPDATE_PATH_RE = re.compile(r"^/stream/([^/]+)/fallbacks$")
+_DURATION_RE = re.compile(r"Duration:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?")
+_SEGMENT_RE = re.compile(r"seg_0*(\d+)\.(m4s|ts)")
+_BYTES_RANGE_RE = re.compile(r"^bytes\s+0-0/(\d+)$")
 
 # HLS segment length. Shorter segments (6 s) minimize the playlist-
 # vs-actual drift that breaks seek accuracy and A/V sync on the fmp4
@@ -1865,7 +1868,7 @@ def _parse_ffmpeg_duration(stderr_text):
 
     Returns duration in seconds as a float, or None if not found.
     """
-    match = re.search(r"Duration:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?", stderr_text)
+    match = _DURATION_RE.search(stderr_text)
     if not match:
         return None
     hours, minutes, seconds, frac = match.groups()
@@ -6289,7 +6292,7 @@ class HlsProducer:
         def _normalize_segment(match):
             return "seg_{}.{}".format(int(match.group(1)), match.group(2))
 
-        text = re.sub(r"seg_0*(\d+)\.(m4s|ts)", _normalize_segment, text)
+        text = _SEGMENT_RE.sub(_normalize_segment, text)
         return text.encode("utf-8")
 
     def _segment_complete(self, seg_n):
@@ -8844,7 +8847,7 @@ class StreamProxy:
                     status = getattr(resp, "status", None)
                     if status is None:
                         status = resp.getcode()
-                    match = re.match(r"^bytes\s+0-0/(\d+)$", cr.strip())
+                    match = _BYTES_RANGE_RE.match(cr.strip())
                     stream_length = int(match.group(1)) if match else 0
                     if status == 206 and stream_length == content_length_hint:
                         return content_length_hint


### PR DESCRIPTION
💡 **What:** Pre-compiles regular expressions at the module level in `repo/plugin.video.nzbdav/resources/lib/stream_proxy.py`.
🎯 **Why:** To remove compilation overhead inside frequently called functions/loops (specifically `_parse_ffmpeg_duration`, `generated_playlist_body`, and `_get_content_length`). 
📊 **Impact:** Reduces runtime overhead during video duration parsing, HLS segment string replacement, and range-request validations.
🔬 **Measurement:** Evaluated purely by removing compilation time overhead. Existing test suites provide confidence in unaltered functional semantics.

---
*PR created automatically by Jules for task [6620632636064530673](https://jules.google.com/task/6620632636064530673) started by @xbmc4lyfe*