### PR TITLE
perf(tests): cut `just test` from 7:42 to ~0:44 and de-flake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,5 @@ markers = [
     "integration: tests that spawn a real ffmpeg binary against a generated MKV; skipped by default, run via `just test-integration`",
     "functional: dev-box tests that use live services plus local playback simulation; skipped by default, run via `just functional-test`",
     "extreme: extreme functional test (20+ minutes, real services); skipped by default, run via `just extreme-functional-test`",
+    "real_readahead: opt out of the autouse read-ahead-daemon suppression so the test exercises the real _start_readahead_prefetch spawn",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,34 @@ def _reap_readahead_threads():
         monitor.waitForAbort.return_value = saved_ret
 
 
+@pytest.fixture(autouse=True)
+def _suppress_readahead_daemon(request):
+    """Skip spawning the read-ahead prefetch daemon in tests that don't target it.
+
+    ``prepare_stream`` spawns a per-session ``nzbdav-readahead`` daemon (read-ahead
+    is on by default). Because ``Monitor.waitForAbort`` REALLY sleeps in this
+    harness, that daemon backs off on real 0.25 s / 1.0 s sleeps: the autouse reaper
+    above then pays ~1.5 s per ``prepare_stream`` test joining it (≈30 s across the
+    suite), and any daemon that outlives the reaper's join races sibling tests'
+    patched ``urlopen`` — the root of the nondeterministic
+    ``test_prevalidated_fallback_reuses_current_probe`` full-suite flake. No general
+    test asserts the daemon spawned (``_serve_proxy`` never spawns it; only
+    ``prepare_stream`` does), so no-op the spawn by default. The few tests that
+    exercise the spawn directly opt back in with ``@pytest.mark.real_readahead``.
+    """
+    if request.node.get_closest_marker("real_readahead"):
+        yield
+        return
+    from resources.lib import stream_proxy
+
+    with patch.object(
+        stream_proxy.StreamProxy,
+        "_start_readahead_prefetch",
+        lambda self, ctx: None,
+    ):
+        yield
+
+
 @pytest.fixture
 def resolver_mocks():
     """Patch the dependencies that nearly every resolver test needs.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,10 +193,19 @@ def _suppress_readahead_daemon(request):
     patched ``urlopen`` — the root of the nondeterministic
     ``test_prevalidated_fallback_reuses_current_probe`` full-suite flake. No general
     test asserts the daemon spawned (``_serve_proxy`` never spawns it; only
-    ``prepare_stream`` does), so no-op the spawn by default. The few tests that
-    exercise the spawn directly opt back in with ``@pytest.mark.real_readahead``.
+    ``prepare_stream`` does), so no-op the spawn by default.
+
+    Exemptions keep the REAL daemon running:
+      * ``real_readahead`` — unit tests that exercise the spawn directly.
+      * ``functional`` / ``integration`` / ``extreme`` — the live/dev-box suites
+        (``just functional-test`` etc.) exist to catch real prefetch/cutover races
+        against actual playback; users get read-ahead by default, so suppressing it
+        there would hide exactly what those suites validate. They are excluded from
+        the default ``just test`` run, so this does not affect the fast unit suite's
+        speed-up or de-flaking.
     """
-    if request.node.get_closest_marker("real_readahead"):
+    keep_real_daemon = ("real_readahead", "functional", "integration", "extreme")
+    if any(request.node.get_closest_marker(marker) for marker in keep_real_daemon):
         yield
         return
     from resources.lib import stream_proxy

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -5819,7 +5819,16 @@ def test_resolve_poll_interval_respected(
 ):
     """resolve() waits between polls with the configured poll_interval."""
     poll_interval = 7
-    mock_poll.return_value = (poll_interval, 3600)
+    # Tiny download_timeout. status stays "Downloading" forever here, so resolve()
+    # only stops at its deadline. Its per-poll wait (_wait_for_abort_or_timeout)
+    # is mocked instant, so the loop does NOT pace on poll_interval — it busy-spins
+    # until the real-monotonic download_timeout deadline (or MAX_POLL_ITERATIONS).
+    # 3600s meant ~17s of spinning before the iteration cap; a fractional deadline
+    # bounds the wall clock directly. resolve() still calls the wait with
+    # poll_interval each pass, so assert_called_with(monitor, poll_interval) is
+    # unchanged. The wall time is the deadline, not the (machine-dependent)
+    # iteration count, so this stays deterministic.
+    mock_poll.return_value = (poll_interval, 0.1)
     mock_submit.return_value = ("SABnzbd_nzo_poll123", None)
     mock_status.return_value = {"status": "Downloading", "percentage": "50"}
     mock_history.return_value = None
@@ -7039,8 +7048,13 @@ def test_poll_until_ready_cleanup_on_max_iterations(
     mock_status.return_value = {"status": "Downloading", "percentage": "10"}
     mock_xbmc.Monitor.return_value = _make_monitor()
 
+    # poll_interval=0: the per-poll wait here is the REAL _wait_for_abort_or_timeout
+    # (not mocked in this test), which spins on a non-mockable real monotonic()
+    # clock, so a non-zero interval costs that many real seconds PER iteration.
+    # MAX_POLL_ITERATIONS is already patched small; zeroing the interval makes
+    # each iteration instant without changing the cancel-on-exhaustion behavior.
     url, headers = _poll_until_ready(
-        "http://hydra/nzb", "movie", _make_dialog(), 2, 3600
+        "http://hydra/nzb", "movie", _make_dialog(), 0, 3600
     )
 
     assert url is None

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -12585,10 +12585,42 @@ def test_serve_proxy_closes_without_zero_filling_remainder_when_recovery_exhaust
         except StopIteration:
             return _fail_probe()
 
-    with patch("resources.lib.stream_proxy.urlopen", side_effect=_dispatch), patch(
-        "resources.lib.stream_proxy.time.sleep"
-    ):
-        handler._serve_proxy(ctx)
+    # This test drives the REAL recovery-exhausted close path. It took ~120s
+    # because conftest's shared Monitor.waitForAbort mock REALLY sleeps its
+    # timeout arg (deliberately, so timing-sensitive HLS/probe tests stay
+    # realistic), and the recovery path backs off via waitForAbort on every
+    # retry-ladder (2,4,8s), skip-probe (2,4,6,8s) and patient-forward-stall
+    # iteration — the stall loop holding the client for the whole
+    # `passthrough_stall_wait` budget (default 120s) before giving up. Two scoped
+    # changes collapse the wall clock to ~0s without altering the path or its
+    # assertion:
+    #   * override ONLY this monitor's waitForAbort to return False instantly (no
+    #     abort, no sleep), restored afterwards. Patching the whole xbmc module
+    #     instead breaks the upstream read so the first chunk never lands.
+    #   * pin the runtime-settings seam _serve_proxy reads to a tiny POSITIVE
+    #     stall budget so the patient-stall exhausts at once. It MUST be >0 —
+    #     exactly 0 skips the `if stall_wait_budget > 0` block, so
+    #     forward_stall_exhausted is never set and the loop never terminates.
+    import sys as _sys
+
+    from resources.lib import stream_proxy as _sp_mod
+
+    fast_runtime = dict(_sp_mod._read_passthrough_runtime_settings())
+    fast_runtime["passthrough_stall_wait_seconds"] = 0.01
+
+    _monitor = _sys.modules["xbmc"].Monitor.return_value
+    _saved_side = _monitor.waitForAbort.side_effect
+    _monitor.waitForAbort.side_effect = lambda timeout=0.0: False
+    try:
+        with patch("resources.lib.stream_proxy.urlopen", side_effect=_dispatch), patch(
+            "resources.lib.stream_proxy.time.sleep"
+        ), patch(
+            "resources.lib.stream_proxy._passthrough_runtime_settings",
+            return_value=fast_runtime,
+        ):
+            handler._serve_proxy(ctx)
+    finally:
+        _monitor.waitForAbort.side_effect = _saved_side
 
     written = _collect_written(handler)
     assert written == first_chunk

--- a/tests/test_stream_proxy_readahead.py
+++ b/tests/test_stream_proxy_readahead.py
@@ -13,6 +13,7 @@ the bounded daemon prefetch run-loop, and lifecycle/teardown.
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
 from resources.lib import stream_proxy
 from resources.lib.stream_proxy import (
     _DEFAULT_READAHEAD_BUFFER_MB,
@@ -635,6 +636,7 @@ def _prefetchable_ctx(content_length=1_000_000, mb=256):
     }
 
 
+@pytest.mark.real_readahead
 def test_start_readahead_prefetch_disabled_when_zero():
     proxy = _make_proxy()
     ctx = _prefetchable_ctx(mb=0)
@@ -643,6 +645,7 @@ def test_start_readahead_prefetch_disabled_when_zero():
     assert _READAHEAD_THREAD_KEY not in ctx
 
 
+@pytest.mark.real_readahead
 def test_start_readahead_prefetch_gated_off_for_remux():
     proxy = _make_proxy()
     ctx = _prefetchable_ctx(mb=256)
@@ -651,6 +654,7 @@ def test_start_readahead_prefetch_gated_off_for_remux():
     assert _READAHEAD_BUFFER_KEY not in ctx
 
 
+@pytest.mark.real_readahead
 def test_start_readahead_prefetch_spawns_daemon():
     proxy = _make_proxy()
     ctx = _prefetchable_ctx(mb=256)
@@ -666,6 +670,7 @@ def test_start_readahead_prefetch_spawns_daemon():
         thread.join(2.0)
 
 
+@pytest.mark.real_readahead
 def test_start_readahead_prefetch_runtimeerror_pops_keys():
     proxy = _make_proxy()
     ctx = _prefetchable_ctx(mb=256)


### PR DESCRIPTION
Closes #319 — the flaky `test_prevalidated_fallback_reuses_current_probe_for_first_fallback_bytes` (cross-test daemon-thread leak), fixed by the read-ahead daemon suppression below.

## Summary

Speeds up `just test` from **7:42 → ~0:44 wall (~10.5×)** and removes a pre-existing nondeterministic flake. **Test-only — no production code changed.**

The suite was dominated by real-time waits in a handful of tests, not computation: `tests/conftest.py` makes the `Monitor.waitForAbort` mock **really sleep** its timeout (deliberate, so HLS/probe timing tests stay realistic), so any production loop that backs off via `waitForAbort` burns real wall-clock in tests.

## Changes

- **`test_serve_proxy_closes_..._recovery_exhausted`: 120s → 0.4s** (was ~54% of the whole suite). It let the pass-through patient-stall budget (`passthrough_stall_wait`, default 120s) elapse via real `waitForAbort` sleeps. Scope an instant no-sleep `waitForAbort` to this test and pin a tiny (`>0`) stall budget — identical code path and assertion (recovery still exhausts, remainder not zero-filled).
- **Two resolver poll tests: ~21s → ~0.3s.** `resolve()` / `_poll_until_ready` busy-spin to a real-monotonic `download_timeout` / `MAX_POLL_ITERATIONS` cap when the wait is mocked instant. Shrink the simulated deadline / interval; assertions unchanged.
- **Suppress the read-ahead prefetch daemon in tests that don't target it** via an autouse fixture that no-ops `StreamProxy._start_readahead_prefetch` (the only spawn site — `_serve_proxy` never spawns it) unless a test is marked `@pytest.mark.real_readahead`. Removes ~30s of per-`prepare_stream`-test reaper teardown **and** fixes the pre-existing nondeterministic `test_prevalidated_fallback_reuses_current_probe` flake, where a leaked daemon's `/fallback.mkv` read raced the test's patched `urlopen`.

## Results

| | Before | After |
|---|---|---|
| `just test` wall-clock | 7:42 | ~0:44 |
| Reliability | ~50% flaky | green across repeated full runs |
| Result | 2064 passed | 2064 passed |

## Notes

- **Test-only**, no production/runtime addon code touched; Python 3.8 runtime compatibility unaffected.
- The 120s test fix preserves the exact recovery-exhausted path and its assertion — it only removes the real-time wait, not the behavior under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
