### PR TITLE
ci: add Code Quality coverage workflow and scope scanners to shipped code

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -34,6 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # On pull_request, checkout defaults to the synthetic merge
+          # commit, but upload-code-coverage attaches the report to the PR
+          # head SHA. Pin the checkout to head so coverage.xml is measured
+          # against the same tree the report maps onto. On push, head.sha is
+          # empty and falls back to github.sha (the pushed main commit).
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,52 @@
+name: Code Coverage
+
+# Generates a Cobertura coverage report for the addon runtime modules and
+# uploads it to GitHub Code Quality, which posts a coverage summary on pull
+# requests and tracks coverage on the default branch. Both push (baseline)
+# and pull_request (comparison) triggers are required by the feature. See
+# https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      code-quality: write
+    env:
+      UV_PYTHON: "3.14"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.14"
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - name: Run tests with coverage
+        run: just test-cov
+      - name: Upload coverage to GitHub Code Quality
+        # Skip on forked PRs: forks lack code-quality:write, and the action
+        # cannot upload to the base repo from a fork context.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@82c7aee3fb2ad768e00b00a0a8d749c5815085b6 # v1
+        with:
+          file: coverage.xml
+          language: Python
+          label: code-coverage/pytest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,14 +39,17 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # Scope analysis to shipped addon code. Test/harness suites and
-        # vendored PTT are not part of the runtime attack surface; this
-        # matches bandit.yml, which already scans repo/plugin.video.nzbdav
-        # only. paths-ignore matches interpreted languages like Python.
+        # Scope analysis to shipped addon code. Top-level scripts/, the
+        # test/harness suites, and vendored PTT are not part of the runtime
+        # attack surface; this matches bandit.yml, which already scans
+        # repo/plugin.video.nzbdav only. `paths` positively restricts the
+        # analysis to that subtree (honored for interpreted languages like
+        # Python), which excludes scripts/, tests/, and tests-extensive/;
+        # paths-ignore then drops the vendored PTT that lives inside it.
         config: |
+          paths:
+            - repo/plugin.video.nzbdav
           paths-ignore:
-            - tests
-            - tests-extensive
             - repo/plugin.video.nzbdav/resources/lib/ptt
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,15 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        # Scope analysis to shipped addon code. Test/harness suites and
+        # vendored PTT are not part of the runtime attack surface; this
+        # matches bandit.yml, which already scans repo/plugin.video.nzbdav
+        # only. paths-ignore matches interpreted languages like Python.
+        config: |
+          paths-ignore:
+            - tests
+            - tests-extensive
+            - repo/plugin.video.nzbdav/resources/lib/ptt
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -41,14 +41,17 @@ jobs:
         # `semgrep scan --config auto` to pull the community default
         # ruleset from the public registry — same behaviour the old
         # action provided when its publishToken was unset.
-        # --exclude scopes the scan to shipped addon code. Test/harness
-        # suites and vendored PTT are not part of the runtime attack
-        # surface; this matches bandit.yml, which already scans
-        # repo/plugin.video.nzbdav only.
+        # The positional target scopes the scan to shipped addon code
+        # (default is the whole working tree), which excludes top-level
+        # scripts/, tests/, and tests-extensive/. These suites and vendored
+        # PTT are not part of the runtime attack surface; this matches
+        # bandit.yml, which already scans repo/plugin.video.nzbdav only.
+        # --exclude ptt drops the vendored tree that lives inside the target.
         run: >-
           semgrep scan --config auto
-          --exclude tests --exclude tests-extensive --exclude ptt
+          --exclude ptt
           --sarif --output=semgrep.sarif
+          repo/plugin.video.nzbdav/
 
       - name: Drop in-source suppressed Semgrep results
         # Semgrep SARIF includes `# nosemgrep` findings as suppressed

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -41,7 +41,14 @@ jobs:
         # `semgrep scan --config auto` to pull the community default
         # ruleset from the public registry — same behaviour the old
         # action provided when its publishToken was unset.
-        run: semgrep scan --config auto --sarif --output=semgrep.sarif
+        # --exclude scopes the scan to shipped addon code. Test/harness
+        # suites and vendored PTT are not part of the runtime attack
+        # surface; this matches bandit.yml, which already scans
+        # repo/plugin.video.nzbdav only.
+        run: >-
+          semgrep scan --config auto
+          --exclude tests --exclude tests-extensive --exclude ptt
+          --sarif --output=semgrep.sarif
 
       - name: Drop in-source suppressed Semgrep results
         # Semgrep SARIF includes `# nosemgrep` findings as suppressed

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 .venv*/
 .coverage
 .coverage.*
+coverage.xml
 htmlcov/
 uv.lock
 

--- a/justfile
+++ b/justfile
@@ -75,7 +75,7 @@ test-verbose:
 # the addon runtime modules. Consumed by the code-coverage.yml workflow
 # (GitHub Code Quality). Vendored PTT is omitted via pyproject.toml.
 test-cov:
-    {{uvdev}} python -m pytest tests/ --tb=short -m "not integration and not functional and not extreme" --cov=resources.lib --cov-report=xml --cov-report=term-missing
+    {{uvdev}} python -m pytest tests/ --tb=short -m "not integration and not functional and not extreme" --cov --cov-report=xml --cov-report=term-missing
 
 # Run integration tests against a real ffmpeg binary. Spawns the
 # actual fmp4 HLS producer pipeline against a tiny test MKV

--- a/justfile
+++ b/justfile
@@ -67,9 +67,15 @@ make-dev:
 test:
     {{uvdev}} python -m pytest tests/ -v --tb=short -m "not integration and not functional and not extreme"
 
-# Run tests with coverage
+# Run the default test selection with long tracebacks
 test-verbose:
     {{uvdev}} python -m pytest tests/ -v --tb=long -m "not integration and not functional and not extreme"
+
+# Run the default test selection and emit a Cobertura coverage.xml for
+# the addon runtime modules. Consumed by the code-coverage.yml workflow
+# (GitHub Code Quality). Vendored PTT is omitted via pyproject.toml.
+test-cov:
+    {{uvdev}} python -m pytest tests/ --tb=short -m "not integration and not functional and not extreme" --cov=resources.lib --cov-report=xml --cov-report=term-missing
 
 # Run integration tests against a real ffmpeg binary. Spawns the
 # actual fmp4 HLS producer pipeline against a tiny test MKV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,18 @@ select = ["E", "F", "W", "I"]
 target-version = ["py38"]
 line-length = 88
 
+[tool.coverage.run]
+# Store repo-relative filenames so the Cobertura report maps onto repo
+# files for GitHub Code Quality. resources.lib resolves to
+# repo/plugin.video.nzbdav/resources/lib (tests/kodi_mocks.py adds it to
+# sys.path). Vendored PTT is third-party and excluded by policy.
+relative_files = true
+source = ["resources.lib"]
+omit = ["*/resources/lib/ptt/*"]
+
+[tool.coverage.report]
+omit = ["*/resources/lib/ptt/*"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # Exact pins so local == CI. Bump deliberately.
 pytest==9.1.1
+pytest-cov==7.1.0
 pylint==4.0.6
 ruff==0.15.20
 black==26.5.1


### PR DESCRIPTION
## Summary

Two related pieces of the GitHub **Code Quality** / code-scanning setup:

1. **Fill in `code-coverage.yml`** (was a 4-byte `---` stub) with a working GitHub Code Quality coverage workflow.
2. **Scope CodeQL + Semgrep to shipped code** so the test-harness alerts on the Security → Code scanning page resolve.

### Code coverage workflow
- Runs the default unit selection with `pytest-cov`, emits a Cobertura `coverage.xml`, and uploads it via `actions/upload-code-coverage@v1` (pinned by SHA). GitHub Code Quality then posts a coverage summary on PRs and tracks the `main` baseline.
- Adds `pytest-cov==7.1.0` and a `just test-cov` recipe. `coverage.run.relative_files` keeps Cobertura filenames repo-relative (verified locally — they map to `repo/plugin.video.nzbdav/resources/lib/…`); vendored PTT is omitted from measurement; `coverage.xml` is gitignored.
- Requires the new `code-quality: write` permission. The upload step is guarded so forked PRs (which lack it) skip cleanly.

> ⚠️ The upload step only does something once the **Code Quality preview is enabled** in repo settings (Security → Code quality — the page in the screenshot). Until it's enabled, the upload may no-op/fail on the base repo.

### Scanner scoping
Both CodeQL and Semgrep were scanning `tests/`, `tests-extensive/`, and vendored `ptt/`, producing **33 alerts** in code that never ships in the addon zip. This scopes them to the shipped addon — matching `bandit.yml`, which already scans `repo/plugin.video.nzbdav/` only.
- `codeql.yml`: `paths-ignore: [tests, tests-extensive, repo/plugin.video.nzbdav/resources/lib/ptt]`
- `semgrep.yml`: `--exclude tests --exclude tests-extensive --exclude ptt`

On the next `main` scan, the 29 Semgrep + 4 CodeQL test-harness alerts close as fixed.

### The one runtime alert
`py/command-line-injection` at `stream_proxy.py:2099` is the only alert in shipped code, and it's a **false positive**: `_is_safe_ffmpeg_cmd` pins the executable to `ffmpeg`, requires an argv list with `shell=False`, and rejects NUL/CR/LF before the spawn. It is dismissed via the code-scanning API as "false positive" with that justification — separate from this PR, no code change.

## Verification
- `just lint` — ruff/black clean, pylint 10.00/10, vermin 3.8+ OK
- `just test` — 2070 passed, 2 skipped
- `just test-cov` — `coverage.xml` emitted with repo-relative paths, PTT omitted
- Workflow YAML validated (parse + nested `config`/`run` scalars)

## Not included (deliberate)
- Enabling the Code Quality preview toggle (a settings-page click)
- Any test-code rewrites or runtime ffmpeg changes (already safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
