### PR TITLE
🎨 Palette: [UX improvement] Add high-contrast focus indicator to results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -157,6 +157,13 @@
           <colordiffuse>FF182538</colordiffuse>
         </control>
 
+        <!-- High-contrast visual focus indicator -->
+        <control type="image">
+          <left>0</left><top>0</top><width>4</width><height>66</height>
+          <texture>white.png</texture>
+          <colordiffuse>FF4A9EFF</colordiffuse>
+        </control>
+
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->
         <control type="label">
           <left>6</left><top>4</top><width>32</width><height>30</height>


### PR DESCRIPTION
💡 **What**: Added a 4px solid vertical accent bar using the primary brand color (`FF4A9EFF`) to the left edge of the `<focusedlayout>` in the results dialog.
🎯 **Why**: Subtle background color shifts for focused items in Kodi skins are insufficient for accessibility and make remote navigation difficult, as users may lose track of which item is currently focused.
♿ **Accessibility**: Improves keyboard and remote navigation by providing an explicit, high-contrast visual focus indicator, ensuring the active item is always unmistakably clear.

---
*PR created automatically by Jules for task [163400556343059473](https://jules.google.com/task/163400556343059473) started by @xbmc4lyfe*