### PR TITLE
chore(ci): preserve CodeRabbit dashboard config via inheritance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,5 +12,13 @@
 # `fail_commit_status: false` stops the can't-review case from posting a failure
 # status. Successful reviews still post a green "success" status, because
 # `commit_status` defaults to true and is left untouched.
+#
+# `inheritance: true` is required, not cosmetic: CodeRabbit config sources do NOT
+# merge by default, so without it this repo file would win outright and every
+# field we don't name here (review profile, path filters, auto-review, learnings,
+# ...) would fall back to CodeRabbit system defaults instead of the Repository/Org
+# UI values. With inheritance on, this file merges with the dashboard/org config
+# and overrides only the single field below.
+inheritance: true
 reviews:
   fail_commit_status: false


### PR DESCRIPTION
## Follow-up to #336

CodeRabbit's [configuration overview](https://docs.coderabbit.ai/guides/configuration-overview) and v2 schema confirm: **config sources don't merge by default.** A repo `.coderabbit.yaml` outranks the Repository/Org UI settings, and `inheritance` defaults to `false` — so any field *omitted* from the repo file falls back to CodeRabbit **system defaults**, not the dashboard values.

That means #336's minimal file (only `reviews.fail_commit_status`) silently resets every other field — review profile, path filters, auto-review labels, accumulated learnings, etc. — to defaults. We know the dashboard had at least one non-default setting (`fail_commit_status` was effectively on; that's the entire reason for #336, see #321), so other UI/org config was being dropped.

## Change

Add top-level `inheritance: true`:

```yaml
inheritance: true
reviews:
  fail_commit_status: false
```

Now the file **merges** with the dashboard/org config and overrides only `fail_commit_status`. Strictly safer — it restores whatever was set in the UI, and is a no-op if nothing was.

Raised by `chatgpt-codex-connector` in review of #336 (https://github.com/Appz4Fun/nzbdavkodi/pull/336#discussion_r3487443176).

## Verification

- `just lint` — clean (black ✓, pylint 10.00/10, vermin 3.8-compatible).
- `just test` — 2104 passed; sole failure is the pre-existing local-only chromadb `$rrf` mismatch (#328), unrelated to YAML config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository settings to inherit shared defaults, so project-level configuration now combines with broader account or organization settings instead of replacing them.
  * Added clarification notes to explain how the configuration is expected to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->