### PR TITLE
🛡️ Sentinel: [security improvement] Secure `subprocess.Popen` execution

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -2095,7 +2095,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
             # fmt: on
         except OSError as error:
             xbmc.log("NZB-DAV: Failed to start ffmpeg: {}".format(error), xbmc.LOGERROR)
@@ -6682,7 +6682,7 @@ class HlsProducer:
                     cwd=self.session_dir,
                 )
                 # fmt: off
-                self._proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
+                self._proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
                 # fmt: on
             except OSError as e:
                 xbmc.log(
@@ -7419,7 +7419,7 @@ class StreamProxy:
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
             # fmt: on
             try:
                 output = proc.communicate(timeout=_FFMPEG_CAPABILITY_PROBE_TIMEOUT)
@@ -8589,7 +8589,7 @@ class StreamProxy:
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
             # fmt: on
             try:
                 stdout_bytes, _ = proc.communicate(timeout=30)
@@ -8664,7 +8664,7 @@ class StreamProxy:
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
             # fmt: on
         except (OSError, subprocess.SubprocessError, ValueError) as e:
             xbmc.log(
@@ -8791,7 +8791,7 @@ class StreamProxy:
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
             # fmt: on
             _, stderr = proc.communicate(timeout=600)  # 10 min timeout
             if proc.returncode != 0:

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -2088,15 +2088,13 @@ class _StreamHandler(BaseHTTPRequestHandler):
             xbmc.LOGINFO,
         )
         try:
-            kw = dict(
+            proc = subprocess.Popen(  # nosec B603 — argv list, shell=False
+                cmd,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
-            # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
-            # fmt: on
         except OSError as error:
             xbmc.log("NZB-DAV: Failed to start ffmpeg: {}".format(error), xbmc.LOGERROR)
             _notify_error("Failed to start ffmpeg")
@@ -6674,16 +6672,14 @@ class HlsProducer:
                 # stdin (TODO.md §H.3 Low — "ffmpeg Popen omits
                 # stdin=DEVNULL"). Harmless on Kodi but tidies the
                 # under-a-terminal case.
-                kw = dict(
+                self._proc = subprocess.Popen(  # nosec B603 — argv list, shell=False
+                    cmd,
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=self._ffmpeg_log,
                     shell=False,
                     cwd=self.session_dir,
                 )
-                # fmt: off
-                self._proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
-                # fmt: on
             except OSError as e:
                 xbmc.log(
                     "NZB-DAV: HLS producer ffmpeg spawn failed: {}".format(e),
@@ -7412,15 +7408,13 @@ class StreamProxy:
             return False
         cmd = [ffmpeg_path, "-hide_banner", "-h", "muxer=hls"]
         try:
-            kw = dict(
+            proc = subprocess.Popen(  # nosec B603 — argv list, shell=False
+                cmd,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
-            # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
-            # fmt: on
             try:
                 output = proc.communicate(timeout=_FFMPEG_CAPABILITY_PROBE_TIMEOUT)
                 if not isinstance(output, (tuple, list)) or len(output) != 2:
@@ -8582,15 +8576,13 @@ class StreamProxy:
                     input_url,
                 ]
             )
-            kw = dict(
+            proc = subprocess.Popen(  # nosec B603 — argv list, shell=False
+                cmd,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
-            # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
-            # fmt: on
             try:
                 stdout_bytes, _ = proc.communicate(timeout=30)
             except subprocess.TimeoutExpired:
@@ -8657,15 +8649,13 @@ class StreamProxy:
         cmd.extend(["-i", input_url, "-f", "null", "-"])
 
         try:
-            kw = dict(
+            proc = subprocess.Popen(  # nosec B603 — argv list, shell=False
+                cmd,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
-            # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
-            # fmt: on
         except (OSError, subprocess.SubprocessError, ValueError) as e:
             xbmc.log(
                 "NZB-DAV: {} probe spawn failed: {}".format(label, e),
@@ -8784,15 +8774,13 @@ class StreamProxy:
         proc = None
         try:
             xbmc.log("NZB-DAV: Temp-file faststart remux starting", xbmc.LOGINFO)
-            kw = dict(
+            proc = subprocess.Popen(  # nosec B603 — argv list, shell=False
+                cmd,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
-            # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm[py/command-line-injection]  # nosec B603
-            # fmt: on
             _, stderr = proc.communicate(timeout=600)  # 10 min timeout
             if proc.returncode != 0:
                 # ffmpeg error messages routinely echo the full input

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -2088,9 +2088,15 @@ class _StreamHandler(BaseHTTPRequestHandler):
             xbmc.LOGINFO,
         )
         try:
-            proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False
+            kw = dict(
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
             )
+            # fmt: off
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            # fmt: on
         except OSError as error:
             xbmc.log("NZB-DAV: Failed to start ffmpeg: {}".format(error), xbmc.LOGERROR)
             _notify_error("Failed to start ffmpeg")
@@ -6668,14 +6674,16 @@ class HlsProducer:
                 # stdin (TODO.md §H.3 Low — "ffmpeg Popen omits
                 # stdin=DEVNULL"). Harmless on Kodi but tidies the
                 # under-a-terminal case.
-                self._proc = subprocess.Popen(
-                    cmd,
+                kw = dict(
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=self._ffmpeg_log,
                     shell=False,
                     cwd=self.session_dir,
                 )
+                # fmt: off
+                self._proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+                # fmt: on
             except OSError as e:
                 xbmc.log(
                     "NZB-DAV: HLS producer ffmpeg spawn failed: {}".format(e),
@@ -7404,12 +7412,15 @@ class StreamProxy:
             return False
         cmd = [ffmpeg_path, "-hide_banner", "-h", "muxer=hls"]
         try:
-            proc = subprocess.Popen(
-                cmd,
+            kw = dict(
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
+            # fmt: off
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            # fmt: on
             try:
                 output = proc.communicate(timeout=_FFMPEG_CAPABILITY_PROBE_TIMEOUT)
                 if not isinstance(output, (tuple, list)) or len(output) != 2:
@@ -8571,12 +8582,15 @@ class StreamProxy:
                     input_url,
                 ]
             )
-            proc = subprocess.Popen(
-                cmd,
+            kw = dict(
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
+            # fmt: off
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            # fmt: on
             try:
                 stdout_bytes, _ = proc.communicate(timeout=30)
             except subprocess.TimeoutExpired:
@@ -8643,12 +8657,15 @@ class StreamProxy:
         cmd.extend(["-i", input_url, "-f", "null", "-"])
 
         try:
-            proc = subprocess.Popen(
-                cmd,
+            kw = dict(
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 shell=False,
             )
+            # fmt: off
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            # fmt: on
         except (OSError, subprocess.SubprocessError, ValueError) as e:
             xbmc.log(
                 "NZB-DAV: {} probe spawn failed: {}".format(label, e),
@@ -8767,9 +8784,15 @@ class StreamProxy:
         proc = None
         try:
             xbmc.log("NZB-DAV: Temp-file faststart remux starting", xbmc.LOGINFO)
-            proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False
+            kw = dict(
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
             )
+            # fmt: off
+            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            # fmt: on
             _, stderr = proc.communicate(timeout=600)  # 10 min timeout
             if proc.returncode != 0:
                 # ffmpeg error messages routinely echo the full input

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -2095,7 +2095,7 @@ class _StreamHandler(BaseHTTPRequestHandler):
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
             # fmt: on
         except OSError as error:
             xbmc.log("NZB-DAV: Failed to start ffmpeg: {}".format(error), xbmc.LOGERROR)
@@ -6682,7 +6682,7 @@ class HlsProducer:
                     cwd=self.session_dir,
                 )
                 # fmt: off
-                self._proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+                self._proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
                 # fmt: on
             except OSError as e:
                 xbmc.log(
@@ -7419,7 +7419,7 @@ class StreamProxy:
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
             # fmt: on
             try:
                 output = proc.communicate(timeout=_FFMPEG_CAPABILITY_PROBE_TIMEOUT)
@@ -8589,7 +8589,7 @@ class StreamProxy:
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
             # fmt: on
             try:
                 stdout_bytes, _ = proc.communicate(timeout=30)
@@ -8664,7 +8664,7 @@ class StreamProxy:
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
             # fmt: on
         except (OSError, subprocess.SubprocessError, ValueError) as e:
             xbmc.log(
@@ -8791,7 +8791,7 @@ class StreamProxy:
                 shell=False,
             )
             # fmt: off
-            proc = subprocess.Popen(cmd, **kw)  # noqa: E501  # lgtm [py/command-line-injection]  # nosec B603
+            proc = subprocess.Popen(cmd, **kw)  # lgtm [py/command-line-injection]  # nosec B603  # noqa: E501
             # fmt: on
             _, stderr = proc.communicate(timeout=600)  # 10 min timeout
             if proc.returncode != 0:


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Secure `subprocess.Popen` execution

Explicitly pass `stdin=subprocess.DEVNULL` to all `subprocess.Popen` invocations in `stream_proxy.py` to prevent background child processes from attempting to read from `stdin` and hanging indefinitely. Extracted `subprocess.Popen` arguments to intermediate dictionaries and safely satisfied security linters using standard suppression comments. Recorded findings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10046843798406952283](https://jules.google.com/task/10046843798406952283) started by @xbmc4lyfe*