### PR TITLE
🎨 Palette: Improve keyboard navigation between list and scrollbar

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -67,6 +67,7 @@
       <left>0</left><top>60</top><width>1910</width><height>975</height>
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
+      <onright>60</onright>
       <scrolltime>200</scrolltime>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
@@ -232,6 +233,7 @@
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
+      <onleft>50</onleft>
       <showonepage>false</showonepage>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>


### PR DESCRIPTION
💡 **What:** Added `<onright>60</onright>` to the main results list and `<onleft>50</onleft>` to the scrollbar in `results-dialog.xml`.
🎯 **Why:** Kodi does not automatically infer horizontal navigation paths between custom UI controls. This prevents keyboard and remote control users from accessing the scrollbar to navigate long lists quickly.
♿ **Accessibility:** Improves keyboard accessibility by manually bridging focus from the main list to the scrollbar and back, conforming to Kodi skinning best practices.

---
*PR created automatically by Jules for task [17406051583296530887](https://jules.google.com/task/17406051583296530887) started by @xbmc4lyfe*