### PR TITLE
🎨 Palette: [UX improvement] Add high-contrast focus indicator to results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -157,6 +157,13 @@
           <colordiffuse>FF182538</colordiffuse>
         </control>
 
+        <!-- High-contrast focus indicator bar -->
+        <control type="image">
+          <left>0</left><top>0</top><width>4</width><height>66</height>
+          <texture>white.png</texture>
+          <colordiffuse>FF4A9EFF</colordiffuse>
+        </control>
+
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->
         <control type="label">
           <left>6</left><top>4</top><width>32</width><height>30</height>


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add high-contrast focus indicator to results list

In `results-dialog.xml`, added an explicit, high-contrast visual focus indicator bar (4px wide, using the primary brand color `FF4A9EFF`) to the left edge of the `<focusedlayout>`. This addresses an accessibility and usability issue where the subtle background color shifts on focus were insufficient for users to unmistakably identify the currently focused item when using a keyboard or remote control.

---
*PR created automatically by Jules for task [11909427027090285193](https://jules.google.com/task/11909427027090285193) started by @xbmc4lyfe*