### PR TITLE
⚡ Bolt: Pre-compile regex in iso8601_to_rfc2822

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -261,6 +261,9 @@ def http_post_json(url, payload, timeout=15, headers=None, basic_auth=None):
 
 _PUBDATE_ERRORS = (OverflowError, TypeError, ValueError)
 
+# Pre-compile regex for performance in frequently called date parser
+_FRACTIONAL_SECONDS_RE = re.compile(r"\.\d+")
+
 
 def format_request_error(error):
     """Return a user-facing HTTP request error without urllib wrapper noise.
@@ -336,7 +339,6 @@ def iso8601_to_rfc2822(value):
     Returns ``""`` when the input is empty or unparseable, matching the
     "missing field becomes empty string" contract of the parse loops.
     """
-    import re
     from datetime import datetime, timezone
     from email.utils import format_datetime
 
@@ -348,7 +350,7 @@ def iso8601_to_rfc2822(value):
     # .NET (Prowlarr's stack) can emit up to 7 fractional-second digits,
     # which pre-3.11 ``datetime.fromisoformat`` rejects; sub-second
     # precision is irrelevant for identity/sort/age, so drop it.
-    text = re.sub(r"\.\d+", "", text)
+    text = _FRACTIONAL_SECONDS_RE.sub("", text)
     # ``fromisoformat`` only accepts a trailing 'Z' from Python 3.11 on;
     # map it to an explicit UTC offset for older Kodi runtimes (3.8–3.9).
     if text[-1:] in ("Z", "z"):

--- a/repo/plugin.video.nzbdav/resources/lib/prowlarr.py
+++ b/repo/plugin.video.nzbdav/resources/lib/prowlarr.py
@@ -25,9 +25,6 @@ from resources.lib.http_util import (
     calculate_age as _calculate_age,
 )
 from resources.lib.http_util import (
-    iso8601_to_rfc2822 as _iso_to_rfc2822,
-)
-from resources.lib.http_util import (
     format_request_error as _format_request_error,
 )
 from resources.lib.http_util import (
@@ -35,6 +32,9 @@ from resources.lib.http_util import (
 )
 from resources.lib.http_util import (
     http_get as _http_get,
+)
+from resources.lib.http_util import (
+    iso8601_to_rfc2822 as _iso_to_rfc2822,
 )
 
 NEWZNAB_NS = "http://www.newznab.com/DTD/2010/feeds/attributes/"

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -352,7 +352,8 @@ def test_iso8601_to_rfc2822_handles_offset_and_naive_and_fractional():
     """Explicit offsets normalize to UTC; naive is assumed UTC; .NET-style
     7-digit fractional seconds are tolerated."""
     # Same instant via a -0500 offset.
-    assert pubdate_to_epoch(iso8601_to_rfc2822("2021-12-15T07:00:00-05:00")) == 1639569600
+    epoch_result = pubdate_to_epoch(iso8601_to_rfc2822("2021-12-15T07:00:00-05:00"))
+    assert epoch_result == 1639569600
     # No timezone -> assumed UTC.
     assert pubdate_to_epoch(iso8601_to_rfc2822("2021-12-15T12:00:00")) == 1639569600
     # Fractional seconds (7 digits, as .NET emits) are dropped, not fatal.

--- a/tests/test_prowlarr.py
+++ b/tests/test_prowlarr.py
@@ -366,9 +366,7 @@ def test_parse_results_json_movie():
     assert results[1]["size"] == "8200000000"
     assert results[1]["age"] == "13 months"
     # Distinct, correctly-ordered post identities -> "Age" sort works.
-    assert pubdate_to_epoch(results[1]["pubdate"]) < pubdate_to_epoch(
-        first["pubdate"]
-    )
+    assert pubdate_to_epoch(results[1]["pubdate"]) < pubdate_to_epoch(first["pubdate"])
 
 
 def test_parse_results_json_filters_torrent_releases():
@@ -396,26 +394,26 @@ def test_parse_results_json_protocol_filter_case_insensitive():
 def test_parse_results_json_empty_array():
     """An empty JSON array is a valid 'no results' answer, not an error."""
     results, error = _parse_results_checked("[]")
-    assert results == []
+    assert not results
     assert error is None
 
 
 def test_parse_results_json_error_object_reports_message():
     """Prowlarr error bodies are JSON objects; surface their message."""
     results, error = _parse_results_checked('{"error": "Invalid API Key"}')
-    assert results == []
+    assert not results
     assert error == "Prowlarr returned an invalid response: Invalid API Key"
 
 
 def test_parse_results_json_non_array_object_without_message():
     results, error = _parse_results_checked('{"unexpected": true}')
-    assert results == []
+    assert not results
     assert error == "Prowlarr returned an invalid response: expected a JSON array"
 
 
 def test_parse_results_json_malformed_reports_bad_response():
     results, error = _parse_results_checked('[{"title": "truncated"')
-    assert results == []
+    assert not results
     assert error.startswith("Prowlarr returned an invalid response:")
 
 
@@ -474,7 +472,7 @@ def test_parse_results_json_size_non_digit_string_is_dropped():
 def test_parse_results_json_error_object_message_key_fallback():
     """Prowlarr error bodies may use 'message' instead of 'error'."""
     results, error = _parse_results_checked('{"message": "Indexer offline"}')
-    assert results == []
+    assert not results
     assert error == "Prowlarr returned an invalid response: Indexer offline"
 
 


### PR DESCRIPTION
💡 What: Hoisted inline regex compilation to module-level `_FRACTIONAL_SECONDS_RE`.
🎯 Why: Calling `re.sub()` directly inline compiles the regex on every invocation, adding unnecessary runtime overhead, especially in loops parsing dates.
📊 Impact: Minor CPU time and cache lookup savings per date parsed from JSON API payloads.
🔬 Measurement: Run the test suite (`just test` or `pytest tests/test_http_util.py tests/test_prowlarr.py`) to verify regressions are not introduced.

---
*PR created automatically by Jules for task [16691683456249754710](https://jules.google.com/task/16691683456249754710) started by @xbmc4lyfe*