### PR TITLE
🎨 Palette: [UX improvement] Add explicit directional navigation between list and scrollbar

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -68,6 +68,7 @@
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
       <scrolltime>200</scrolltime>
+      <onright>60</onright>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
       <itemlayout width="1910" height="66">
@@ -233,6 +234,7 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <showonepage>false</showonepage>
+      <onleft>50</onleft>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>
       <texturesliderbarfocus colordiffuse="FF4A9EFF">white.png</texturesliderbarfocus>


### PR DESCRIPTION
💡 What: Added explicit `<onright>` and `<onleft>` directional navigation attributes to link the main search results list (`id="50"`) and its associated scrollbar (`id="60"`).
🎯 Why: Without explicit mappings, users using a keyboard or D-pad remote cannot seamlessly navigate between the list items and the scrollbar, limiting ease-of-use and accessibility.
♿ Accessibility: Ensures full keyboard/remote D-pad navigability across UI elements, satisfying basic a11y requirements.

---
*PR created automatically by Jules for task [77000405662571518](https://jules.google.com/task/77000405662571518) started by @xbmc4lyfe*