### PR TITLE
fix(search): strip query-breaking '&' from indexer keyword searches (closes #294)

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -147,6 +147,24 @@ def redact_text(text):
     return _EMBEDDED_URL_RE.sub(_redact_url_userinfo_span, redacted)
 
 
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def clean_search_query(title):
+    """Normalize a title for use as a Newznab/Prowlarr keyword query.
+
+    Indexers tokenize the ``q``/``query`` text and AND each term against
+    release names. A literal ``&`` (e.g. "Your Friends & Neighbors") becomes a
+    term that no release name carries — releases spell it "and" or drop it
+    entirely — so the search matches nothing and returns zero results (#294).
+    Replace ``&`` with a space and collapse the surrounding whitespace so the
+    remaining words still match; ``&``-free titles are returned unchanged.
+    """
+    if not title:
+        return ""
+    return _WHITESPACE_RE.sub(" ", str(title).replace("&", " ")).strip()
+
+
 _ALLOWED_HTTP_SCHEMES = frozenset({"http", "https"})
 HTTP_USER_AGENT = "NZB-DAV Kodi Addon"
 _HTTP_USER_AGENT = HTTP_USER_AGENT

--- a/repo/plugin.video.nzbdav/resources/lib/hydra.py
+++ b/repo/plugin.video.nzbdav/resources/lib/hydra.py
@@ -24,6 +24,9 @@ from resources.lib.http_util import (
     calculate_age as _calculate_age,
 )
 from resources.lib.http_util import (
+    clean_search_query as _clean_search_query,
+)
+from resources.lib.http_util import (
     format_request_error as _format_request_error,
 )
 from resources.lib.http_util import (
@@ -166,7 +169,11 @@ def _legacy_hydra_title_fallback(primary, title):
     # result (issue #318). Mirrors the Prowlarr fallback.
     fallback.pop("tvdbid", None)
     fallback.pop("imdbid", None)
-    fallback["q"] = title
+    # Clean the raw caller title here too (#294): this fallback is built in
+    # hydra (not via plan_newznab_search), so it bypasses the planner-level
+    # clean_search_query and would otherwise re-send a literal '&' the primary
+    # query already stripped — a term no release name carries.
+    fallback["q"] = _clean_search_query(title)
     return fallback
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/prowlarr.py
+++ b/repo/plugin.video.nzbdav/resources/lib/prowlarr.py
@@ -25,6 +25,9 @@ from resources.lib.http_util import (
     calculate_age as _calculate_age,
 )
 from resources.lib.http_util import (
+    clean_search_query as _clean_search_query,
+)
+from resources.lib.http_util import (
     format_request_error as _format_request_error,
 )
 from resources.lib.http_util import (
@@ -156,7 +159,11 @@ def _build_prowlarr_query(search_type, title, imdb="", tvdb="", season="", episo
             tokens.append("{{imdbid:{}}}".format(imdbid))
 
     token_str = "".join(tokens)
-    text = (title or "").strip()
+    # Strip query-breaking '&' from the keyword title (#294): Prowlarr passes
+    # the query text through to the indexer, which ANDs each term against
+    # release names that spell '&' as "and" or omit it. The {token:value} ids
+    # are appended after, so they are never touched.
+    text = _clean_search_query(title)
     if text and token_str:
         return "{} {}".format(text, token_str)
     return text or token_str

--- a/repo/plugin.video.nzbdav/resources/lib/search_planner.py
+++ b/repo/plugin.video.nzbdav/resources/lib/search_planner.py
@@ -5,6 +5,7 @@
 
 from dataclasses import dataclass
 
+from resources.lib.http_util import clean_search_query
 from resources.lib.indexer_presets import (
     DIRECT_FALLBACK_HOSTS,
     DOGNZB_TVSEARCH_FALLBACK_HOSTS,
@@ -34,6 +35,10 @@ def plan_newznab_search(
     tvdb=None,
 ):
     base = {"apikey": api_key, "o": "xml", "limit": max_results}
+    # Strip query-breaking '&' from the keyword title once, so every q=title
+    # branch below (and its title fallback) searches a term the indexer can
+    # actually match (#294). Id-keyed searches are unaffected.
+    title = clean_search_query(title)
     if _missing_caps(caps):
         return _missing_caps_plan(base, search_type, title, imdb, season, episode, tvdb)
 

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from resources.lib.http_util import (
     HttpResponseTooLarge,
+    clean_search_query,
     http_get,
     http_post_json,
     iso8601_to_rfc2822,
@@ -418,3 +419,29 @@ def test_http_post_json_rejects_non_http_scheme():
 
     with pytest.raises(ValueError):
         http_post_json("file:///etc/passwd", {}, timeout=5)
+
+
+# --- clean_search_query: strip query-breaking '&' from keyword searches (#294) ---
+
+
+def test_clean_search_query_drops_ampersand():
+    """A literal '&' in the title (e.g. 'Your Friends & Neighbors') must not
+    reach the indexer keyword search: release names spell it 'and' or omit it,
+    so an '&' token matches nothing and the search returns zero results (#294).
+    """
+    assert clean_search_query("Your Friends & Neighbors") == "Your Friends Neighbors"
+
+
+def test_clean_search_query_collapses_whitespace_left_by_ampersand():
+    """Removing '&' must not leave a double space that becomes an empty token."""
+    assert clean_search_query("Law & Order") == "Law Order"
+    assert clean_search_query("AT&T") == "AT T"
+
+
+def test_clean_search_query_leaves_plain_title_untouched():
+    assert clean_search_query("The Matrix") == "The Matrix"
+
+
+def test_clean_search_query_handles_empty_and_none():
+    assert clean_search_query("") == ""
+    assert clean_search_query(None) == ""

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -183,6 +183,50 @@ def test_search_hydra_no_caps_tvdb_fallback_strips_tvdbid(mock_settings):
     assert "q=Breaking+Bad" in fallback_url or "q=Breaking%20Bad" in fallback_url
 
 
+def test_legacy_hydra_title_fallback_strips_ampersand():
+    """The no-caps legacy fallback rebuilds q= from the RAW caller title, which
+    bypasses the planner-level clean. It must strip '&' itself (#294) or the
+    broadening retry re-sends a '&' term no release name carries."""
+    from resources.lib.hydra import _legacy_hydra_title_fallback
+
+    primary = {"apikey": "k", "t": "tvsearch", "tvdbid": "305288", "season": "1"}
+    fallback = _legacy_hydra_title_fallback(primary, "Will & Grace")
+
+    assert fallback["q"] == "Will Grace"
+    assert "&" not in fallback["q"]
+    assert "tvdbid" not in fallback  # still drops the failing id (#318)
+
+
+@patch("resources.lib.hydra._get_settings")
+def test_search_hydra_no_caps_title_fallback_strips_ampersand(mock_settings):
+    """End-to-end: with no provider caps the broadening retry's q= must be
+    '&'-free, matching the de-ampersanded query the planner already sends on the
+    primary (#294)."""
+    mock_settings.return_value = ("http://hydra:5076", "testkey")
+    empty_rss = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<rss version="2.0" '
+        'xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">'
+        '<channel><newznab:response offset="0" total="0"/></channel></rss>'
+    )
+    with patch("resources.lib.hydra._http_get") as mock_http, patch(
+        "resources.lib.hydra.load_provider_caps"
+    ) as mock_load_caps:
+        mock_load_caps.return_value = {}  # no caps -> legacy fallback path
+        mock_http.side_effect = [empty_rss, empty_rss]
+
+        results, error = hydra.search_hydra(
+            "episode", "Will & Grace", tvdb="305288", season="1", episode="1"
+        )
+
+    assert error is None
+    assert mock_http.call_count == 2
+    fallback_url = mock_http.call_args_list[1][0][0]
+    assert "tvdbid" not in fallback_url  # fallback dropped the failing id
+    assert "%26" not in fallback_url  # '&' stripped, not URL-encoded literal
+    assert _query_params(fallback_url)["q"] == "Will Grace"
+
+
 def test_parse_results_movie():
     xml_text = _load_fixture("hydra_movie_response.xml")
     results = parse_results(xml_text)

--- a/tests/test_prowlarr.py
+++ b/tests/test_prowlarr.py
@@ -95,6 +95,28 @@ def test_build_prowlarr_query_sanitizes_decorated_tvdb():
     assert q == "Show {tvdbid:81189}{season:1}{episode:2}"
 
 
+def test_build_prowlarr_query_strips_ampersand_from_title():
+    """A '&' in the title must not reach Prowlarr's keyword query — indexers
+    AND query terms against release names that spell it 'and' or omit it, so
+    an '&' token matches nothing and the search returns nothing (#294)."""
+    from resources.lib.prowlarr import _build_prowlarr_query
+
+    assert (
+        _build_prowlarr_query("movie", "Your Friends & Neighbors")
+        == "Your Friends Neighbors"
+    )
+
+
+def test_build_prowlarr_query_strips_ampersand_but_keeps_tokens():
+    """Title cleaning must leave the {token:value} ids intact."""
+    from resources.lib.prowlarr import _build_prowlarr_query
+
+    q = _build_prowlarr_query(
+        "episode", "Will & Grace", tvdb="305288", season="1", episode="2"
+    )
+    assert q == "Will Grace {tvdbid:305288}{season:1}{episode:2}"
+
+
 # --- parse_results tests ---
 
 

--- a/tests/test_search_planner.py
+++ b/tests/test_search_planner.py
@@ -61,6 +61,42 @@ def test_movie_title_on_nzbgeek_falls_back_to_search():
     assert plan.reason == "direct_movie_title_search_fallback"
 
 
+def test_movie_title_ampersand_stripped_from_query():
+    """A title with '&' must not put a literal '&' in the keyword query: the
+    indexer ANDs query terms against release names, which spell it 'and' or
+    omit it, so an '&' token matches nothing → zero results (#294)."""
+    plan = plan_newznab_search(
+        provider_kind="direct",
+        host="https://api.example.test",
+        search_type="movie",
+        title="Your Friends & Neighbors",
+        caps=_supported_caps(),
+        api_key="secret",
+        max_results=25,
+    )
+
+    assert plan.primary["q"] == "Your Friends Neighbors"
+    assert "&" not in plan.primary["q"]
+
+
+def test_episode_title_ampersand_stripped_from_query():
+    """The tvsearch keyword (and its title fallback) must also be '&'-free."""
+    plan = plan_newznab_search(
+        provider_kind="direct",
+        host="https://api.example.test",
+        search_type="episode",
+        title="Will & Grace",
+        season="1",
+        episode="1",
+        caps=_supported_caps(),
+        api_key="secret",
+        max_results=25,
+    )
+
+    assert plan.primary["q"] == "Will Grace"
+    assert plan.fallback["q"] == "Will Grace"
+
+
 def _supported_caps_with_tvdbid():
     caps = _supported_caps()
     caps["supported_params"]["tvsearch"] = ["q", "imdbid", "tvdbid", "season", "ep"]


### PR DESCRIPTION
## Problem

Titles containing an ampersand — e.g. **"Your Friends & Neighbors"** — return **zero results** from indexers (reported against NinjaCentral in #294).

## Root cause (and where it actually lives)

URL-encoding was never the issue: every query path already runs through `urlencode`, so `&` correctly becomes `%26` on the wire. The literal `&` then reaches the indexer as **keyword text**. NZBHydra2 / Prowlarr / the underlying Newznab indexer tokenize the `q`/`query` string and AND each term against stored release names — but release names never carry a literal `&` (scene/P2P naming spells it `and`, e.g. `Your.Friends.and.Neighbors.S01E01...`, or drops it). So the `&` term matches nothing and the search comes back empty.

**The zero-results failure is genuinely service-side** — NZBHydra2/Prowlarr/Newznab can't match a literal `&`. The addon's only correct lever is to send a query their AND-tokenizer *can* match. (NZBGet is a pure download backend and builds no keyword query, so it cannot be the origin.)

## Fix

`http_util.clean_search_query()` — replaces `&` with a space and collapses whitespace — applied at every place the addon builds a keyword query from the title:

| Location | Providers covered |
|----------|-------------------|
| `search_planner.plan_newznab_search` (entry) | NZBHydra2 + direct Newznab — primary, planner fallback, and missing-caps `q=` branches |
| `prowlarr._build_prowlarr_query` | Prowlarr — id-keyed path **and** the no-id title fallback |
| `hydra._legacy_hydra_title_fallback` | NZBHydra2 **degraded-caps** retry (built outside the planner) |

- `"Your Friends & Neighbors"` → `"Your Friends Neighbors"`, which still matches `Your.Friends.and.Neighbors...` (every query term is present in the release name).
- Replacing with a space (not `"and"`) is intentional: it matches releases that spell it `and` **and** those that omit it. Transliterating to `"and"` would re-break the dropped-separator variant.
- Id-keyed searches (`imdbid`/`tvdbid`) and Prowlarr's `{token:value}` ids are untouched; `&`-free titles pass through unchanged.

### Scope verification (multi-agent boundary audit)

I traced a `&`-bearing title/name through **every** integration boundary — direct Newznab, Prowlarr, NZBHydra2, NZBGet submit, nzbdav submit, identity/fallback/dedup, and the manual-search/link-fetch path — with adversarial verification. Conclusions:

- The three query builders above are the **only** addon-side paths that send a raw `&` keyword query. The `hydra._legacy_hydra_title_fallback` gap was found by this audit and is fixed here (second commit).
- All **post-search** boundaries (router dispatch, results cache, NZBGet/nzbdav submit `nzbname`/`DupeKey`, completed-file match, dedup/identity, the indexer-provided result `link`, and hydra's dup-upload lookup) are correctly **decoupled** — they key on the indexer-returned release title or on raw titles *symmetrically*. `clean_search_query` is deliberately **not** applied there; one-sided stripping would regress identity/dedup. (The existing `_INVALID_TITLE_RE`/`_normalize_title` sanitizers already map `&`→space, so those paths were always `&`-safe and stay consistent with this fix.)

## Tests (TDD — RED→GREEN)

- `test_http_util.py` — `clean_search_query` unit cases.
- `test_search_planner.py` — movie + episode `q`/fallback are `&`-free.
- `test_prowlarr.py` — `_build_prowlarr_query` strips `&` while keeping `{token:value}` ids intact.
- `test_hydra.py` — `_legacy_hydra_title_fallback` (unit) and the no-caps retry URL (integration) are `&`-free.

## Verification

- `just lint` — ruff/black clean, pylint **10.00/10**, vermin 3.8+ OK.
- `just test` — full suite green. (The one unrelated failure, `test_chroma_dev_search.py::...group_by_api`, is the known non-hermetic chromadb-version test tracked in #328 — independent of this change.)

## Known residual (out of scope — separate low-priority ticket)

`fallback_streams._normalize_title` keeps the literal word `and`, so a `&`-spelled and an `and`-spelled release of the same yearless/episode-less movie don't peer as fallbacks. It **fails closed** (never serves wrong content) and is unrelated to the #294 search bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)