### PR TITLE
test(stream_proxy): direct coverage for segment-name normalization regex

### DIFF
--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -4773,6 +4773,26 @@ def test_serve_hls_playlist_prefers_generated_ffmpeg_durations(tmp_path):
         producer.close()
 
 
+def test_segment_normalize_re_strips_zero_padding():
+    """_SEGMENT_NORMALIZE_RE strips zero-padding from both .m4s and .ts
+    segment names, preserves multi-digit indices, and leaves the all-zero
+    index as a single 0 (parity with the former int()-based callback). The
+    existing playlist test only exercises the fmp4/.m4s path, so this pins
+    the .ts branch and multi-digit stripping directly."""
+    from resources.lib.stream_proxy import _SEGMENT_NORMALIZE_RE
+
+    def norm(text):
+        return _SEGMENT_NORMALIZE_RE.sub(r"seg_\1.\2", text)
+
+    assert norm("seg_000000.m4s") == "seg_0.m4s"
+    assert norm("seg_000001.m4s") == "seg_1.m4s"
+    assert norm("seg_000123.ts") == "seg_123.ts"
+    assert norm("seg_010.ts") == "seg_10.ts"
+    # already minimal -> unchanged
+    assert norm("seg_0.ts") == "seg_0.ts"
+    assert norm("seg_7.m4s") == "seg_7.m4s"
+
+
 def test_serve_hls_playlist_fmp4_version_is_7():
     """fmp4 ctx emits #EXT-X-VERSION:7."""
     from resources.lib.stream_proxy import _StreamHandler


### PR DESCRIPTION
## What
Adds a focused unit test for `_SEGMENT_NORMALIZE_RE` (the pre-compiled HLS segment-name normalizer already on `main`).

## Why
The existing test only exercises the **fmp4/`.m4s`** path through the handler. This pins the parts left uncovered:
- the **`.ts`** branch of the `(m4s|ts)` alternation
- **multi-digit** index preservation (`seg_000123.ts` → `seg_123.ts`)
- the all-zero edge case (`seg_000000` → `seg_0`)

## Context
Salvaged from PR #295, which proposed an *equivalent* pre-compiled-regex optimization that `main` had already independently landed. The perf change there was redundant churn, so #295 is being closed; this test is the only net-new value and is rebased cleanly onto `main`.

## Verification
- `pytest tests/test_stream_proxy.py::test_segment_normalize_re_strips_zero_padding` — passes
- `just lint` — ruff/black clean, pylint 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)