### PR TITLE
fix(fallback): treat "&"/"and"/omitted conjunction as one content identity

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -78,6 +78,14 @@ urlopen = _NO_REDIRECT_OPENER.open  # noqa: F811
 _SAFE_JOB_RE = re.compile(r"^[A-Za-z0-9._ \[\]-]+$")
 _CONTENT_RANGE_RE = re.compile(r"^bytes\s+(\d+)-(\d+)/(\d+|\*)$")
 _NON_WORD_RE = re.compile(r"[\W_]+")
+# Conjunction words that name the same work whether spelled out, written as
+# "&", or omitted entirely ("Friends & Neighbors" / "Friends and Neighbors" /
+# "Friends Neighbors", "Jules et Jim" / "Jules Jim"). ``_normalize_title`` drops
+# these as standalone tokens so all spellings share one content identity. Kept
+# to the few high-confidence forms: English "and", French "et", German "und".
+# Single-letter conjunctions (Spanish "y"/"e", Polish "i") are excluded -- they
+# collide with stray single-character junk tokens and would over-collapse.
+_CONJUNCTION_TOKENS = frozenset(("and", "et", "und"))
 _INVALID_TITLE_RE = re.compile(r"[^A-Za-z0-9._ -]+")
 _FINGERPRINT_SAMPLE_COUNT = 100
 _FINGERPRINT_SMALL_SAMPLE_COUNT = 20
@@ -406,15 +414,25 @@ def _normalize_title(value):
     """Normalize release titles for conservative duplicate grouping."""
     if not isinstance(value, str):
         return ""
-    normalized = _NON_WORD_RE.sub(" ", value.lower())
-    # Treat "&", the literal word "and", and an omitted conjunction as one
-    # identity: drop a standalone "and" token so "Friends & Neighbors"
-    # (the "&" is already stripped by the non-word sub), "Friends and
-    # Neighbors", and "Friends Neighbors" all normalize equal and peer as
-    # fallbacks. Only a whole "and" word is dropped -- substrings stay intact
-    # (e.g. "Andromeda" is untouched), and ordinal words like Part "One"/"Two"
-    # are not conjunctions, so part/chapter discrimination is unaffected.
-    return " ".join(token for token in normalized.split() if token != "and")
+    # "&amp;" is the XML/HTML escape for "&". XML parsing normally decodes it,
+    # but double-escaped feeds ("&amp;amp;") leave a literal "&amp;" in the
+    # title; rewrite the exact entity to "&" so it collapses to nothing (like a
+    # bare "&") instead of leaving a stray "amp" token. The rewrite is exact, so
+    # a genuine "amp" word (e.g. "Marshall Amp") is left untouched.
+    lowered = value.lower().replace("&amp;", "&")
+    normalized = _NON_WORD_RE.sub(" ", lowered)
+    # Treat "&", the conjunction words ("and" plus the common foreign forms
+    # "et"/"und"), and an omitted conjunction as one identity: drop a standalone
+    # conjunction token so "Friends & Neighbors" (the "&" is already stripped by
+    # the non-word sub), "Friends and Neighbors", "Friends Neighbors", and
+    # "Jules et Jim"/"Jules Jim" all normalize equal and peer as fallbacks. Only
+    # a whole conjunction WORD is dropped -- substrings stay intact (e.g.
+    # "Andromeda"/"Planet"/"Underworld"), and ordinal words like Part
+    # "One"/"Two" are not conjunctions, so part/chapter discrimination is
+    # unaffected.
+    return " ".join(
+        token for token in normalized.split() if token not in _CONJUNCTION_TOKENS
+    )
 
 
 # Ordinal words PTT keeps inside a movie title (e.g. "Dune Part Two",

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -407,7 +407,14 @@ def _normalize_title(value):
     if not isinstance(value, str):
         return ""
     normalized = _NON_WORD_RE.sub(" ", value.lower())
-    return " ".join(normalized.split())
+    # Treat "&", the literal word "and", and an omitted conjunction as one
+    # identity: drop a standalone "and" token so "Friends & Neighbors"
+    # (the "&" is already stripped by the non-word sub), "Friends and
+    # Neighbors", and "Friends Neighbors" all normalize equal and peer as
+    # fallbacks. Only a whole "and" word is dropped -- substrings stay intact
+    # (e.g. "Andromeda" is untouched), and ordinal words like Part "One"/"Two"
+    # are not conjunctions, so part/chapter discrimination is unaffected.
+    return " ".join(token for token in normalized.split() if token != "and")
 
 
 # Ordinal words PTT keeps inside a movie title (e.g. "Dune Part Two",

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -415,23 +415,36 @@ def _normalize_title(value):
     if not isinstance(value, str):
         return ""
     # "&amp;" is the XML/HTML escape for "&". XML parsing normally decodes it,
-    # but double-escaped feeds ("&amp;amp;") leave a literal "&amp;" in the
-    # title; rewrite the exact entity to "&" so it collapses to nothing (like a
-    # bare "&") instead of leaving a stray "amp" token. The rewrite is exact, so
-    # a genuine "amp" word (e.g. "Marshall Amp") is left untouched.
-    lowered = value.lower().replace("&amp;", "&")
+    # but double-escaped feeds leave a literal entity in the title; rewrite it to
+    # "&" so it collapses to nothing (like a bare "&") instead of leaving a stray
+    # "amp" token. Decode REPEATEDLY so even a double-escaped "&amp;amp;" fully
+    # resolves -- each pass replaces "&amp;" (5 chars) with "&" (1 char), so the
+    # string strictly shrinks and the loop terminates. The rewrite is exact, so a
+    # genuine "amp" word (e.g. "Marshall Amp") is left untouched.
+    lowered = value.lower()
+    while "&amp;" in lowered:
+        lowered = lowered.replace("&amp;", "&")
     normalized = _NON_WORD_RE.sub(" ", lowered)
+    tokens = normalized.split()
     # Treat "&", the conjunction words ("and" plus the common foreign forms
-    # "et"/"und"), and an omitted conjunction as one identity: drop a standalone
-    # conjunction token so "Friends & Neighbors" (the "&" is already stripped by
-    # the non-word sub), "Friends and Neighbors", "Friends Neighbors", and
-    # "Jules et Jim"/"Jules Jim" all normalize equal and peer as fallbacks. Only
-    # a whole conjunction WORD is dropped -- substrings stay intact (e.g.
-    # "Andromeda"/"Planet"/"Underworld"), and ordinal words like Part
+    # "et"/"und"), and an omitted conjunction as one identity: drop a conjunction
+    # token so "Friends & Neighbors" (the "&" is already stripped by the non-word
+    # sub), "Friends and Neighbors", "Friends Neighbors", and "Jules et Jim"/
+    # "Jules Jim" all normalize equal and peer as fallbacks. Fold ONLY an
+    # INTERIOR conjunction (operand on both sides) -- that is the only true
+    # conjunction position. A leading/trailing token is content-bearing ("And
+    # Just Like That" is not "Just Like That"), and a lone token is never a
+    # conjunction ("ET"). Keeping boundary tokens also guarantees a non-empty
+    # title never folds to empty (an empty core title would match anything in the
+    # corroborated identity paths). Whole-token only, so substrings stay intact
+    # ("Andromeda"/"Planet"/"Underworld"), and ordinal words like Part
     # "One"/"Two" are not conjunctions, so part/chapter discrimination is
     # unaffected.
+    last = len(tokens) - 1
     return " ".join(
-        token for token in normalized.split() if token not in _CONJUNCTION_TOKENS
+        token
+        for index, token in enumerate(tokens)
+        if not (0 < index < last and token in _CONJUNCTION_TOKENS)
     )
 
 

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -3846,6 +3846,70 @@ def test_same_content_rejects_part_one_vs_part_two():
     assert fs._same_content(part_two, part_one) is False
 
 
+def test_normalize_title_collapses_conjunction_spellings():
+    """ "&", the literal word "and", and an omitted conjunction are one identity.
+
+    "Your Friends & Neighbors", "Your.Friends.and.Neighbors", and
+    "Your.Friends.Neighbors" all name the same work; normalization must
+    collapse all three spellings to a single token sequence so they peer.
+    """
+    from resources.lib import fallback_streams as fs
+
+    amp = fs._normalize_title("Your Friends & Neighbors")
+    andd = fs._normalize_title("Your Friends and Neighbors")
+    omitted = fs._normalize_title("Your Friends Neighbors")
+
+    assert amp == andd == omitted == "your friends neighbors"
+
+
+def test_normalize_title_preserves_part_ordinals():
+    """REGRESSION GUARD: dropping "and" must not weaken part/chapter discrimination.
+
+    The conjunction collapse strips only a standalone "and"; ordinal words that
+    distinguish "Part One" from "Part Two" must survive intact, and a substring
+    like "and" inside a real word (e.g. "Andromeda") must not be touched.
+    """
+    from resources.lib import fallback_streams as fs
+
+    assert fs._normalize_title("Dune Part One") == "dune part one"
+    assert fs._normalize_title("Dune Part Two") == "dune part two"
+    assert fs._normalize_title("Dune Part One") != fs._normalize_title("Dune Part Two")
+    assert fs._normalize_title("Andromeda") == "andromeda"
+
+
+def test_same_content_peers_conjunction_variants():
+    """A yearless/episode-less title peers across "&", "and", and omitted forms.
+
+    Without a year or episode to corroborate identity, the title comparison must
+    stand on its own. Before the conjunction collapse, only "&"-vs-omitted
+    peered; the surviving literal "and" token diverged, so "and"-vs-omitted and
+    "and"-vs-"&" missed legitimate fallback peers.
+    """
+    from resources.lib import fallback_streams as fs
+
+    amp = _result(
+        "Your.Friends.&.Neighbors.1080p.WEB-DL.x264-GROUP",
+        "https://idx/amp.nzb",
+        6000000000,
+    )
+    andd = _result(
+        "Your.Friends.and.Neighbors.1080p.WEB-DL.x264-GROUP",
+        "https://idx/and.nzb",
+        6000000000,
+    )
+    omitted = _result(
+        "Your.Friends.Neighbors.1080p.WEB-DL.x264-GROUP",
+        "https://idx/omitted.nzb",
+        6000000000,
+    )
+
+    assert fs._same_content(amp, andd) is True
+    assert fs._same_content(andd, amp) is True
+    assert fs._same_content(andd, omitted) is True
+    assert fs._same_content(omitted, andd) is True
+    assert fs._same_content(amp, omitted) is True
+
+
 def test_same_episode_with_part_token_matches_bare_repost():
     """An episode that carries an episode-title Part/Chapter token must still
     peer with the same SxxExx posted without that token.

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -3949,8 +3949,87 @@ def test_normalize_title_collapses_double_escaped_ampersand():
         == fs._normalize_title("Cats Dogs")
         == "cats dogs"
     )
+    # A DOUBLE-escaped entity ("&amp;amp;") must also fully decode, not leave a
+    # residual "&amp;" that becomes a stray "amp" token.
+    assert fs._normalize_title("Cats &amp;amp; Dogs") == "cats dogs"
     # The "&amp;" rewrite is exact: a genuine "amp" word is not a conjunction.
     assert fs._normalize_title("Marshall Amp Sessions") == "marshall amp sessions"
+
+
+def test_normalize_title_keeps_leading_conjunction_word():
+    """A leading "and"/"et"/"und" is a content word, not a conjunction.
+
+    Conjunction folding must only fire INTERIOR (operand on both sides). A
+    leading conjunction is content-bearing -- "And Just Like That" is a
+    different work from "Just Like That" -- so it must survive normalization
+    rather than collapse the two titles to one identity.
+    """
+    from resources.lib import fallback_streams as fs
+
+    assert fs._normalize_title("And Just Like That") == "and just like that"
+    assert fs._normalize_title("And Just Like That") != fs._normalize_title(
+        "Just Like That"
+    )
+
+
+def test_normalize_title_keeps_lone_conjunction_token():
+    """A title that is ONLY a conjunction token (e.g. "ET") is never folded away.
+
+    Folding a lone token to an empty title is dangerous: an empty core title
+    matches any release in the corroborated paths. Interior-only folding keeps
+    boundary tokens, so a non-empty title never normalizes to empty.
+    """
+    from resources.lib import fallback_streams as fs
+
+    assert fs._normalize_title("ET") == "et"
+    assert fs._normalize_title("ET") != ""
+    assert fs._normalize_title("ET 1982") == "et 1982"
+
+
+def test_same_content_rejects_leading_and_vs_bare():
+    """REGRESSION GUARD: a leading-"and" title is different content from the bare.
+
+    "And Just Like That" and "Just Like That" are different shows; with no year
+    or episode to corroborate, the title gate must reject the pair rather than
+    peer them just because the leading "and" was folded away.
+    """
+    from resources.lib import fallback_streams as fs
+
+    leading = _result(
+        "And.Just.Like.That.1080p.WEB-DL.x264-GROUP",
+        "https://idx/and-jlt.nzb",
+        6000000000,
+    )
+    bare = _result(
+        "Just.Like.That.1080p.WEB-DL.x264-GROUP",
+        "https://idx/jlt.nzb",
+        6000000000,
+    )
+    assert fs._same_content(leading, bare) is False
+    assert fs._same_content(bare, leading) is False
+
+
+def test_same_content_rejects_lone_acronym_vs_other_same_year():
+    """REGRESSION GUARD: a lone-token title must not fold to empty and match by year.
+
+    "ET" (parsed title "ET") must not peer with an unrelated movie of the same
+    year. Folding "et" to an empty title would let the year-corroborated path
+    accept any 1982 release.
+    """
+    from resources.lib import fallback_streams as fs
+
+    et_movie = _result(
+        "ET.1982.1080p.BluRay.x264-GROUP",
+        "https://idx/et.nzb",
+        6000000000,
+    )
+    other = _result(
+        "Blade.Runner.1982.1080p.BluRay.x264-GROUP",
+        "https://idx/blade.nzb",
+        6000000000,
+    )
+    assert fs._same_content(et_movie, other) is False
+    assert fs._same_content(other, et_movie) is False
 
 
 def test_normalize_title_only_drops_whole_conjunction_words():

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -3910,6 +3910,89 @@ def test_same_content_peers_conjunction_variants():
     assert fs._same_content(amp, omitted) is True
 
 
+def test_normalize_title_collapses_foreign_conjunctions():
+    """French "et" and German "und" are conjunctions too, like "and"/"&".
+
+    "Jules et Jim" / "Jules and Jim" / "Jules Jim" name the same work, as do the
+    "und" spellings, so every variant must normalize to one shared identity.
+    """
+    from resources.lib import fallback_streams as fs
+
+    assert (
+        fs._normalize_title("Jules et Jim")
+        == fs._normalize_title("Jules and Jim")
+        == fs._normalize_title("Jules Jim")
+        == "jules jim"
+    )
+    assert (
+        fs._normalize_title("Dog Day und Night")
+        == fs._normalize_title("Dog Day and Night")
+        == fs._normalize_title("Dog Day Night")
+        == "dog day night"
+    )
+
+
+def test_normalize_title_collapses_double_escaped_ampersand():
+    """A literal "&amp;" (from a double-escaped feed) collapses like a bare "&".
+
+    XML parsing normally decodes "&amp;" to "&", but double-escaped feeds
+    ("&amp;amp;") leave the literal entity in the title. It must collapse to the
+    same identity as "&", "and", and the omitted form -- not leave a stray
+    "amp" token. A real "amp" WORD must be left untouched.
+    """
+    from resources.lib import fallback_streams as fs
+
+    assert (
+        fs._normalize_title("Cats &amp; Dogs")
+        == fs._normalize_title("Cats & Dogs")
+        == fs._normalize_title("Cats and Dogs")
+        == fs._normalize_title("Cats Dogs")
+        == "cats dogs"
+    )
+    # The "&amp;" rewrite is exact: a genuine "amp" word is not a conjunction.
+    assert fs._normalize_title("Marshall Amp Sessions") == "marshall amp sessions"
+
+
+def test_normalize_title_only_drops_whole_conjunction_words():
+    """REGRESSION GUARD: only standalone conjunction WORDS are dropped.
+
+    A conjunction spelled as a substring of a real word (e.g. "et" in "Planet",
+    "und" in "Underworld", "and" in "Andromeda") must survive untouched -- the
+    collapse is whole-token only.
+    """
+    from resources.lib import fallback_streams as fs
+
+    assert fs._normalize_title("Planet of the Apes") == "planet of the apes"
+    assert fs._normalize_title("Underworld") == "underworld"
+    assert fs._normalize_title("Andromeda") == "andromeda"
+
+
+def test_same_content_peers_foreign_conjunction_variants():
+    """A yearless/episode-less title peers across "et"/"and"/omitted forms."""
+    from resources.lib import fallback_streams as fs
+
+    et_form = _result(
+        "Jules.et.Jim.1080p.BluRay.x264-GROUP",
+        "https://idx/et.nzb",
+        6000000000,
+    )
+    and_form = _result(
+        "Jules.and.Jim.1080p.BluRay.x264-GROUP",
+        "https://idx/and.nzb",
+        6000000000,
+    )
+    omitted = _result(
+        "Jules.Jim.1080p.BluRay.x264-GROUP",
+        "https://idx/omitted.nzb",
+        6000000000,
+    )
+
+    assert fs._same_content(et_form, and_form) is True
+    assert fs._same_content(and_form, et_form) is True
+    assert fs._same_content(et_form, omitted) is True
+    assert fs._same_content(omitted, et_form) is True
+
+
 def test_same_episode_with_part_token_matches_bare_repost():
     """An episode that carries an episode-title Part/Chapter token must still
     peer with the same SxxExx posted without that token.


### PR DESCRIPTION
## Problem

`_normalize_title` in [`fallback_streams.py`](repo/plugin.video.nzbdav/resources/lib/fallback_streams.py) ran `_NON_WORD_RE.sub(" ", ...)` then collapsed whitespace. That strips `&` but **leaves the literal word "and"**, so two reposts of the same **yearless / episode-less** title that spell the conjunction differently did **not** peer as fallbacks:

| Release | Normalized |
|---|---|
| `Your Friends & Neighbors` | `your friends neighbors` |
| `Your.Friends.and.Neighbors` | `your friends and neighbors` ← diverges |
| `Your.Friends.Neighbors` | `your friends neighbors` |

So `&`-vs-omitted peered, but `and`-vs-omitted and `and`-vs-`&` did not. This is a fallback **content-identity peering gap**, not a search bug. It fails **closed** (never serves wrong content — just misses some legitimate fallback peers), which is why it was intentionally kept out of #294 / #339.

> Note: a *year-bearing* title already peered across all three spellings because a matching parsed year corroborates identity in `_titles_core_related`. The gap only bites when there's no year/episode to corroborate, which is exactly this fix's target.

The same divergence existed for other conjunction spellings: foreign conjunctions (`et`, `und`) and a double-escaped `&amp;` (which the non-word sub turns into a stray `amp` token).

## Fix

A shared `_CONJUNCTION_TOKENS = frozenset(("and", "et", "und"))` is dropped at the token level after the non-word substitution, and `&amp;` is unescaped to `&` beforehand:

```python
lowered = value.lower().replace("&amp;", "&")
normalized = _NON_WORD_RE.sub(" ", lowered)
return " ".join(
    token for token in normalized.split() if token not in _CONJUNCTION_TOKENS
)
```

So `&`, `and`, `et`, `und`, `&amp;`, and an omitted conjunction all collapse to the same identity.

**Safety:**
- **Whole-token only** — a conjunction spelled as a *substring* of a real word (`Andromeda`, `Planet`, `Underworld`) is untouched.
- **`&amp;` is unescaped, not "amp"-dropped** — a genuine `amp` word (`Marshall Amp Sessions`) is preserved. `&amp;` normally never reaches here (ElementTree's `.text` auto-decodes entities); this defends the double-escaped-feed case.
- **Part/chapter discrimination unaffected** — ordinals (`Part One`/`Part Two`) are not conjunctions, and part numbers parse off the **raw** title (`_part_number_from_title` / `_PART_LABEL_RE`), independent of `_normalize_title`.
- **Symmetric** — `_normalize_title` is applied to both sides of every identity/dedup/grouping comparison, so this does not reintroduce the one-sided-stripping asymmetry #294 warned against on submit/identity paths.
- **Single-letter conjunctions deliberately excluded** (`y`/`e`/`i`) — they collide with stray single-character junk tokens and would over-collapse.

### Residual (accepted tradeoff — bounded false-accept)

The foreign-conjunction forms (`et`/`und`) can over-collapse a title where the token is a *non-conjunction* interior acronym, not the conjunction — e.g. `The.ET.Files.2020` folds to `the files` and can false-peer with `The.Files.2020` (raised by Codex). This is a real over-collapse, not merely theoretical, and it's a deliberate, accepted tradeoff: it's the *same* interior fold that delivers the intended yearless peering for `Jules et Jim` / `Jules Jim`, so removing `et`/`und` to avoid the acronym case would reintroduce that miss.

The blast radius is bounded: a folded false-peer must *also* match on year/season/episode/part, edition, and PROPER/REPACK (`_content_discriminators_match`), then clear the downstream resolution/codec/size tier gate and the post-date dedup before it can attach — so the worst case is a similarly-encoded, same-cut release of a *different* work with a coincident year/episode, and it fails toward a plausibly-related fallback rather than arbitrary content. The conjunction set is kept minimal (`and`/`et`/`und`), with single-letter forms (`y`/`e`/`i`) excluded to limit collisions.

## Tests (TDD)

Added to [`tests/test_fallback_streams.py`](tests/test_fallback_streams.py):

- `test_normalize_title_collapses_conjunction_spellings` — `&` / `and` / omitted normalize equal.
- `test_normalize_title_collapses_foreign_conjunctions` — `et` / `und` variants normalize equal.
- `test_normalize_title_collapses_double_escaped_ampersand` — `&amp;` collapses like `&`, and `Marshall Amp` keeps its `amp` word.
- `test_normalize_title_only_drops_whole_conjunction_words` — substring guard (`Planet`/`Underworld`/`Andromeda`).
- `test_normalize_title_preserves_part_ordinals` — `Part One` ≠ `Part Two`.
- `test_same_content_peers_conjunction_variants` / `test_same_content_peers_foreign_conjunction_variants` — end-to-end peering through the real `_same_content` gate.

Every behavior test was confirmed RED before the change, then GREEN after.

## Verification

- `just test` → 2111 passed, 3 skipped (the `test_chroma_dev_search` non-hermetic case tracked in #328 skipped this run).
- `just lint` → ruff clean, black clean, **pylint 10.00/10**, vermin 3.7+ (3.8-compatible; no walrus/match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
