### PR TITLE
🎨 Palette: [UX improvement] Add high-contrast focus indicator to results dialog list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -157,6 +157,13 @@
           <colordiffuse>FF182538</colordiffuse>
         </control>
 
+        <!-- Focus Indicator -->
+        <control type="image">
+          <left>0</left><top>0</top><width>4</width><height>66</height>
+          <texture>white.png</texture>
+          <colordiffuse>FF4A9EFF</colordiffuse>
+        </control>
+
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->
         <control type="label">
           <left>6</left><top>4</top><width>32</width><height>30</height>


### PR DESCRIPTION
💡 What: Added a 4px wide solid vertical accent bar to the left edge of the focused list item in `results-dialog.xml` using the primary brand color (`FF4A9EFF`).
🎯 Why: In Kodi XML skins, subtle background color shifts for focused items are often insufficient for users navigating with a keyboard or remote control. This explicit visual indicator ensures unmistakable focus feedback.
♿ Accessibility: Dramatically improves visual accessibility by ensuring a clear, high-contrast indicator when users move focus within the results list.

---
*PR created automatically by Jules for task [11542177381987611782](https://jules.google.com/task/11542177381987611782) started by @xbmc4lyfe*