### PR TITLE
🎨 Palette: Add explicit visual focus indicator to results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -157,6 +157,13 @@
           <colordiffuse>FF182538</colordiffuse>
         </control>
 
+        <!-- Focus Accent Line -->
+        <control type="image">
+          <left>0</left><top>0</top><width>4</width><height>66</height>
+          <texture>white.png</texture>
+          <colordiffuse>FF4A9EFF</colordiffuse>
+        </control>
+
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->
         <control type="label">
           <left>6</left><top>4</top><width>32</width><height>30</height>


### PR DESCRIPTION
Adds a 4px blue accent bar to the focused state in the results dialog list. This explicitly highlights which list item has keyboard/remote focus, improving overall UI accessibility compared to relying purely on subtle background color shifts. Also logs this learning into `.Jules/palette.md`.

---
*PR created automatically by Jules for task [6106948580543071909](https://jules.google.com/task/6106948580543071909) started by @xbmc4lyfe*