### PR TITLE
chore(ci): stop CodeRabbit rate-limit from posting a failing status

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# Minimal CodeRabbit config. The one thing this overrides is commit-status
+# behavior on a *failed* review.
+#
+# When CodeRabbit cannot review a PR -- most commonly because the hourly review
+# rate limit is exceeded -- it was posting a red "CodeRabbit / failure" commit
+# status ("Review rate limit exceeded"; see PR #321). That reads like a failed
+# check even though `main` is not a protected branch and the review just needs a
+# retry on the next push.
+#
+# `fail_commit_status: false` stops the can't-review case from posting a failure
+# status. Successful reviews still post a green "success" status, because
+# `commit_status` defaults to true and is left untouched.
+reviews:
+  fail_commit_status: false

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ devdocs
 -*
 !/.gitignore
 !/.nojekyll
+!/.coderabbit.yaml
 !.env.example
 
 


### PR DESCRIPTION
## Problem

When CodeRabbit can't review a PR — most often because its **hourly review rate limit is exceeded** — it posts a red `CodeRabbit / failure` commit status (e.g. **#321** → *"Review rate limit exceeded"*). That reads like a failed check.

It never actually blocked merges (`main` isn't a protected branch), but it's misleading red noise that clears on the next push once the limit resets.

## Why a repo config file

CodeRabbit is a GitHub App posting a *commit status* — not a workflow we own, so it can't be fixed from `.github/workflows/`. The lever is `reviews.fail_commit_status` ([official schema](https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json)):

> Set the commit status to 'failure' when the PR cannot be reviewed by CodeRabbit for any reason. *(default: `false`)*

The documented default is already `false`, yet #321 failed — so the **org/dashboard** has this toggled on. A repo-level `.coderabbit.yaml` overrides the dashboard, so this pins the intended behavior in version control where it's reviewable and travels with the repo.

## Change

```yaml
reviews:
  fail_commit_status: false
```

- **Successful reviews still post a green ✓** — `commit_status` defaults to `true` and is left untouched.
- **The can't-review / rate-limited case posts no status** instead of red ✗.
- `.gitignore` ignores all dotfiles via `.*`, so a `!/.coderabbit.yaml` negation is added (matching the existing `!/.gitignore` / `!/.nojekyll` convention) to keep the file tracked.

| PR state | before | after |
|---|---|---|
| reviewed | green ✓ | green ✓ |
| rate-limited / unreviewable | **red ✗** | *(no status)* |

## Verification

- `just lint` — clean (black ✓, pylint 10.00/10, vermin 3.8-compatible).
- `just test` — 2104 passed; the lone failure is the pre-existing local-only chromadb `$rrf` mismatch (**#328**), which a YAML config can't affect.

## Trade-off

With `fail_commit_status: false`, a *genuine* can't-review case (not just rate limits) also goes silent rather than red. Given CodeRabbit is advisory here and `main` is unprotected, that's an acceptable and arguably desirable trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)