### PR TITLE
🛡️ Sentinel: [security improvement] XXE protection for XML endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-05-18 - XXE Defense-in-Depth for `ET.fromstring`
+
+**Vulnerability:** Missing XML External Entity (XXE) protections for some standard library XML parsing endpoints.
+**Learning:** Python 3.8+ `xml.etree.ElementTree` attempts to disable external entity resolution by default, but it still resolves internal entities, creating potential Denial of Service (Billion Laughs) vectors. Also, standard library defenses are not as robust as `defusedxml`. While many endpoints used a custom expat parser wrapper (`_build_xxe_safe_parser`), `newznab_caps.py` and `router.py` still invoked `ET.fromstring` directly with only comments noting Python 3.8+ defaults.
+**Prevention:** Always apply defense-in-depth for standard library XML parsing. If `defusedxml` is not available, explicitly reject payloads containing `<!DOCTYPE` or `<!ENTITY` declarations before feeding them to `ET.fromstring`. Add explicit string checks before parsing: e.g., `if _contains_xml_declaration_markup(response): raise ValueError(...)`

--- a/repo/plugin.video.nzbdav/resources/lib/newznab_caps.py
+++ b/repo/plugin.video.nzbdav/resources/lib/newznab_caps.py
@@ -75,10 +75,20 @@ def _params(value):
     return [item.strip() for item in str(value or "").split(",") if item.strip()]
 
 
+def _contains_xml_declaration_markup(xml_text):
+    if isinstance(xml_text, bytes):
+        probe = xml_text.lower()
+        return b"<!doctype" in probe or b"<!entity" in probe
+    probe = str(xml_text).lower()
+    return "<!doctype" in probe or "<!entity" in probe
+
+
 def parse_caps(xml_text):
     try:
+        if _contains_xml_declaration_markup(xml_text):
+            raise ValueError("DTD and entity declarations are not allowed")
         root = ET.fromstring(xml_text)  # nosec B314 - Python 3.8+ disables entities
-    except (ET.ParseError, TypeError):
+    except (ET.ParseError, TypeError, ValueError):
         return _empty_caps()
 
     search_types = []

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -2162,13 +2162,23 @@ def _json_object(response):
     return data if isinstance(data, dict) else {}
 
 
+def _contains_xml_declaration_markup(xml_text):
+    if isinstance(xml_text, bytes):
+        probe = xml_text.lower()
+        return b"<!doctype" in probe or b"<!entity" in probe
+    probe = str(xml_text).lower()
+    return "<!doctype" in probe or "<!entity" in probe
+
+
 def _xml_root_name(response):
     """Return the unqualified root XML tag name, lowercased."""
     import xml.etree.ElementTree as ET  # nosec B405 - trusted service response
 
     try:
+        if _contains_xml_declaration_markup(response):
+            raise ValueError("DTD and entity declarations are not allowed")
         root = ET.fromstring(response)  # nosec B314 - trusted service response
-    except (TypeError, ET.ParseError):
+    except (TypeError, ET.ParseError, ValueError):
         return ""
     return root.tag.rsplit("}", 1)[-1].lower()
 


### PR DESCRIPTION
This PR implements a defense-in-depth protection against XML External Entity (XXE) and Billion Laughs (Denial of Service) attacks. 

While much of the codebase uses a secure wrapper for `ET.fromstring`, `resources/lib/newznab_caps.py` and `resources/lib/router.py` were calling `ET.fromstring` directly, relying entirely on Python 3.8+ defaults which disable external entities but *still* resolve internal entities.

This adds a strict string/bytes-level pre-validation function `_contains_xml_declaration_markup` to proactively reject any payloads containing `<!DOCTYPE` or `<!ENTITY` declarations before they are parsed by the standard library. The code has been safely updated to catch the resulting `ValueError` and fall back cleanly, avoiding unhandled exceptions or stack trace leaks on malformed indexer responses.

A corresponding entry was recorded in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4936881114460332019](https://jules.google.com/task/4936881114460332019) started by @xbmc4lyfe*