### PR TITLE
fix(prowlarr): parse native /api/v1/search JSON response (#313)

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -320,6 +320,78 @@ def pubdate_to_epoch(pubdate_str):
         return None
 
 
+def iso8601_to_rfc2822(value):
+    """Convert an ISO-8601 datetime string to an RFC-2822 string.
+
+    Prowlarr's native JSON API reports ``publishDate`` in ISO-8601
+    (e.g. ``"2026-06-25T11:00:00Z"``), but every ``pubdate`` consumer in
+    this addon parses RFC-2822 via ``email.utils.parsedate_to_datetime``:
+    :func:`pubdate_to_epoch` (the stable identity key behind the picker's
+    DL/repost gate and the fallback same-window dedup) and
+    ``filter._pubdate_sort_key`` (the "Age" sort). ISO-8601 makes both
+    silently fail — epoch ``None`` / sort key ``0`` — so we normalize at
+    the source and keep the ``pubdate`` field format uniform rather than
+    teaching every consumer a second grammar.
+
+    Returns ``""`` when the input is empty or unparseable, matching the
+    "missing field becomes empty string" contract of the parse loops.
+    """
+    import re
+    from datetime import datetime, timezone
+    from email.utils import format_datetime
+
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    if not text:
+        return ""
+    # .NET (Prowlarr's stack) can emit up to 7 fractional-second digits,
+    # which pre-3.11 ``datetime.fromisoformat`` rejects; sub-second
+    # precision is irrelevant for identity/sort/age, so drop it.
+    text = re.sub(r"\.\d+", "", text)
+    # ``fromisoformat`` only accepts a trailing 'Z' from Python 3.11 on;
+    # map it to an explicit UTC offset for older Kodi runtimes (3.8–3.9).
+    if text[-1:] in ("Z", "z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except (TypeError, ValueError):
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    try:
+        return format_datetime(dt)
+    except (TypeError, ValueError, OverflowError):
+        return ""
+
+
+def age_string_from_days(days):
+    """Format an integer day-count as a human-readable age string.
+
+    Shared by the RFC-2822 ``pubDate`` path (``calculate_age``) and the
+    Prowlarr native-JSON path, which reports an integer ``age`` (in days)
+    directly rather than a parseable date string. Returns ``"today"``,
+    ``"1 day"``, ``"<n> days"``, ``"1 month"``, ``"<n> months"``, or an
+    empty string when ``days`` is missing, non-numeric, or negative.
+    """
+    try:
+        days = int(days)
+    except (TypeError, ValueError):
+        return ""
+    if days < 0:
+        return ""
+    if days == 0:
+        return "today"
+    if days == 1:
+        return "1 day"
+    if days < 30:
+        return "{} days".format(days)
+    months = days // 30
+    if months == 1:
+        return "1 month"
+    return "{} months".format(months)
+
+
 def calculate_age(pubdate_str):
     """Return a human-readable age string computed from an RFC 2822 date.
 
@@ -334,17 +406,7 @@ def calculate_age(pubdate_str):
         pub = parsedate_to_datetime(pubdate_str)
         now = datetime.now(timezone.utc)
         delta = now - pub
-        days = delta.days
-        if days == 0:
-            return "today"
-        if days == 1:
-            return "1 day"
-        if days < 30:
-            return "{} days".format(days)
-        months = days // 30
-        if months == 1:
-            return "1 month"
-        return "{} months".format(months)
+        return age_string_from_days(delta.days)
     except _PUBDATE_ERRORS:
         return ""
 

--- a/repo/plugin.video.nzbdav/resources/lib/prowlarr.py
+++ b/repo/plugin.video.nzbdav/resources/lib/prowlarr.py
@@ -1,15 +1,31 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 nzbdav contributors
 
-"""Prowlarr Newznab API client."""
+"""Prowlarr search client.
 
+Prowlarr's native ``/api/v1/search`` endpoint (the one this client calls,
+with the Prowlarr API key + ``indexerIds``) returns a **JSON** array of
+release objects — not Newznab RSS/XML. Historically this module parsed the
+response as XML, which crashed with ``syntax error: line 1, column 0`` the
+moment Prowlarr answered (issue #313). The parser now sniffs the payload and
+routes JSON to ``_parse_json_results`` while still understanding Newznab XML
+(e.g. a reverse-proxied per-indexer ``/{id}/api`` feed) via the legacy path.
+"""
+
+import json
 import xml.etree.ElementTree as ET  # nosec B405 — parsing trusted Prowlarr responses from user-configured local service
 from urllib.parse import urlencode, urlparse
 
 import xbmc
 
 from resources.lib.http_util import (
+    age_string_from_days as _age_from_days,
+)
+from resources.lib.http_util import (
     calculate_age as _calculate_age,
+)
+from resources.lib.http_util import (
+    iso8601_to_rfc2822 as _iso_to_rfc2822,
 )
 from resources.lib.http_util import (
     format_request_error as _format_request_error,
@@ -254,7 +270,90 @@ def parse_results(xml_text):
     return results
 
 
-def _parse_results_checked(xml_text):
+def _parse_results_checked(text):
+    """Parse a Prowlarr search response into normalized result dicts.
+
+    Prowlarr's native ``/api/v1/search`` returns a JSON array; a
+    reverse-proxied per-indexer Newznab feed returns RSS/XML. Sniff the
+    first non-whitespace character and dispatch accordingly so both shapes
+    work and a server that switches formats can't silently break search.
+
+    Returns ``(results, error_message)`` — ``error_message`` is ``None`` on
+    success or a short human-readable string on a malformed/unexpected body.
+    """
+    stripped = (text or "").lstrip()
+    if stripped[:1] in ("[", "{"):
+        return _parse_json_results(stripped)
+    return _parse_xml_results(text)
+
+
+def _parse_json_results(text):
+    """Parse a Prowlarr native ``/api/v1/search`` JSON array into result dicts.
+
+    Each element is a Prowlarr ``ReleaseResource``. Torrent releases are
+    skipped — nzbdav only consumes NZB/usenet downloads — and the remaining
+    fields are mapped onto the same ``{title, link, size, indexer, pubdate,
+    age}`` shape the XML path produces, so downstream consumers don't care
+    which transport answered.
+    """
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError) as e:
+        xbmc.log(
+            "NZB-DAV: Failed to parse Prowlarr JSON response: {}".format(e),
+            xbmc.LOGERROR,
+        )
+        return [], "Prowlarr returned an invalid response: {}".format(e)
+
+    if not isinstance(data, list):
+        # Prowlarr error bodies are JSON objects ({"error": ...}), not arrays.
+        message = ""
+        if isinstance(data, dict):
+            message = data.get("error") or data.get("message") or ""
+        xbmc.log(
+            "NZB-DAV: Unexpected Prowlarr JSON payload (not an array): {}".format(
+                message or type(data).__name__
+            ),
+            xbmc.LOGERROR,
+        )
+        detail = ": {}".format(message) if message else ": expected a JSON array"
+        return [], "Prowlarr returned an invalid response{}".format(detail)
+
+    results = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        # nzbdav downloads NZBs; magnet/torrent releases are unusable here.
+        if (entry.get("protocol") or "").lower() == "torrent":
+            continue
+
+        size_val = entry.get("size")
+        if isinstance(size_val, bool):
+            size = ""
+        elif isinstance(size_val, int) and size_val > 0:
+            size = str(size_val)
+        elif isinstance(size_val, str) and size_val.strip().isdigit():
+            size = size_val.strip()
+        else:
+            size = ""
+
+        results.append(
+            {
+                "title": entry.get("title") or "",
+                "link": entry.get("downloadUrl") or "",
+                "size": size,
+                "indexer": entry.get("indexer") or "",
+                # publishDate is ISO-8601; normalize to RFC-2822 so the
+                # pubdate_to_epoch / Age-sort consumers can parse it.
+                "pubdate": _iso_to_rfc2822(entry.get("publishDate")),
+                "age": _age_from_days(entry.get("age")),
+            }
+        )
+
+    return results, None
+
+
+def _parse_xml_results(xml_text):
     """
     Parse a Prowlarr Newznab RSS XML response into a list of normalized
     result dictionaries.

--- a/tests/fixtures/prowlarr_movie_response.json
+++ b/tests/fixtures/prowlarr_movie_response.json
@@ -1,0 +1,47 @@
+[
+  {
+    "guid": "https://nzbgeek.info/details/abc123",
+    "age": 1,
+    "ageHours": 30.5,
+    "ageMinutes": 1830.0,
+    "size": 45000000000,
+    "indexerId": 1,
+    "indexer": "NZBgeek",
+    "title": "The.Matrix.1999.2160p.UHD.BluRay.REMUX.HDR.HEVC.DTS-HD.MA.7.1-GROUP",
+    "publishDate": "2026-06-25T11:00:00Z",
+    "downloadUrl": "http://192.168.1.12:9696/1/download?apikey=REDACTED&link=prowlarr-abc123",
+    "infoUrl": "https://nzbgeek.info/details/abc123",
+    "protocol": "usenet",
+    "categories": [{ "id": 2040, "name": "Movies/HD" }]
+  },
+  {
+    "guid": "https://nzbgeek.info/details/def456",
+    "age": 400,
+    "ageHours": 9600.0,
+    "size": 8200000000,
+    "indexerId": 1,
+    "indexer": "NZBgeek",
+    "title": "The.Matrix.1999.1080p.BluRay.x264-GROUP",
+    "publishDate": "2025-05-22T11:00:00Z",
+    "downloadUrl": "http://192.168.1.12:9696/1/download?apikey=REDACTED&link=prowlarr-def456",
+    "infoUrl": "https://nzbgeek.info/details/def456",
+    "protocol": "usenet",
+    "categories": [{ "id": 2040, "name": "Movies/HD" }]
+  },
+  {
+    "guid": "magnet-stub-xyz",
+    "age": 2,
+    "size": 12000000000,
+    "indexerId": 5,
+    "indexer": "SomeTorrentTracker",
+    "title": "The.Matrix.1999.1080p.BluRay.x264-TORRENT",
+    "publishDate": "2026-06-24T11:00:00Z",
+    "downloadUrl": null,
+    "magnetUrl": "magnet:?xt=urn:btih:DEADBEEF",
+    "infoUrl": "https://tracker.example/xyz",
+    "protocol": "torrent",
+    "seeders": 120,
+    "leechers": 4,
+    "categories": [{ "id": 2040, "name": "Movies/HD" }]
+  }
+]

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -8,6 +8,7 @@ from resources.lib.http_util import (
     HttpResponseTooLarge,
     http_get,
     http_post_json,
+    iso8601_to_rfc2822,
     notify,
     pubdate_to_epoch,
     redact_text,
@@ -331,6 +332,43 @@ def test_pubdate_to_epoch_returns_none_on_garbage():
     assert pubdate_to_epoch("") is None
     assert pubdate_to_epoch("not a date") is None
     assert pubdate_to_epoch(None) is None
+
+
+# --- iso8601_to_rfc2822 (Prowlarr native-JSON publishDate normalization) ---
+
+
+def test_iso8601_to_rfc2822_round_trips_through_pubdate_to_epoch():
+    """The whole point: an ISO-8601 publishDate must normalize to an
+    RFC-2822 string that pubdate_to_epoch can then parse to the correct
+    absolute epoch (it rejects raw ISO-8601)."""
+    # Sanity: pubdate_to_epoch genuinely cannot read ISO-8601.
+    assert pubdate_to_epoch("2021-12-15T12:00:00Z") is None
+    rfc = iso8601_to_rfc2822("2021-12-15T12:00:00Z")
+    assert "T" not in rfc  # converted, not passed through
+    assert pubdate_to_epoch(rfc) == 1639569600
+
+
+def test_iso8601_to_rfc2822_handles_offset_and_naive_and_fractional():
+    """Explicit offsets normalize to UTC; naive is assumed UTC; .NET-style
+    7-digit fractional seconds are tolerated."""
+    # Same instant via a -0500 offset.
+    assert pubdate_to_epoch(iso8601_to_rfc2822("2021-12-15T07:00:00-05:00")) == 1639569600
+    # No timezone -> assumed UTC.
+    assert pubdate_to_epoch(iso8601_to_rfc2822("2021-12-15T12:00:00")) == 1639569600
+    # Fractional seconds (7 digits, as .NET emits) are dropped, not fatal.
+    assert (
+        pubdate_to_epoch(iso8601_to_rfc2822("2021-12-15T12:00:00.1234567Z"))
+        == 1639569600
+    )
+
+
+def test_iso8601_to_rfc2822_returns_empty_on_bad_input():
+    """Empty / non-string / unparseable input returns '' (parse loops
+    treat a missing field as an empty string, never an exception)."""
+    assert iso8601_to_rfc2822("") == ""
+    assert iso8601_to_rfc2822(None) == ""
+    assert iso8601_to_rfc2822("not a date") == ""
+    assert iso8601_to_rfc2822(12345) == ""
 
 
 def test_http_post_json_posts_body_and_returns_text():

--- a/tests/test_prowlarr.py
+++ b/tests/test_prowlarr.py
@@ -4,7 +4,11 @@
 import os
 from unittest.mock import patch
 
-from resources.lib.prowlarr import parse_results, search_prowlarr
+from resources.lib.prowlarr import (
+    _parse_results_checked,
+    parse_results,
+    search_prowlarr,
+)
 
 
 def _load_fixture(name):
@@ -319,3 +323,166 @@ def test_parse_results_enclosure_length_fills_in_when_attr_size_missing():
     results = parse_results(xml_text)
     assert len(results) == 1
     assert results[0]["size"] == "987654321"
+
+
+# --- native JSON response parsing (issue #313) ---
+#
+# Prowlarr's /api/v1/search endpoint answers with a JSON array, not Newznab
+# XML. The old XML-only parser crashed every search with
+# "syntax error: line 1, column 0". These tests pin the JSON path.
+
+
+def test_parse_results_json_movie():
+    """A native Prowlarr JSON array parses into normalized result dicts."""
+    json_text = _load_fixture("prowlarr_movie_response.json")
+    results = parse_results(json_text)
+    # 3 entries in the fixture, but the torrent release is dropped.
+    assert len(results) == 2
+
+    first = results[0]
+    assert (
+        first["title"]
+        == "The.Matrix.1999.2160p.UHD.BluRay.REMUX.HDR.HEVC.DTS-HD.MA.7.1-GROUP"
+    )
+    assert first["link"].startswith("http://192.168.1.12:9696/1/download")
+    assert first["size"] == "45000000000"
+    assert first["indexer"] == "NZBgeek"
+    assert first["age"] == "1 day"
+
+    # publishDate (ISO-8601) is normalized to RFC-2822 so the stable-identity
+    # and "Age" sort consumers (pubdate_to_epoch / filter._pubdate_sort_key)
+    # can parse it — they reject ISO-8601 outright (issue #313 review).
+    from datetime import datetime, timezone
+
+    from resources.lib.http_util import pubdate_to_epoch
+
+    assert first["pubdate"] != "2026-06-25T11:00:00Z"  # normalized, not raw ISO
+    expected_epoch = int(
+        datetime(2026, 6, 25, 11, 0, 0, tzinfo=timezone.utc).timestamp()
+    )
+    assert pubdate_to_epoch(first["pubdate"]) == expected_epoch
+
+    # 400-day-old release -> 400 // 30 == 13 months.
+    assert results[1]["size"] == "8200000000"
+    assert results[1]["age"] == "13 months"
+    # Distinct, correctly-ordered post identities -> "Age" sort works.
+    assert pubdate_to_epoch(results[1]["pubdate"]) < pubdate_to_epoch(
+        first["pubdate"]
+    )
+
+
+def test_parse_results_json_filters_torrent_releases():
+    """Torrent releases are unusable for an NZB pipeline and must be dropped."""
+    json_text = _load_fixture("prowlarr_movie_response.json")
+    results = parse_results(json_text)
+    titles = [r["title"] for r in results]
+    assert "The.Matrix.1999.1080p.BluRay.x264-TORRENT" not in titles
+    assert all("magnet:" not in r["link"] for r in results)
+
+
+def test_parse_results_json_protocol_filter_case_insensitive():
+    """Prowlarr may serialize the protocol enum as 'Torrent' (capitalized)."""
+    json_text = (
+        '[{"title": "X", "downloadUrl": "http://x/1", "size": 100, '
+        '"protocol": "Torrent"}, '
+        '{"title": "Y", "downloadUrl": "http://x/2", "size": 200, '
+        '"protocol": "Usenet"}]'
+    )
+    results = parse_results(json_text)
+    assert len(results) == 1
+    assert results[0]["title"] == "Y"
+
+
+def test_parse_results_json_empty_array():
+    """An empty JSON array is a valid 'no results' answer, not an error."""
+    results, error = _parse_results_checked("[]")
+    assert results == []
+    assert error is None
+
+
+def test_parse_results_json_error_object_reports_message():
+    """Prowlarr error bodies are JSON objects; surface their message."""
+    results, error = _parse_results_checked('{"error": "Invalid API Key"}')
+    assert results == []
+    assert error == "Prowlarr returned an invalid response: Invalid API Key"
+
+
+def test_parse_results_json_non_array_object_without_message():
+    results, error = _parse_results_checked('{"unexpected": true}')
+    assert results == []
+    assert error == "Prowlarr returned an invalid response: expected a JSON array"
+
+
+def test_parse_results_json_malformed_reports_bad_response():
+    results, error = _parse_results_checked('[{"title": "truncated"')
+    assert results == []
+    assert error.startswith("Prowlarr returned an invalid response:")
+
+
+def test_parse_results_json_missing_fields_degrade_to_empty_strings():
+    """Sparse releases must not raise; missing fields become empty strings."""
+    results = parse_results('[{"title": "Only A Title"}]')
+    assert len(results) == 1
+    assert results[0] == {
+        "title": "Only A Title",
+        "link": "",
+        "size": "",
+        "indexer": "",
+        "pubdate": "",
+        "age": "",
+    }
+
+
+@patch("resources.lib.prowlarr._get_settings")
+@patch("resources.lib.prowlarr._http_get")
+def test_search_prowlarr_parses_json_response(mock_http, mock_settings):
+    """End-to-end regression for issue #313: a JSON body yields results,
+    not 'Prowlarr returned an invalid response'."""
+    mock_settings.return_value = ("http://192.168.1.12:9696", "testkey", ["1"])
+    mock_http.return_value = _load_fixture("prowlarr_movie_response.json")
+
+    results, error = search_prowlarr("movie", "The Avengers", imdb="tt0848228")
+    assert error is None
+    assert len(results) == 2
+
+    call_url = mock_http.call_args[0][0]
+    assert "/api/v1/search" in call_url
+    assert "t=movie" in call_url
+    assert "imdbid=tt0848228" in call_url
+
+
+def test_parse_results_json_size_as_digit_string():
+    """Some indexers serialize size as a numeric string, not an int."""
+    results = parse_results(
+        '[{"title": "Z", "downloadUrl": "http://x/3", "size": "500", '
+        '"protocol": "usenet"}]'
+    )
+    assert len(results) == 1
+    assert results[0]["size"] == "500"
+
+
+def test_parse_results_json_size_non_digit_string_is_dropped():
+    """A non-numeric size string must degrade to empty, not crash/leak."""
+    results = parse_results(
+        '[{"title": "Z", "downloadUrl": "http://x/3", "size": "unknown", '
+        '"protocol": "usenet"}]'
+    )
+    assert len(results) == 1
+    assert results[0]["size"] == ""
+
+
+def test_parse_results_json_error_object_message_key_fallback():
+    """Prowlarr error bodies may use 'message' instead of 'error'."""
+    results, error = _parse_results_checked('{"message": "Indexer offline"}')
+    assert results == []
+    assert error == "Prowlarr returned an invalid response: Indexer offline"
+
+
+def test_parse_results_json_skips_non_dict_array_entries():
+    """A defensive array with stray scalars must skip them, not raise."""
+    results = parse_results(
+        '[null, 42, "junk", {"title": "X", "downloadUrl": "http://x/1", '
+        '"protocol": "Usenet"}]'
+    )
+    assert len(results) == 1
+    assert results[0]["title"] == "X"


### PR DESCRIPTION
## What & why

Addresses #313 — Prowlarr searches crashed with `Failed to parse Prowlarr XML response: syntax error: line 1, column 0`. (Intentionally **not** using an auto-close keyword — keeping #313 open until the reporter confirms the fix on their setup.)

**Root cause:** Prowlarr's native `GET /api/v1/search` (the endpoint this client calls, with the Prowlarr API key + `indexerIds`) returns a **JSON array** of `ReleaseResource` objects — not Newznab RSS/XML. The client parsed every response as XML, so it failed on the leading `[` the moment Prowlarr answered (the user even tried `&format=xml`; the native API ignores it).

## Changes

- **Format-sniffing dispatcher.** `_parse_results_checked` now inspects the first non-whitespace character: `[`/`{` → JSON (`_parse_json_results`), `<` → the legacy Newznab XML path (still supported for reverse-proxied per-indexer feeds). The public `parse_results()` handles both.
- **`_parse_json_results`** maps Prowlarr `ReleaseResource` → the existing `{title, link, size, indexer, pubdate, age}` shape (`link` ← `downloadUrl`), and **skips torrent releases** (case-insensitive `protocol`) since nzbdav only consumes NZBs.
- **pubdate contract.** `publishDate` is ISO-8601, but the `pubdate` field has an implicit **RFC-2822** contract across the addon — `http_util.pubdate_to_epoch` (the picker DL/repost identity gate + fallback same-window dedup) and `filter._pubdate_sort_key` (the "Age" sort) both reject ISO-8601 and fail soft. New `http_util.iso8601_to_rfc2822()` normalizes at the source (handles `Z`/offset/naive, strips .NET 7-digit fractional seconds, fails soft to `""`), keeping every consumer working.
- **Age.** `calculate_age` now delegates to a shared `age_string_from_days()` helper, which the JSON path uses against Prowlarr's integer `age` (days) field. Existing `calculate_age` behavior is preserved for all callers (hydra, direct_indexers, prowlarr XML).

## Testing

- `+12` Prowlarr JSON tests: end-to-end #313 regression (a JSON body yields results, not "invalid response"), torrent filtering, case-insensitive protocol, empty array, error bodies (`error`/`message` keys), malformed JSON, sparse fields, non-dict array entries, size-as-string, and a `pubdate_to_epoch` round-trip proving the RFC-2822 normalization.
- `+3` `iso8601_to_rfc2822` unit tests (round-trip, offset/naive/fractional, bad input).
- New JSON fixture `tests/fixtures/prowlarr_movie_response.json`.
- Full unit suite: **2066 passed, 7 skipped** (the one intermittent `test_stream_proxy.py` failure is a pre-existing cross-test daemon-leak flake — passes in isolation — tracked in #319, unrelated to this change).
- Reviewed via an adversarial multi-agent pass; all confirmed findings folded in (the ISO-pubdate contract issue above was caught there).

## Notes / follow-ups

- TV-search accuracy (`tvdbid` instead of `imdbid`), raised in the #313 comments, is split out to #318 as a separate enhancement.
- Pre-existing test flake tracked in #319.

Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)
