### PR TITLE
fix(resolver): extend #282 stub guard to pre-submit cache-hit shortcuts

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -1892,18 +1892,41 @@ def _find_video_stream_for_folder(webdav_folder, settings_getter=None, title_hin
     return video_path, stream_url, stream_headers
 
 
+def _record_rejected_completed_id(completed_job, rejected_completed_ids):
+    """Record a rejected Completed row's ``nzo_id`` so the submit / poll-loop
+    by-name paths skip re-adopting the very row we just rejected.
+
+    No-op when no set was provided or the row has no ``nzo_id``. Shared by the
+    pre-submit shortcut's stub guard and its mid-file body probe so both
+    rejection reasons feed the same skip set.
+    """
+    if rejected_completed_ids is None:
+        return
+    rejected_nzo_id = completed_job.get("nzo_id")
+    if rejected_nzo_id:
+        rejected_completed_ids.add(rejected_nzo_id)
+
+
 def _completed_job_stream(
     title,
     completed_job,
     on_existing_completed=None,
     settings_getter=None,
     rejected_completed_ids=None,
+    download_size=None,
 ):
     """Return a WebDAV stream URL from a completed nzbdav history row.
 
     When the mid-file body probe rejects a row and ``rejected_completed_ids``
     is provided, the row's ``nzo_id`` is recorded into that set so the submit
     path that follows does not re-adopt the very row we just rejected.
+
+    ``download_size`` is the indexer-advertised release size (bytes), threaded
+    in from ``params['_download_size']``. It powers the same #282 job-start-stub
+    guard the post-submit accept path applies (``_discovered_video_is_stub``):
+    a stale stub left in a Completed row from a prior failed attempt has an
+    available body and would otherwise pass the probe below. Defaults to
+    ``None`` (guard fails open) so callers without a size are unaffected.
     """
     if not isinstance(completed_job, dict):
         return None
@@ -1932,16 +1955,28 @@ def _completed_job_stream(
     )
     if not video_path:
         return None
+    # #282 follow-up: reject nzbdav's job-start stub before the body probe. A
+    # stale stub left in a Completed row from a prior failed attempt has an
+    # available body and would otherwise pass the probe below and be served --
+    # the same placeholder .mp4 the post-submit accept path (_handle_history_result)
+    # rejects. Null it out here too and record the nzo_id so the submit / poll
+    # paths skip it. Fails open / pack-exempt inside _discovered_video_is_stub.
+    if _discovered_video_is_stub(video_path, download_size, title):
+        xbmc.log(
+            "NZB-DAV: '{}' completed row exposes '{}' far smaller than the "
+            "advertised release size; treating as nzbdav job-start stub and "
+            "re-downloading instead of streaming directly".format(title, video_path),
+            xbmc.LOGWARNING,
+        )
+        _record_rejected_completed_id(completed_job, rejected_completed_ids)
+        return None
     if not _completed_stream_body_available(stream_url, stream_headers):
         xbmc.log(
             "NZB-DAV: '{}' is marked Completed but its mid-file body is "
             "unavailable; re-downloading instead of streaming directly".format(title),
             xbmc.LOGWARNING,
         )
-        if rejected_completed_ids is not None:
-            rejected_nzo_id = completed_job.get("nzo_id")
-            if rejected_nzo_id:
-                rejected_completed_ids.add(rejected_nzo_id)
+        _record_rejected_completed_id(completed_job, rejected_completed_ids)
         return None
     return stream_url, stream_headers
 
@@ -1953,14 +1988,22 @@ def _existing_completed_stream(
     completed_job_lookup_done=False,
     settings_getter=None,
     rejected_completed_ids=None,
+    download_size=None,
 ):
-    """Return an already-downloaded stream URL when the title exists."""
+    """Return an already-downloaded stream URL when the title exists.
+
+    ``download_size`` (indexer-advertised bytes) is threaded to
+    ``_completed_job_stream`` so the pre-submit shortcut rejects the #282
+    job-start stub just like the post-submit accept path. Defaults to ``None``
+    (guard fails open).
+    """
     hinted_stream = _completed_job_stream(
         title,
         completed_job_hint,
         on_existing_completed=on_existing_completed,
         settings_getter=settings_getter,
         rejected_completed_ids=rejected_completed_ids,
+        download_size=download_size,
     )
     if hinted_stream is not None:
         return hinted_stream
@@ -1975,6 +2018,7 @@ def _existing_completed_stream(
         on_existing_completed=on_existing_completed,
         settings_getter=settings_getter,
         rejected_completed_ids=rejected_completed_ids,
+        download_size=download_size,
     )
 
 
@@ -2005,6 +2049,11 @@ def _picker_completed_stream(
         completed_job_lookup_done=lookup_done,
         settings_getter=settings_getter,
         rejected_completed_ids=rejected_completed_ids,
+        # The indexer-advertised size rides along on the picker params; thread it
+        # through so a picker-supplied Completed row that is the #282 job-start
+        # stub is rejected before the progress UI opens, exactly as the
+        # submit/poll paths do.
+        download_size=params.get("_download_size"),
     )
 
 
@@ -2606,6 +2655,12 @@ def _completed_copy_blocks_clear(title, settings_getter):
 
     def _probe():
         try:
+            # No download_size here on purpose: this gate only decides whether to
+            # SKIP clearing OTHER queued jobs, and never serves a stream to Kodi.
+            # Letting a stub look adoptable just leaves the queue intact -- the
+            # conservative default this guard already documents. The #282 stub
+            # guard runs on the authoritative playback probe (_poll_until_ready /
+            # picker), which DOES thread download_size and rejects the stub there.
             result["stream"] = _existing_completed_stream(
                 title, **_settings_getter_kwargs(settings_getter)
             )
@@ -3913,6 +3968,7 @@ def _poll_until_ready(
         completed_job_lookup_done=completed_job_lookup_done,
         settings_getter=settings_getter,
         rejected_completed_ids=rejected_completed_ids,
+        download_size=download_size,
     )
     if existing_stream is not None:
         return existing_stream

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -537,6 +537,208 @@ def test_completed_job_stream_streams_when_midfile_body_available(mock_find_stre
     assert stream == ("http://webdav/movie.mkv", {"Authorization": "Basic x"})
 
 
+# ---------------------------------------------------------------------------
+# #282 follow-up: the pre-submit cache-hit shortcuts (_completed_job_stream /
+# _existing_completed_stream / _picker_completed_stream) must reject the same
+# job-start stub the post-submit accept path does. A stale stub left in a
+# Completed history row from a prior failed attempt -- whose tiny body IS
+# available -- would otherwise pass the body probe and be served, bypassing the
+# #282 guard. Same advertised-size sanity check, threaded via download_size /
+# params["_download_size"]. Fails OPEN / pack-exempt exactly as the post-submit
+# guard does (see the _handle_history_result tests below).
+# ---------------------------------------------------------------------------
+
+
+@patch("resources.lib.webdav.get_video_file_size_hint", return_value=362_076_665)
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
+@patch("resources.lib.resolver._find_video_stream_for_folder")
+def test_completed_job_stream_rejects_stub_far_below_advertised(
+    mock_find_stream, mock_probe, _mock_size
+):
+    """A Completed row whose discovered video (362 MB) is a tiny fraction of the
+    advertised size (~81 GB) is nzbdav's job-start stub. The pre-submit shortcut
+    must reject it (return None) and record its nzo_id, even though its body IS
+    available -- the body probe is never reached."""
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/UNDERTAKERS.mp4",
+        "http://webdav/UNDERTAKERS.mp4",
+        {"Authorization": "Basic x"},
+    )
+    rejected = set()
+    job = {
+        "status": "Completed",
+        "name": "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+        "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+        "nzo_id": "stub_completed",
+    }
+
+    stream = _completed_job_stream(
+        "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+        job,
+        rejected_completed_ids=rejected,
+        download_size="81610612736",  # ~81 GB advertised
+    )
+
+    assert stream is None
+    assert "stub_completed" in rejected
+    mock_probe.assert_not_called()  # rejected on size before any body probe
+
+
+@patch("resources.lib.webdav.get_video_file_size_hint", return_value=80_000_000_000)
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
+@patch("resources.lib.resolver._find_video_stream_for_folder")
+def test_completed_job_stream_streams_single_file_matching_advertised(
+    mock_find_stream, mock_probe, _mock_size
+):
+    """A single-file release whose discovered video (~80 GB) is close to the
+    advertised size (~81 GB) is the real feature and streams normally."""
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/movie.mkv",
+        "http://webdav/movie.mkv",
+        {"Authorization": "Basic x"},
+    )
+
+    stream = _completed_job_stream(
+        "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+        {
+            "status": "Completed",
+            "name": "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+            "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+            "nzo_id": "good_completed",
+        },
+        download_size="81610612736",
+    )
+
+    assert stream == ("http://webdav/movie.mkv", {"Authorization": "Basic x"})
+
+
+@patch("resources.lib.webdav.get_video_file_size_hint", return_value=3_000_000_000)
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
+@patch("resources.lib.resolver._find_video_stream_for_folder")
+def test_completed_job_stream_streams_pack_episode_below_advertised(
+    mock_find_stream, mock_probe, _mock_size
+):
+    """A season pack's advertised size covers every episode, so a single picked
+    episode (3 GB) far below the pack size (30 GB) must NOT be rejected as a
+    stub -- the guard is skipped for packs."""
+    mock_find_stream.return_value = (
+        "/content/uncategorized/show/show.s01e03.mkv",
+        "http://webdav/show.s01e03.mkv",
+        {"Authorization": "Basic x"},
+    )
+
+    stream = _completed_job_stream(
+        "Some.Show.S01.1080p.WEB-DL.x264-GROUP",  # whole-season pack
+        {
+            "status": "Completed",
+            "name": "Some.Show.S01.1080p.WEB-DL.x264-GROUP",
+            "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/show",
+            "nzo_id": "pack_completed",
+        },
+        download_size="30000000000",  # 30 GB whole pack
+    )
+
+    assert stream == ("http://webdav/show.s01e03.mkv", {"Authorization": "Basic x"})
+
+
+@patch("resources.lib.webdav.get_video_file_size_hint", return_value=1_000_000)
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
+@patch("resources.lib.resolver._find_video_stream_for_folder")
+def test_completed_job_stream_streams_when_advertised_size_unknown(
+    mock_find_stream, mock_probe, _mock_size
+):
+    """Fail OPEN: with no advertised size the guard cannot judge plausibility,
+    so a tiny discovered file streams exactly as before (no regression)."""
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/movie.mkv",
+        "http://webdav/movie.mkv",
+        {"Authorization": "Basic x"},
+    )
+
+    stream = _completed_job_stream(
+        "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+        {
+            "status": "Completed",
+            "name": "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+            "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+            "nzo_id": "no_advertised",
+        },
+        download_size=None,
+    )
+
+    assert stream == ("http://webdav/movie.mkv", {"Authorization": "Basic x"})
+
+
+@patch("resources.lib.webdav.get_video_file_size_hint", return_value=362_076_665)
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
+@patch("resources.lib.resolver._find_video_stream_for_folder")
+def test_existing_completed_stream_rejects_stub_via_download_size(
+    mock_find_stream, mock_probe, _mock_size
+):
+    """_existing_completed_stream threads download_size down to the stub guard,
+    so a hinted Completed row that is actually the job-start stub is rejected
+    before its body is probed."""
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/UNDERTAKERS.mp4",
+        "http://webdav/UNDERTAKERS.mp4",
+        {"Authorization": "Basic x"},
+    )
+    job = {
+        "status": "Completed",
+        "name": "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+        "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+        "nzo_id": "stub_hint",
+    }
+
+    stream = _existing_completed_stream(
+        "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+        completed_job_hint=job,
+        completed_job_lookup_done=True,
+        download_size="81610612736",
+    )
+
+    assert stream is None
+    mock_probe.assert_not_called()
+
+
+@patch("resources.lib.webdav.get_video_file_size_hint", return_value=362_076_665)
+@patch("resources.lib.resolver._completed_stream_body_available", return_value=True)
+@patch("resources.lib.resolver._find_video_stream_for_folder")
+def test_picker_completed_stream_rejects_stub_via_params_download_size(
+    mock_find_stream, mock_probe, _mock_size
+):
+    """The picker pre-submit shortcut reads params['_download_size'] and rejects
+    the job-start stub before the progress UI opens, recording its nzo_id so the
+    submit/poll paths skip it too."""
+    from resources.lib.resolver import _picker_completed_stream
+
+    mock_find_stream.return_value = (
+        "/content/uncategorized/movie/UNDERTAKERS.mp4",
+        "http://webdav/UNDERTAKERS.mp4",
+        {"Authorization": "Basic x"},
+    )
+    rejected = set()
+    params = {
+        "_completed_job": {
+            "status": "Completed",
+            "name": "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+            "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
+            "nzo_id": "stub_picker",
+        },
+        "_download_size": "81610612736",
+    }
+
+    stream = _picker_completed_stream(
+        "The.Undertakers.2024.2160p.UHD.BluRay.x265-GROUP",
+        params,
+        rejected_completed_ids=rejected,
+    )
+
+    assert stream is None
+    assert "stub_picker" in rejected
+    mock_probe.assert_not_called()
+
+
 def test_fallback_worker_append_invokes_on_append_hook():
     """When a live-push hook is armed, each job the worker adopts fires it so
     late-adopted fallbacks get pushed to the proxy session."""


### PR DESCRIPTION
Follow-up to #340 (#282), **stacked on `fix/282-expected-length-size-validation`** — review/merge that first; GitHub will auto-retarget this PR to `main` once it lands.

## Problem

The #282 advertised-size stub guard only covers the **post-submit** accept path (`_handle_history_result`). The **pre-submit** cache-hit shortcuts gated only on body availability:

`_completed_job_stream` ← `_existing_completed_stream` ← `_picker_completed_stream`, plus `_poll_until_ready`'s adopt probe.

A stale job-start stub left in a Completed row from a prior failed attempt — whose tiny body *is* available — could still be served, bypassing the new guard. Narrow residual (router `_completed_job_matches_result`'s 15% name+size tolerance partially shields it today), but real.

## Fix

- Thread `download_size` (`params["_download_size"]`) into `_completed_job_stream` / `_existing_completed_stream` / `_picker_completed_stream`, and reuse the existing `_discovered_video_is_stub` helper **before** the body probe.
- The picker reads `_download_size` from its own `params`; its two call sites are unchanged.
- Extract `_record_rejected_completed_id` so the stub-guard and body-unavailable branches share one rejected-`nzo_id` recorder (the submit/poll paths then skip the rejected row).
- **Intentionally not threaded:** `_completed_copy_blocks_clear` (the clear-queue gate) — it only decides whether to skip cancelling *other* queued jobs and never serves a stream, so its conservative leave-queue-intact default is correct. Documented inline.

## Tests

Six focused tests mirroring the post-submit ones, written test-first:

- stub far below advertised → rejected, `nzo_id` recorded, body probe never reached
- single-file ≈ advertised → streams
- pack episode below advertised → exempt, streams
- advertised-size unknown → fails open, streams

…across all three pre-submit functions.

## Verification

- `just lint` — green (ruff, black, pylint 10.00/10, vermin → Python 3.8 compatible)
- `just test` — 2122 passed. The only failure is the pre-existing, unrelated `test_chroma_dev_search` non-hermetic chromadb mismatch (#328), which fails identically on the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)