### PR TITLE
test: de-flake wall-clock timing assertions (load-robust, red-on-regression)

### DIFF
--- a/tests/test_direct_indexers.py
+++ b/tests/test_direct_indexers.py
@@ -670,10 +670,13 @@ def test_search_direct_indexers_fans_out_concurrently(mock_xbmcaddon, mock_confi
     lock = Lock()
     started_ids = set()
 
+    both_started_at = [None]
+
     def slow_search(indexer, *_args, **_kwargs):
         with lock:
             started_ids.add(indexer["id"])
             if len(started_ids) == 2:
+                both_started_at[0] = time.monotonic()
                 both_started.set()
         assert both_started.wait(0.5)
         time.sleep(0.2)
@@ -681,13 +684,25 @@ def test_search_direct_indexers_fans_out_concurrently(mock_xbmcaddon, mock_confi
 
     with patch("resources.lib.direct_indexers._search_one_indexer", new=slow_search):
         results, error = search_direct_indexers("movie", "The Matrix")
+    returned_at = time.monotonic()
 
     assert error is None
     assert len(results) == 2
     # both_started.is_set() (set only when both workers are concurrently in-flight)
-    # plus error is None / len == 2 already prove the fan-out ran in parallel; the
-    # removed wall-clock bound proved nothing further and only flaked under load.
+    # plus error is None / len == 2 prove the fan-out ran in parallel.
     assert both_started.is_set()
+    # Return-latency guard (Codex P2): once both workers are in flight they each
+    # finish ~0.2s later, so the fan-out must return shortly after -- it must NOT
+    # perform an extra bounded wait or serial cleanup first (which the removed
+    # total-elapsed bound caught). Measured from both-in-flight so it excludes
+    # worker-start latency; a generous 2s bound (~10x the 0.2s worker body)
+    # tolerates heavy CPU load yet stays red on a >~1.5s extra-wait regression.
+    assert both_started_at[0] is not None
+    return_latency = returned_at - both_started_at[0]
+    assert return_latency < 2.0, (
+        "fan-out returned {:.3f}s after both workers were in flight (extra wait "
+        "or serial cleanup before returning?)".format(return_latency)
+    )
 
 
 @patch("resources.lib.direct_indexers.get_configured_indexers")
@@ -771,13 +786,11 @@ def test_test_configured_indexers_marks_incomplete_futures_timed_out(
         }
     ]
 
-    caps_started = Event()
     release_caps = Event()
     caps_completions = [0]
     completions_lock = Lock()
 
     def slow_caps(*_args, **_kwargs):
-        caps_started.set()
         # Released only in the finally below (AFTER the snapshot), with no early
         # timer, so the caps worker can never complete before we record whether
         # the fan-out joined it -- the snapshot is load-independent. The 2s cap
@@ -800,7 +813,11 @@ def test_test_configured_indexers_marks_incomplete_futures_timed_out(
         finally:
             release_caps.set()
 
-    assert caps_started.wait(0.2)
+    # Do not require the caps worker to have started (Codex P2): with the fan-out
+    # timeout patched to 0.05s, a loaded runner can legitimately hit the timeout
+    # before the executor schedules the worker -- and timing out an unscheduled
+    # worker is itself the behavior under test. The caps-not-completed snapshot
+    # below holds whether the worker blocked in-flight or never ran.
     assert ok_count == 0
     assert total_count == 1
     assert len(errors) == 1

--- a/tests/test_direct_indexers.py
+++ b/tests/test_direct_indexers.py
@@ -771,11 +771,21 @@ def test_test_configured_indexers_marks_incomplete_futures_timed_out(
         }
     ]
 
+    caps_started = Event()
+    release_caps = Event()
+    caps_completions = [0]
+    completions_lock = Lock()
+
     def slow_caps(*_args, **_kwargs):
-        # Sleep far longer than the 0.05s fan-out timeout so a regression that
-        # waits on the worker (e.g. executor.shutdown(wait=True)) is ~1.0s --
-        # dramatically over the bound -- while the timeout path stays ~0.05s.
-        time.sleep(1.0)
+        caps_started.set()
+        # Released only in the finally below (AFTER the snapshot), with no early
+        # timer, so the caps worker can never complete before we record whether
+        # the fan-out joined it -- the snapshot is load-independent. The 2s cap
+        # only bounds a regression where the fan-out waits on the worker (e.g.
+        # executor.shutdown(wait=True)).
+        release_caps.wait(timeout=2)
+        with completions_lock:
+            caps_completions[0] += 1
         return "<caps></caps>"
 
     mock_http.side_effect = slow_caps
@@ -783,16 +793,24 @@ def test_test_configured_indexers_marks_incomplete_futures_timed_out(
     with patch(
         "resources.lib.direct_indexers._DIRECT_FANOUT_TIMEOUT", 0.05, create=True
     ):
-        started = time.monotonic()
-        ok_count, total_count, errors = test_configured_indexers()
-        elapsed = time.monotonic() - started
+        try:
+            ok_count, total_count, errors = test_configured_indexers()
+            with completions_lock:
+                caps_completions_at_return = caps_completions[0]
+        finally:
+            release_caps.set()
 
+    assert caps_started.wait(0.2)
     assert ok_count == 0
     assert total_count == 1
     assert len(errors) == 1
     assert "Direct indexer Slow unavailable:" in errors[0]
     assert "timed out" in errors[0]
-    assert elapsed < 0.5
+    # Structural proof (load-independent): the fan-out must return at
+    # _DIRECT_FANOUT_TIMEOUT without joining the still-blocked caps worker.
+    # Only the finally above releases it, after the snapshot -- so if the
+    # fan-out wrongly waited, the worker would complete -> count > 0.
+    assert caps_completions_at_return == 0
 
 
 @patch("resources.lib.direct_indexers.get_configured_indexers")

--- a/tests/test_direct_indexers.py
+++ b/tests/test_direct_indexers.py
@@ -679,15 +679,15 @@ def test_search_direct_indexers_fans_out_concurrently(mock_xbmcaddon, mock_confi
         time.sleep(0.2)
         return ([{"title": indexer["label"], "link": indexer["id"]}], None)
 
-    started = time.monotonic()
     with patch("resources.lib.direct_indexers._search_one_indexer", new=slow_search):
         results, error = search_direct_indexers("movie", "The Matrix")
-    elapsed = time.monotonic() - started
 
     assert error is None
     assert len(results) == 2
+    # both_started.is_set() (set only when both workers are concurrently in-flight)
+    # plus error is None / len == 2 already prove the fan-out ran in parallel; the
+    # removed wall-clock bound proved nothing further and only flaked under load.
     assert both_started.is_set()
-    assert elapsed < 0.55
 
 
 @patch("resources.lib.direct_indexers.get_configured_indexers")
@@ -709,7 +709,10 @@ def test_search_direct_indexers_marks_incomplete_futures_timed_out(
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
 
     def slow_search(*_args, **_kwargs):
-        time.sleep(0.2)
+        # Sleep far longer than the 0.05s fan-out timeout so a regression that
+        # waits on the worker (e.g. executor.shutdown(wait=True)) is ~1.0s --
+        # dramatically over the bound -- while the timeout path stays ~0.05s.
+        time.sleep(1.0)
         return ([{"title": "late", "link": "late"}], None)
 
     mock_search_one.side_effect = slow_search
@@ -724,7 +727,7 @@ def test_search_direct_indexers_marks_incomplete_futures_timed_out(
     assert not results
     assert "Direct indexer Slow unavailable:" in error
     assert "timed out" in error
-    assert elapsed < 0.15
+    assert elapsed < 0.5
 
 
 @patch("resources.lib.direct_indexers.get_configured_indexers")
@@ -769,7 +772,10 @@ def test_test_configured_indexers_marks_incomplete_futures_timed_out(
     ]
 
     def slow_caps(*_args, **_kwargs):
-        time.sleep(0.2)
+        # Sleep far longer than the 0.05s fan-out timeout so a regression that
+        # waits on the worker (e.g. executor.shutdown(wait=True)) is ~1.0s --
+        # dramatically over the bound -- while the timeout path stays ~0.05s.
+        time.sleep(1.0)
         return "<caps></caps>"
 
     mock_http.side_effect = slow_caps
@@ -786,7 +792,7 @@ def test_test_configured_indexers_marks_incomplete_futures_timed_out(
     assert len(errors) == 1
     assert "Direct indexer Slow unavailable:" in errors[0]
     assert "timed out" in errors[0]
-    assert elapsed < 0.15
+    assert elapsed < 0.5
 
 
 @patch("resources.lib.direct_indexers.get_configured_indexers")

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -3,7 +3,6 @@
 
 import hashlib
 import threading
-import time as _time
 from unittest.mock import ANY, MagicMock, patch
 from urllib.error import URLError
 from urllib.parse import urlsplit
@@ -1393,26 +1392,36 @@ def test_selection_fallback_skips_candidate_wait_after_unusable_selected_manifes
     candidate_started = threading.Event()
     release_candidates = threading.Event()
 
+    candidate_completions = [0]
+    completions_lock = threading.Lock()
+
     def fetch(url, **_kwargs):
         if url == selected["link"]:
             return manifests[url]
         candidate_started.set()
-        release_candidates.wait(timeout=1)
+        # Released only in the finally below (AFTER the snapshot), with no early
+        # timer, so a candidate fetch can never complete before we record whether
+        # the scan consumed it -- the snapshot is load-independent. The 2s cap
+        # only bounds a regression where the scan wrongly waits for this fetch.
+        release_candidates.wait(timeout=2)
+        with completions_lock:
+            candidate_completions[0] += 1
         return manifests[url]
 
     mock_fetch.side_effect = fetch
-    release_timer = threading.Timer(0.3, release_candidates.set)
-    release_timer.start()
     try:
-        before = _time.monotonic()
         attach_fallback_candidates_for_selection(selected, [selected] + candidates)
-        elapsed = _time.monotonic() - before
+        with completions_lock:
+            candidate_completions_at_return = candidate_completions[0]
     finally:
         release_candidates.set()
-        release_timer.cancel()
 
     assert candidate_started.wait(0.2)
-    assert elapsed < 0.2
+    # Structural proof (load-independent): the unusable selected manifest must
+    # abort the scan before any blocked candidate fetch is released (only the
+    # finally above releases it, after the snapshot). If the scan wrongly kept
+    # waiting, a candidate fetch would complete and be consumed -> count > 0.
+    assert candidate_completions_at_return == 0
     assert selected["_fallback_candidates"] == []
     assert selected["_fallback_manifest_error"] == "fetch_error"
 
@@ -2092,15 +2101,16 @@ def test_selection_fallback_uses_later_completed_candidate_instead_of_slow_gap(
     release_timer = threading.Timer(0.25, release_slow.set)
     release_timer.start()
     try:
-        before = _time.monotonic()
         attach_fallback_candidates_for_selection(selected, [selected] + candidates)
-        elapsed = _time.monotonic() - before
     finally:
         release_slow.set()
         release_timer.cancel()
 
     assert slow_started.is_set()
-    assert elapsed < 0.18
+    # Structural proof subsumes the wall-clock bound: if the scan had blocked on
+    # the slow candidate[1] (GAP02) instead of using the faster-completing
+    # candidate[2] (GAP03), the attached list would be [candidates[0],
+    # candidates[1]]. The list assertion below is the load-independent guard.
     assert selected["_fallback_candidates"] == [candidates[0], candidates[2]]
 
 
@@ -2283,25 +2293,32 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_max_filled(
     slow_started = threading.Event()
     release_slow = threading.Event()
 
+    tail_completed = [False]
+
     def fetch(url, **_kwargs):
         if url == candidates[6]["link"]:
             slow_started.set()
-            release_slow.wait(timeout=1)
+            # Released only in the finally below (AFTER the snapshot), with no
+            # early timer, so the optional-tail fetch cannot complete before we
+            # record whether the scan waited for it -- load-independent. The 2s
+            # cap only bounds a regression where the scan blocks on this fetch.
+            release_slow.wait(timeout=2)
+            tail_completed[0] = True
         return manifests[url]
 
     mock_fetch.side_effect = fetch
-    release_timer = threading.Timer(0.25, release_slow.set)
-    release_timer.start()
     try:
-        before = _time.monotonic()
         attach_fallback_candidates_for_selection(selected, [selected] + candidates)
-        elapsed = _time.monotonic() - before
+        tail_completed_at_return = tail_completed[0]
     finally:
         release_slow.set()
-        release_timer.cancel()
 
     assert slow_started.is_set()
-    assert elapsed < 0.18
+    # Structural proof (load-independent): with max_candidates already filled,
+    # the scan must return before the optional-tail fetch (candidates[6]) is
+    # released (only the finally above releases it, after the snapshot). If it
+    # wrongly waited, that fetch would complete -> tail_completed_at_return True.
+    assert tail_completed_at_return is False
     assert selected["_fallback_candidates"] == candidates[:4] + [candidates[5]]
 
 
@@ -2363,15 +2380,17 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_partial_match(
     release_timer = threading.Timer(0.3, release_slow.set)
     release_timer.start()
     try:
-        before = _time.monotonic()
         attach_fallback_candidates_for_selection(selected, [selected] + candidates)
-        elapsed = _time.monotonic() - before
     finally:
         release_slow.set()
         release_timer.cancel()
 
     assert slow_started.is_set()
-    assert elapsed < 0.22
+    # Structural proof subsumes the wall-clock bound: candidates[1] (PARTIAL02)
+    # is itself a match, so if the scan had blocked on it until the slow release
+    # it would have been consumed and attached, making the list
+    # [candidates[0], candidates[1]]. The list assertion below is the
+    # load-independent guard that the slow optional tail was not awaited.
     assert selected["_fallback_candidates"] == [candidates[0]]
 
 

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -2090,27 +2090,33 @@ def test_selection_fallback_uses_later_completed_candidate_instead_of_slow_gap(
     }
     slow_started = threading.Event()
     release_slow = threading.Event()
+    slow_completed = threading.Event()
 
     def fetch(url, **_kwargs):
         if url == candidates[1]["link"]:
             slow_started.set()
+            # Released only in the finally below (after the snapshot), with no
+            # early timer, so the slow gap candidate can never complete before
+            # we record whether the scan waited for it -- load-independent.
             release_slow.wait(timeout=1)
+            slow_completed.set()
         return manifests[url]
 
     mock_fetch.side_effect = fetch
-    release_timer = threading.Timer(0.25, release_slow.set)
-    release_timer.start()
     try:
         attach_fallback_candidates_for_selection(selected, [selected] + candidates)
+        slow_completed_at_return = slow_completed.is_set()
     finally:
         release_slow.set()
-        release_timer.cancel()
 
     assert slow_started.is_set()
-    # Structural proof subsumes the wall-clock bound: if the scan had blocked on
-    # the slow candidate[1] (GAP02) instead of using the faster-completing
-    # candidate[2] (GAP03), the attached list would be [candidates[0],
-    # candidates[1]]. The list assertion below is the load-independent guard.
+    # Structural proof (load-independent): the slow gap candidate (GAP02) is left
+    # in flight and never released here, so a healthy early-return that uses the
+    # faster candidate[2] (GAP03) must NOT have waited for it. A
+    # "waits-but-same-result" regression (drain the slow in-flight fetch, then
+    # discard it) would block until it completed -> slow_completed set.
+    assert not slow_completed_at_return
+    # The list assertion then confirms the right (faster) candidate was attached.
     assert selected["_fallback_candidates"] == [candidates[0], candidates[2]]
 
 
@@ -2369,28 +2375,33 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_partial_match(
     }
     slow_started = threading.Event()
     release_slow = threading.Event()
+    slow_completed = threading.Event()
 
     def fetch(url, **_kwargs):
         if url == candidates[1]["link"]:
             slow_started.set()
+            # Released only in the finally below (after the snapshot), with no
+            # early timer, so the slow optional-tail candidate can never complete
+            # before we record whether the scan waited for it -- load-independent.
             release_slow.wait(timeout=1)
+            slow_completed.set()
         return manifests[url]
 
     mock_fetch.side_effect = fetch
-    release_timer = threading.Timer(0.3, release_slow.set)
-    release_timer.start()
     try:
         attach_fallback_candidates_for_selection(selected, [selected] + candidates)
+        slow_completed_at_return = slow_completed.is_set()
     finally:
         release_slow.set()
-        release_timer.cancel()
 
     assert slow_started.is_set()
-    # Structural proof subsumes the wall-clock bound: candidates[1] (PARTIAL02)
-    # is itself a match, so if the scan had blocked on it until the slow release
-    # it would have been consumed and attached, making the list
-    # [candidates[0], candidates[1]]. The list assertion below is the
-    # load-independent guard that the slow optional tail was not awaited.
+    # Structural proof (load-independent): the slow optional-tail candidate is
+    # left in flight and never released here, so a healthy bounded tail-wait must
+    # give up and return WITHOUT it completing. A "waits-but-same-result"
+    # regression (drain the slow in-flight fetch, then discard it) would block
+    # until it completed -> slow_completed set.
+    assert not slow_completed_at_return
+    # The list assertion confirms the slow optional tail was not attached.
     assert selected["_fallback_candidates"] == [candidates[0]]
 
 

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -1397,13 +1397,22 @@ def test_selection_fallback_skips_candidate_wait_after_unusable_selected_manifes
 
     def fetch(url, **_kwargs):
         if url == selected["link"]:
+            # Load-independent gate: the scan aborts on the unusable selected
+            # manifest only once selected_ready, so block the selected manifest
+            # until a candidate fetch has actually started. Candidates are in the
+            # initial fetch window (submitted without needing selected_ready), so
+            # this cannot deadlock -- candidate_started is set before the scan
+            # aborts at realistic load. The 30s is a hang-safety bound only (a
+            # normally scheduled daemon thread starts in ms).
+            candidate_started.wait(30)
             return manifests[url]
         candidate_started.set()
-        # Released only in the finally below (AFTER the snapshot), with no early
-        # timer, so a candidate fetch can never complete before we record whether
-        # the scan consumed it -- the snapshot is load-independent. The 2s cap
-        # only bounds a regression where the scan wrongly waits for this fetch.
-        release_candidates.wait(timeout=2)
+        # No self-timeout: a candidate fetch stays in flight until the finally
+        # below releases it (after the snapshot), so it can never complete before
+        # we record whether the scan consumed it. The generous 3s only bounds a
+        # regression where the scan wrongly waits for this fetch (then it completes
+        # -> candidate_completions -> caught below).
+        release_candidates.wait(timeout=3)
         with completions_lock:
             candidate_completions[0] += 1
         return manifests[url]
@@ -1416,7 +1425,9 @@ def test_selection_fallback_skips_candidate_wait_after_unusable_selected_manifes
     finally:
         release_candidates.set()
 
-    assert candidate_started.wait(0.2)
+    # Deterministic via the selected-manifest gate above: candidate_started is
+    # guaranteed set before the scan aborts, so this assert is load-independent.
+    assert candidate_started.is_set()
     # Structural proof (load-independent): the unusable selected manifest must
     # abort the scan before any blocked candidate fetch is released (only the
     # finally above releases it, after the snapshot). If the scan wrongly kept
@@ -2095,11 +2106,22 @@ def test_selection_fallback_uses_later_completed_candidate_instead_of_slow_gap(
     def fetch(url, **_kwargs):
         if url == candidates[1]["link"]:
             slow_started.set()
-            # Released only in the finally below (after the snapshot), with no
-            # early timer, so the slow gap candidate can never complete before
-            # we record whether the scan waited for it -- load-independent.
-            release_slow.wait(timeout=1)
+            # No self-timeout: the slow gap candidate stays in flight until the
+            # finally below releases it (after the snapshot), so it can never
+            # complete before we record whether the scan waited for it. The
+            # generous 3s only bounds a regression where the scan blocks on this
+            # fetch (then it completes -> slow_completed -> caught below).
+            release_slow.wait(timeout=3)
             slow_completed.set()
+        elif url == selected["link"]:
+            # Load-independent gate: no candidate is attached, and the scan cannot
+            # return, until selected_ready. Block the selected manifest until the
+            # slow gap candidate's daemon thread has actually started, so
+            # slow_started is provably set before the scan returns -- removing the
+            # thread-start race at realistic load. The 30s is a hang-safety bound
+            # only (a normally scheduled daemon thread starts in ms; the slow
+            # candidate is in the initial window, so it is always submitted).
+            slow_started.wait(30)
         return manifests[url]
 
     mock_fetch.side_effect = fetch
@@ -2109,6 +2131,8 @@ def test_selection_fallback_uses_later_completed_candidate_instead_of_slow_gap(
     finally:
         release_slow.set()
 
+    # Deterministic via the selected-manifest gate above: slow_started is
+    # guaranteed set before the scan returns, so this assert is load-independent.
     assert slow_started.is_set()
     # Structural proof (load-independent): the slow gap candidate (GAP02) is left
     # in flight and never released here, so a healthy early-return that uses the
@@ -2304,12 +2328,22 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_max_filled(
     def fetch(url, **_kwargs):
         if url == candidates[6]["link"]:
             slow_started.set()
-            # Released only in the finally below (AFTER the snapshot), with no
-            # early timer, so the optional-tail fetch cannot complete before we
-            # record whether the scan waited for it -- load-independent. The 2s
-            # cap only bounds a regression where the scan blocks on this fetch.
-            release_slow.wait(timeout=2)
+            # No self-timeout: the optional-tail fetch stays in flight until the
+            # finally below releases it (after the snapshot), so it cannot complete
+            # before we record whether the scan waited for it. The generous 3s only
+            # bounds a regression where the scan blocks on this fetch (then it
+            # completes -> tail_completed -> caught below).
+            release_slow.wait(timeout=3)
             tail_completed[0] = True
+        elif url == selected["link"]:
+            # Load-independent gate: no candidate is attached, and the scan cannot
+            # return, until selected_ready. Block the selected manifest until the
+            # optional-tail candidate (candidates[6]) has actually started. It is
+            # submitted by the post-miss window refill, which does NOT require
+            # selected_ready, so this cannot deadlock -- slow_started is set
+            # before the scan returns at realistic load. The 30s is a hang-safety
+            # bound only (a normally scheduled daemon thread starts in ms).
+            slow_started.wait(30)
         return manifests[url]
 
     mock_fetch.side_effect = fetch
@@ -2319,6 +2353,8 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_max_filled(
     finally:
         release_slow.set()
 
+    # Deterministic via the selected-manifest gate above: slow_started is
+    # guaranteed set before the scan returns, so this assert is load-independent.
     assert slow_started.is_set()
     # Structural proof (load-independent): with max_candidates already filled,
     # the scan must return before the optional-tail fetch (candidates[6]) is
@@ -2380,11 +2416,22 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_partial_match(
     def fetch(url, **_kwargs):
         if url == candidates[1]["link"]:
             slow_started.set()
-            # Released only in the finally below (after the snapshot), with no
-            # early timer, so the slow optional-tail candidate can never complete
-            # before we record whether the scan waited for it -- load-independent.
-            release_slow.wait(timeout=1)
+            # No self-timeout: the slow optional-tail candidate stays in flight
+            # until the finally below releases it (after the snapshot), so it can
+            # never complete before we record whether the scan waited for it. The
+            # generous 3s only bounds a regression where the scan blocks on this
+            # fetch (then it completes -> slow_completed -> caught below).
+            release_slow.wait(timeout=3)
             slow_completed.set()
+        elif url == selected["link"]:
+            # Load-independent gate: no candidate is attached, and the scan cannot
+            # return, until selected_ready. Block the selected manifest until the
+            # slow optional-tail candidate's daemon thread has actually started, so
+            # slow_started is provably set before the scan returns -- removing the
+            # thread-start race at realistic load. The 30s is a hang-safety bound
+            # only (a normally scheduled daemon thread starts in ms; the slow
+            # candidate is in the initial window, so it is always submitted).
+            slow_started.wait(30)
         return manifests[url]
 
     mock_fetch.side_effect = fetch
@@ -2394,6 +2441,8 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_partial_match(
     finally:
         release_slow.set()
 
+    # Deterministic via the selected-manifest gate above: slow_started is
+    # guaranteed set before the scan returns, so this assert is load-independent.
     assert slow_started.is_set()
     # Structural proof (load-independent): the slow optional-tail candidate is
     # left in flight and never released here, so a healthy bounded tail-wait must

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -2403,6 +2403,14 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_partial_match(
     assert not slow_completed_at_return
     # The list assertion confirms the slow optional tail was not attached.
     assert selected["_fallback_candidates"] == [candidates[0]]
+    # Premise pin (load-independent): the structural slow_completed guard proves
+    # the scan does not BLOCK on the optional tail, but it cannot see drift in the
+    # bounded wait the scan grants before giving up. Widening that wait (e.g. to
+    # 0.2s) would keep this test green yet slow every real partial-match path.
+    # Pin the documented optional-tail wait so such a drift goes red here.
+    from resources.lib import fallback_streams
+
+    assert fallback_streams._FALLBACK_MANIFEST_OPTIONAL_TAIL_WAIT_SECONDS == 0.1
 
 
 @patch("resources.lib.fallback_streams.fetch_nzb_video_manifest")

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -2335,15 +2335,6 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_max_filled(
             # completes -> tail_completed -> caught below).
             release_slow.wait(timeout=3)
             tail_completed[0] = True
-        elif url == selected["link"]:
-            # Load-independent gate: no candidate is attached, and the scan cannot
-            # return, until selected_ready. Block the selected manifest until the
-            # optional-tail candidate (candidates[6]) has actually started. It is
-            # submitted by the post-miss window refill, which does NOT require
-            # selected_ready, so this cannot deadlock -- slow_started is set
-            # before the scan returns at realistic load. The 30s is a hang-safety
-            # bound only (a normally scheduled daemon thread starts in ms).
-            slow_started.wait(30)
         return manifests[url]
 
     mock_fetch.side_effect = fetch
@@ -2353,9 +2344,14 @@ def test_selection_fallback_does_not_wait_for_optional_tail_after_max_filled(
     finally:
         release_slow.set()
 
-    # Deterministic via the selected-manifest gate above: slow_started is
-    # guaranteed set before the scan returns, so this assert is load-independent.
-    assert slow_started.is_set()
+    # Unlike the other optional-tail tests, the in-flight tail here
+    # (candidates[6]) is beyond max_candidates, so the rolling window submits it
+    # only AFTER the selected manifest is ready -- it cannot be gated on the
+    # selected fetch without deadlocking the scan (Codex P2). Confirm it started
+    # with a generous 10s bound (a normally scheduled daemon thread starts in
+    # ms); the not-completed-at-return snapshot below is the real structural
+    # proof and does not depend on this.
+    assert slow_started.wait(10)
     # Structural proof (load-independent): with max_candidates already filled,
     # the scan must return before the optional-tail fetch (candidates[6]) is
     # released (only the finally above releases it, after the snapshot). If it

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -388,25 +388,36 @@ def test_handle_job_status_accepts_fractional_percentage():
 
 
 def test_handle_job_status_does_not_block_on_stuck_dialog_update():
+    update_started = threading.Event()
+    release_update = threading.Event()
+    update_finished = threading.Event()
+
     def stuck_update(*_args):
-        _time.sleep(0.25)
+        update_started.set()
+        release_update.wait(5)
+        update_finished.set()
 
     dialog = MagicMock()
     dialog.iscanceled.return_value = False
     dialog.update.side_effect = stuck_update
 
-    started = _time.perf_counter()
-    should_stop, last_status = _handle_job_status(
-        {"status": "Downloading", "percentage": "99"},
-        "nzo_stuck_dialog",
-        dialog,
-        None,
-    )
-    elapsed = _time.perf_counter() - started
+    try:
+        should_stop, last_status = _handle_job_status(
+            {"status": "Downloading", "percentage": "99"},
+            "nzo_stuck_dialog",
+            dialog,
+            None,
+        )
 
-    assert should_stop is False
-    assert last_status == "Downloading"
-    assert elapsed < 0.2
+        # The call returns while the (blocked) dialog.update is still in flight:
+        # proves the update was dispatched to a background thread, not awaited.
+        assert update_started.wait(1.0)
+        assert not update_finished.is_set()
+        assert should_stop is False
+        assert last_status == "Downloading"
+    finally:
+        release_update.set()
+        update_finished.wait(1.0)
 
 
 @patch("resources.lib.resolver.find_video_file")
@@ -2391,7 +2402,10 @@ def test_resolve_overlaps_bookmark_cleanup_with_post_submit_poll(
         "after_ready_cleanup={:.3f}s".format(elapsed, after_ready_cleanup)
     )
     assert timing["cleanup_end"] <= timing["play"]
-    assert elapsed < 0.35, "selected-to-play path took {:.3f}s".format(elapsed)
+    # Intervals [cleanup_start, cleanup_end] and [poll_start, poll_end] intersect
+    # => cleanup ran in parallel with the post-submit poll (serial would not overlap).
+    assert timing["cleanup_start"] < timing["poll_end"]
+    assert timing["poll_start"] < timing["cleanup_end"]
 
 
 @patch("resources.lib.resolver._fallback_submit_jobs_snapshot", return_value=[])
@@ -2597,8 +2611,10 @@ def test_resolve_overlaps_proxy_prepare_with_bookmark_cleanup_after_ready(
 
     assert timing["prepare_start"] < timing["cleanup_end"]
     assert timing["cleanup_end"] <= timing["resolved"]
-    elapsed = timing["resolved"] - timing["ready"]
-    assert elapsed < 0.32, "ready-to-resolved stayed serial at {:.3f}s".format(elapsed)
+    # Intervals [prepare_start, prepare_end] and [cleanup_start, cleanup_end]
+    # intersect => proxy prepare overlapped the in-flight cleanup (not serial).
+    assert timing["prepare_start"] < timing["cleanup_end"]
+    assert timing["cleanup_start"] < timing["prepare_end"]
 
 
 @patch("resources.lib.cache_prompt.maybe_show_cache_prompt")
@@ -3314,9 +3330,10 @@ def test_resolve_overlaps_bookmark_cleanup_with_existing_completed_fast_path(
         )
     )
     assert timing["cleanup_end"] <= timing["play"]
-    assert elapsed < 0.35, "existing-completed selected-to-play took {:.3f}s".format(
-        elapsed
-    )
+    # Intervals [cleanup_start, cleanup_end] and [video_scan_start, video_scan_end]
+    # intersect => cleanup overlapped the completed-path video scan (serial would not).
+    assert timing["cleanup_start"] < timing["video_scan_end"]
+    assert timing["video_scan_start"] < timing["cleanup_end"]
 
 
 @patch("resources.lib.resolver._fallback_submit_jobs_snapshot", return_value=[])
@@ -3870,17 +3887,17 @@ def test_start_direct_playback_prepare_snapshots_settings_in_worker(
             release_settings.wait(0.2)
         return default
 
-    started_at = _time.monotonic()
     state = _start_direct_playback_prepare(
         "http://webdav/content/movie.mkv",
         {"Authorization": "Basic abc"},
         fallback_sources=[],
         settings_getter=settings_getter,
     )
-    elapsed = _time.monotonic() - started_at
 
     try:
-        assert elapsed < 0.18
+        # Prepare returns while the worker is still blocked in the slow settings
+        # getter => the work was dispatched to a background thread, not awaited.
+        assert not state["done"].is_set()
         assert slow_started.wait(0.2)
         release_settings.set()
         prepared = _wait_direct_playback_prepare(state)
@@ -6491,8 +6508,13 @@ def test_poll_once_returns_full_progress_queue_before_slow_history(
 ):
     """A 100% queue row should not block behind a slow history request."""
 
+    # Slow path is pushed far above the bound so the assertion stays
+    # red-on-regression: the legitimate path returns after the ~0.14s
+    # full-progress grace, while a regression that blocks on history would
+    # take ~2s and fail the widened bound. The wide gap (0.14s grace vs 2.0s
+    # block, bound 1.0s) makes the wall-clock check load-robust.
     def slow_history(_nzo_id):
-        _time.sleep(0.25)
+        _time.sleep(2.0)
 
     mock_status.return_value = {"status": "Downloading", "percentage": "100"}
     mock_history.side_effect = slow_history
@@ -6501,7 +6523,7 @@ def test_poll_once_returns_full_progress_queue_before_slow_history(
     job_status, history, webdav_error = _poll_once("nzo_full", "movie", _make_monitor())
     elapsed = _time.monotonic() - started
 
-    assert elapsed < 0.2, "100% queue row waited on history for {:.3f}s".format(elapsed)
+    assert elapsed < 1.0, "100% queue row waited on history for {:.3f}s".format(elapsed)
     assert job_status == mock_status.return_value
     assert history is None
     assert webdav_error is None
@@ -6813,18 +6835,18 @@ def test_poll_until_ready_waits_for_full_progress_history_before_poll_tick(
     mock_find.return_value = "/content/uncategorized/movie/movie.mkv"
     mock_stream_url.return_value = ("http://webdav/movie.mkv", {"Authorization": "x"})
 
-    started = _time.perf_counter()
     url, headers = _poll_until_ready(
         "http://hydra/nzb", "movie", _make_dialog(), 0.25, 3600
     )
-    elapsed = _time.perf_counter() - started
 
     assert url == "http://webdav/movie.mkv"
     assert headers == {"Authorization": "x"}
+    # Structural guard (replaces a flake-prone wall-clock bound that sat only
+    # ~0.05s above the 0.12s history latency + 0.14s grace): get_history returns
+    # the completed row immediately on every call, so finishing with exactly one
+    # history call proves the 100% row caught history inside the full-progress
+    # grace on the first poll. A missed grace forces a second poll -> 2 calls.
     assert len(history_calls) == 1
-    assert elapsed < 0.2, "full-progress history missed grace by {:.3f}s".format(
-        elapsed
-    )
 
 
 @patch("resources.lib.resolver._existing_completed_stream", return_value=None)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4975,12 +4975,26 @@ def test_submit_ui_pump_continues_when_probe_threads_cannot_start(
 def test_submit_ui_pump_terminal_error_does_not_wait_for_probe_cleanup(
     mock_submit, mock_find_queued, mock_find_completed
 ):
+    probe_in_flight = threading.Event()
+    release_probe = threading.Event()
+    probe_completed = []
+
     def terminal_submit(_nzb_url, _title, **_kwargs):
-        _time.sleep(0.03)
+        # Hold the terminal error until a probe is genuinely MID-FLIGHT, so the
+        # snapshot below is meaningful: the terminal path must return while
+        # slow_probe is still blocked. A regression that joined/awaited probe
+        # cleanup on the terminal path would block on this in-flight probe.
+        assert probe_in_flight.wait(timeout=2)
         return None, {"status": 400, "message": "TooManyRequests"}
 
     def slow_probe(*_args, **_kwargs):
-        _time.sleep(0.25)
+        # Mark in-flight, then block until the test releases us in its finally
+        # (AFTER the snapshot), with no timer -- load-independent. The bounded
+        # wait caps the regression case (a terminal path that DOES await probe
+        # cleanup) so the test cannot hang.
+        probe_in_flight.set()
+        release_probe.wait(timeout=2)
+        probe_completed.append(True)
 
     mock_submit.side_effect = terminal_submit
     mock_find_queued.side_effect = slow_probe
@@ -4990,18 +5004,23 @@ def test_submit_ui_pump_terminal_error_does_not_wait_for_probe_cleanup(
     monitor = MagicMock()
     monitor.abortRequested.return_value = False
 
-    started = _time.monotonic()
-    nzo_id, submit_error = _submit_nzb_with_ui_pump(
-        "http://hydra/getnzb/rate-limited",
-        "movie.mkv",
-        dialog,
-        monitor,
-    )
-    elapsed = _time.monotonic() - started
-
-    assert nzo_id is None
-    assert submit_error == {"status": 400, "message": "TooManyRequests"}
-    assert elapsed < 0.2
+    try:
+        nzo_id, submit_error = _submit_nzb_with_ui_pump(
+            "http://hydra/getnzb/rate-limited",
+            "movie.mkv",
+            dialog,
+            monitor,
+        )
+        # Load-independent proof: the terminal error returned WHILE the probe is
+        # still mid-flight (blocked) -- it was NOT awaited, so no slow_probe ran
+        # past its block and the completed list is still empty at return. A
+        # regression that awaits the probe would block until the 2s timeout, then
+        # record a completion, making this list non-empty and failing the assert.
+        assert not probe_completed
+        assert nzo_id is None
+        assert submit_error == {"status": 400, "message": "TooManyRequests"}
+    finally:
+        release_probe.set()
 
 
 @patch("resources.lib.resolver._show_submit_error_dialog")
@@ -5149,10 +5168,16 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
     """Existing nzbdav queue jobs should be adopted without a fixed grace wait."""
     queue_seen = threading.Event()
     submit_can_finish = threading.Event()
+    submit_completed = [False]
 
     def delayed_submit(_nzb_url, _title):
         assert queue_seen.wait(timeout=1)
+        # Released only in the finally below (AFTER the snapshot), with no
+        # early timer, so the slow submit worker cannot finish before we
+        # record whether adoption waited for it -- load-independent. The
+        # 0.75s cap only bounds a regression that blocks on this submit.
         submit_can_finish.wait(timeout=0.75)
+        submit_completed[0] = True
         return "SABnzbd_nzo_submitted_late", None
 
     def queued_job(_title):
@@ -5170,18 +5195,22 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
     monitor = MagicMock()
     monitor.waitForAbort.side_effect = lambda seconds: (_time.sleep(seconds) or False)
 
-    started = _time.perf_counter()
     try:
         nzo_id, submit_error = _submit_nzb_with_ui_pump(
             "http://hydra/getnzb/abc", "movie.mkv", dialog, monitor
         )
+        submit_completed_at_return = submit_completed[0]
     finally:
         submit_can_finish.set()
-    elapsed = _time.perf_counter() - started
 
     assert (nzo_id, submit_error) == ("SABnzbd_nzo_existing_queue", None)
     monitor.waitForAbort.assert_not_called()
-    assert elapsed < 0.2, "existing queue adoption took {:.3f}s".format(elapsed)
+    # Structural proof (load-independent): the existing-queue hit must be
+    # adopted before the slow submit worker is released (only the finally
+    # above releases it, after the snapshot). If adoption wrongly waited out
+    # a fixed grace, delayed_submit would finish its bounded wait and set
+    # submit_completed -> submit_completed_at_return True.
+    assert submit_completed_at_return is False
 
 
 @patch("resources.lib.resolver._existing_completed_stream", return_value=None)
@@ -5193,9 +5222,16 @@ def test_submit_ui_pump_rechecks_queue_quickly_after_initial_fast_miss(
     """A queue hit just after the first probe should not wait 200 ms."""
     submit_can_finish = threading.Event()
     queue_probe_times = []
+    submit_completed = [False]
 
     def delayed_submit(_nzb_url, _title):
+        # Slow op: blocks until the test releases submit_can_finish in its
+        # finally (AFTER snapshotting the flag below). submit_completed flips
+        # True only once this wait returns, so a fast path that adopts the
+        # queue hit without awaiting the worker observes it still False --
+        # load-independent. The 0.75s cap only bounds a regression that waits.
         submit_can_finish.wait(timeout=0.75)
+        submit_completed[0] = True
         return "SABnzbd_nzo_submitted", None
 
     def queued_job(_title):
@@ -5215,18 +5251,22 @@ def test_submit_ui_pump_rechecks_queue_quickly_after_initial_fast_miss(
     monitor = MagicMock()
     monitor.waitForAbort.side_effect = lambda seconds: (_time.sleep(seconds) or False)
 
-    started = _time.perf_counter()
     try:
         nzo_id, submit_error = _submit_nzb_with_ui_pump(
             "http://hydra/getnzb/abc", "movie.mkv", dialog, monitor
         )
+        submit_completed_at_return = submit_completed[0]
     finally:
         submit_can_finish.set()
-    elapsed = _time.perf_counter() - started
 
     assert (nzo_id, submit_error) == ("SABnzbd_nzo_second_fast_probe", None)
     assert len(queue_probe_times) == 2
-    assert elapsed < 0.2, "second fast queue probe took {:.3f}s".format(elapsed)
+    # Structural proof (load-independent): the second queue probe's hit is
+    # adopted and returned while the submit worker is still blocked on
+    # submit_can_finish (released only in the finally above, after this
+    # snapshot). A regression that waits for the submit worker would let it
+    # complete first -> submit_completed_at_return True.
+    assert submit_completed_at_return is False
 
 
 @patch("resources.lib.resolver.find_completed_by_name")
@@ -6453,19 +6493,31 @@ def test_poll_once_returns_active_queue_before_slow_history(
 ):
     """An active queue row is enough to update progress and start the next poll."""
 
+    # Load-independent structural guard: the history fetch blocks on an event
+    # the test releases only in finally, AFTER the fast-path result is captured.
+    # If _poll_once returns without awaiting history, history_completed stays
+    # False at the snapshot. A regression that blocks on history would run
+    # slow_history to completion (setting the flag) before returning -> red.
+    release = threading.Event()
+    history_completed = {"done": False}
+
     def slow_history(_nzo_id):
-        _time.sleep(0.25)
+        release.wait(timeout=2)
+        history_completed["done"] = True
 
     mock_status.return_value = {"status": "Downloading", "percentage": "50"}
     mock_history.side_effect = slow_history
 
-    started = _time.monotonic()
-    job_status, history, webdav_error = _poll_once(
-        "nzo_active", "movie", _make_monitor()
-    )
-    elapsed = _time.monotonic() - started
+    try:
+        job_status, history, webdav_error = _poll_once(
+            "nzo_active", "movie", _make_monitor()
+        )
+        # The fast active-queue path must return before the slow history fetch
+        # has completed.
+        assert not history_completed["done"]
+    finally:
+        release.set()
 
-    assert elapsed < 0.2
     assert job_status == mock_status.return_value
     assert history is None
     assert webdav_error is None
@@ -6858,9 +6910,11 @@ def test_poll_until_ready_waits_for_full_progress_history_before_poll_tick(
 @patch("resources.lib.resolver.find_video_file")
 @patch("resources.lib.resolver.get_job_history")
 @patch("resources.lib.resolver.get_job_status")
+@patch("resources.lib.resolver._wait_for_abort_or_timeout", return_value=False)
 @patch("resources.lib.resolver.xbmc")
 def test_poll_until_ready_repolls_full_progress_history_miss_before_full_tick(
     mock_xbmc,
+    mock_wait,
     mock_status,
     mock_history,
     mock_find,
@@ -6869,6 +6923,9 @@ def test_poll_until_ready_repolls_full_progress_history_miss_before_full_tick(
     _mock_find_completed,
 ):
     """A 100% queue row with a fast history miss should not wait a full tick."""
+    from resources.lib.resolver import _POLL_NEAR_COMPLETE_FAST_REPOLL_SECONDS
+
+    poll_interval = 1
     completed_history = {
         "status": "Completed",
         "storage": "/mnt/nzbdav/completed-symlinks/uncategorized/movie",
@@ -6878,32 +6935,36 @@ def test_poll_until_ready_repolls_full_progress_history_miss_before_full_tick(
     mock_status.return_value = {"status": "Downloading", "percentage": "100"}
 
     def get_history(_nzo_id):
-        history_calls.append(_time.perf_counter())
+        history_calls.append(_nzo_id)
         if len(history_calls) == 1:
             return None
         return completed_history
 
     monitor = MagicMock()
-    monitor.waitForAbort.side_effect = lambda seconds: (_time.sleep(seconds) or False)
+    monitor.waitForAbort.return_value = False
     mock_xbmc.Monitor.return_value = monitor
     mock_history.side_effect = get_history
     mock_find.return_value = "/content/uncategorized/movie/movie.mkv"
     mock_stream_url.return_value = ("http://webdav/movie.mkv", {"Authorization": "x"})
 
-    started = _time.perf_counter()
     url, headers = _poll_until_ready(
-        "http://hydra/nzb", "movie", _make_dialog(), 1, 3600
+        "http://hydra/nzb", "movie", _make_dialog(), poll_interval, 3600
     )
-    elapsed = _time.perf_counter() - started
 
     assert url == "http://webdav/movie.mkv"
     assert headers == {"Authorization": "x"}
+    # The full-progress miss forced exactly one repoll (2 history calls).
     assert len(history_calls) == 2
-    history_gap = history_calls[1] - history_calls[0]
-    assert history_gap < 0.5, "full-progress history retry gap was {:.3f}s".format(
-        history_gap
-    )
-    assert elapsed < 0.5, "full-progress repoll waited {:.3f}s".format(elapsed)
+    # Structural, load-independent proof the repoll happened BEFORE the full
+    # poll tick. The per-poll wait (_wait_for_abort_or_timeout) is mocked, so it
+    # never really sleeps -- there is no wall-clock bound. The 100% (full
+    # progress) row must pace the single inter-poll wait on the near-complete
+    # fast-repoll interval, strictly shorter than the full poll_interval the
+    # slow path would have waited. A regression that drops the near-complete
+    # fast repoll would call this with poll_interval and fail the assertion.
+    expected_wait = min(poll_interval, _POLL_NEAR_COMPLETE_FAST_REPOLL_SECONDS)
+    mock_wait.assert_called_once_with(monitor, expected_wait)
+    assert expected_wait < poll_interval
 
 
 @patch("resources.lib.resolver.cancel_job")
@@ -7143,15 +7204,19 @@ def test_poll_until_ready_rechecks_completed_webdav_before_full_poll_interval(
         {"Authorization": "Basic primary"},
     )
 
-    started = _time.perf_counter()
     url, headers = _poll_until_ready(
         "http://hydra/nzb", "movie", _make_dialog(), 1, 3600
     )
-    elapsed = _time.perf_counter() - started
 
     assert url == "http://webdav/content/uncategorized/movie/movie.mkv"
     assert headers == {"Authorization": "Basic primary"}
-    assert elapsed < 0.5, "completed WebDAV recheck waited {:.3f}s".format(elapsed)
+    # Completed-WebDAV recheck guard (replaces a flake-prone wall-clock bound).
+    # The first find_video_file miss must recheck inline on the graduated
+    # 0.025s fast recheck delay -- it returns the video on that recheck rather
+    # than letting the poll loop fall through and wait a full poll_interval (1s)
+    # tick before re-polling. If the inline recheck regressed away, this fast
+    # recheck delay is never requested and the assertion fails.
+    monitor.waitForAbort.assert_any_call(0.025)
 
 
 @patch("resources.lib.resolver._existing_completed_stream", return_value=None)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -3899,6 +3899,13 @@ def test_start_direct_playback_prepare_snapshots_settings_in_worker(
         settings_getter=settings_getter,
     )
 
+    # Load-independent thread-handle proof: the returned state must carry the
+    # live worker thread. If thread.start() raised and prepare ran synchronously
+    # (or a refactor dropped the handle / took the ready-state path), state
+    # carries "thread": None. This goes red even when the in-flight gate timing
+    # below stays green (e.g. a dropped ``state["thread"] = thread`` assignment).
+    assert state["thread"] is not None
+
     try:
         # The worker is genuinely in-flight (it has entered the blocked settings
         # read) but cannot have finished prepare while the gate above is closed
@@ -5314,8 +5321,16 @@ def test_submit_ui_pump_rechecks_queue_quickly_after_initial_fast_miss(
     # interval while still going red on a slow-interval regression.
     from resources.lib.resolver import (  # pylint: disable=import-outside-toplevel
         _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS,
+        _SUBMIT_QUEUE_PROBE_FAST_WINDOW_SECONDS,
         _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
     )
+
+    # Premise pin (load-independent): the cadence proof assumes the 2nd probe
+    # (~0.05s in) lands inside the fast-retry window. Shrinking the window to an
+    # intermediate value (e.g. 0.06s) would still keep probe_gap < midpoint green
+    # yet degrade behavior by ending the fast cadence prematurely. Pin the
+    # documented window so such a config drift goes red here.
+    assert _SUBMIT_QUEUE_PROBE_FAST_WINDOW_SECONDS >= 2.0
 
     probe_gap = queue_probe_times[1] - queue_probe_times[0]
     fast_slow_midpoint = (
@@ -6981,6 +6996,16 @@ def test_poll_until_ready_waits_for_full_progress_history_before_poll_tick(
         "full-progress grace missed history on poll 1 and slept a poll wait "
         "before resolving; waitForAbort delays={}".format(poll_waits)
     )
+    # Premise pin (load-independent): the structural proof above rides on the
+    # ~0.02s simulated history latency landing inside the documented grace. An
+    # intermediate grace reduction (e.g. 0.07) would still sit above 0.02 and
+    # keep the len==1 / no-poll-wait snapshot green, yet shrink the real-world
+    # safety margin. Pin the documented grace so such a drift goes red here.
+    from resources.lib.resolver import (  # pylint: disable=import-outside-toplevel
+        _POLL_FULL_PROGRESS_HISTORY_GRACE_SECONDS,
+    )
+
+    assert _POLL_FULL_PROGRESS_HISTORY_GRACE_SECONDS == 0.14
 
 
 @patch("resources.lib.resolver._existing_completed_stream", return_value=None)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -5075,11 +5075,14 @@ def test_wait_direct_playback_prepare_waits_for_local_proxy_when_prepare_stalls(
     mock_prepare.side_effect = slow_prepare
 
     state = _start_direct_playback_prepare(stream_url, stream_headers)
-    started = _time.perf_counter()
     prepared = _wait_direct_playback_prepare(state, wait_seconds=0.01)
-    elapsed = _time.perf_counter() - started
 
-    assert elapsed >= 0.03
+    # The returned proxy_url is the SLOW prepare's own output (".../stream/slow"),
+    # which only exists once the stalled 0.04s prepare ran to completion -- so a
+    # correct result proves _wait_direct_playback_prepare waited for it. The old
+    # `elapsed >= 0.03` lower bound was redundant with that AND flaked under load
+    # (the worker's 0.04s sleep can begin before `started` is captured, so the
+    # measured span dips below 0.03 even though the wait happened).
     assert prepared["service_port"] == 57800
     assert prepared["stream_url"] == stream_url
     assert prepared["stream_headers"] == stream_headers

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -5230,12 +5230,22 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
     # a fixed grace, delayed_submit would finish its bounded wait and set
     # submit_completed -> submit_completed_at_return True.
     assert submit_completed_at_return is False
-    # No-initial-probe-delay guard (CodeRabbit Major): a reintroduced non-zero
-    # _SUBMIT_QUEUE_PROBE_INITIAL_DELAY_SECONDS pushes the FIRST queue probe out
-    # by that delay (the worker does `queue_stop.wait(delay)` before its first
-    # find_queued_by_name). Healthy path issues it in ~ms; this generous 0.1s
-    # ceiling sits far below any meaningful reintroduced delay yet well above
-    # scheduling jitter, catching what the submit_completed snapshot cannot.
+    # No-initial-probe-delay guard (CodeRabbit): the load-independent PRIMARY
+    # check is that the production constant is still zero -- it catches ANY
+    # reintroduced non-zero initial grace, including a small one (e.g. 0.05) that
+    # the coarse runtime ceiling below would let slip. The worker does
+    # `queue_stop.wait(_SUBMIT_QUEUE_PROBE_INITIAL_DELAY_SECONDS)` before its
+    # first find_queued_by_name, so a non-zero value delays the FIRST probe --
+    # which the submit_completed snapshot above cannot see.
+    from resources.lib.resolver import (  # pylint: disable=import-outside-toplevel
+        _SUBMIT_QUEUE_PROBE_INITIAL_DELAY_SECONDS,
+    )
+
+    assert _SUBMIT_QUEUE_PROBE_INITIAL_DELAY_SECONDS == 0
+    # Coarse runtime sanity check (secondary): the first probe is issued in ~ms
+    # on the healthy path; this generous 0.1s ceiling sits well above scheduling
+    # jitter and catches a large reintroduced delay even if the constant assert
+    # is somehow bypassed.
     assert first_probe_at, "queue probe never ran"
     first_probe_delay = first_probe_at[0] - started
     assert (

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -5220,7 +5220,6 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
     monitor = MagicMock()
     monitor.waitForAbort.side_effect = lambda seconds: (_time.sleep(seconds) or False)
 
-    started = _time.perf_counter()
     try:
         nzo_id, submit_error = _submit_nzb_with_ui_pump(
             "http://hydra/getnzb/abc", "movie.mkv", dialog, monitor
@@ -5249,17 +5248,12 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
     )
 
     assert _SUBMIT_QUEUE_PROBE_INITIAL_DELAY_SECONDS == 0
-    # Coarse runtime sanity check (secondary): the first probe is issued in ~ms
-    # on the healthy path; this generous 0.1s ceiling sits well above scheduling
-    # jitter and catches a large reintroduced delay even if the constant assert
-    # is somehow bypassed.
+    # Non-vacuity: the queue probe actually ran, so the adoption above was
+    # genuinely exercised. The previous 0.1s wall-clock ceiling on the first
+    # probe was removed (Codex P2): it measured thread creation + worker
+    # scheduling, so a loaded runner could exceed it even with a healthy zero
+    # initial delay -- the constant pin above is the load-independent guard.
     assert first_probe_at, "queue probe never ran"
-    first_probe_delay = first_probe_at[0] - started
-    assert (
-        first_probe_delay < 0.1
-    ), "first queue probe was delayed {:.3f}s (initial grace reintroduced?)".format(
-        first_probe_delay
-    )
 
 
 @patch("resources.lib.resolver._existing_completed_stream", return_value=None)
@@ -5300,48 +5294,62 @@ def test_submit_ui_pump_rechecks_queue_quickly_after_initial_fast_miss(
     monitor = MagicMock()
     monitor.waitForAbort.side_effect = lambda seconds: (_time.sleep(seconds) or False)
 
+    # Record the actual interval the probe worker waits between probes by
+    # capturing queue_stop.wait(interval) directly (Codex P2) -- a load-robust
+    # signal that does not depend on scheduler-delayed wall-clock gaps.
+    recorded_probe_waits = []
+
+    class _RecordingEvent(threading.Event):
+        def wait(self, timeout=None):
+            recorded_probe_waits.append(timeout)
+            return super().wait(timeout)
+
     try:
-        nzo_id, submit_error = _submit_nzb_with_ui_pump(
-            "http://hydra/getnzb/abc", "movie.mkv", dialog, monitor
-        )
+        with patch("resources.lib.resolver.threading.Event", _RecordingEvent):
+            nzo_id, submit_error = _submit_nzb_with_ui_pump(
+                "http://hydra/getnzb/abc", "movie.mkv", dialog, monitor
+            )
         submit_completed_at_return = submit_completed[0]
     finally:
         submit_can_finish.set()
 
     assert (nzo_id, submit_error) == ("SABnzbd_nzo_second_fast_probe", None)
     assert len(queue_probe_times) == 2
-    # Cadence guard (CodeRabbit Major): two probes happening is not enough -- the
-    # second probe must have been paced by the FAST retry interval, not the
-    # normal slow poll. A regression dropping the recheck to the slow poll (still
-    # < the 0.75s submit timeout) keeps len == 2 and the submit-not-completed
-    # snapshot green. The probe worker waits via queue_stop.wait(interval) (a
-    # real Event, not mockable), so the inter-probe GAP is the only observable
-    # signal; pin it below the fast/slow midpoint, derived from the production
-    # constants so it tracks them and tolerates load overrun up to ~3x the fast
-    # interval while still going red on a slow-interval regression.
+    # Cadence guard (CodeRabbit Major + Codex P2): two probes happening is not
+    # enough -- the second probe must have been paced by the FAST retry interval,
+    # not the normal slow poll. A regression dropping the recheck to the slow poll
+    # (still < the 0.75s submit timeout) keeps len == 2 and the submit-not-
+    # completed snapshot green. Instead of measuring the scheduler-delayed inter-
+    # probe wall-clock gap (which flakes under load), the recording Event above
+    # captured the actual interval the worker passed to queue_stop.wait(); assert
+    # the slow interval was never used to pace a reprobe.
     from resources.lib.resolver import (  # pylint: disable=import-outside-toplevel
         _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS,
         _SUBMIT_QUEUE_PROBE_FAST_WINDOW_SECONDS,
         _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
     )
 
-    # Premise pin (load-independent): the cadence proof assumes the 2nd probe
-    # (~0.05s in) lands inside the fast-retry window. Shrinking the window to an
-    # intermediate value (e.g. 0.06s) would still keep probe_gap < midpoint green
-    # yet degrade behavior by ending the fast cadence prematurely. Pin the
-    # documented window so such a config drift goes red here.
+    # Premise pin (load-independent): the fast cadence only applies while elapsed
+    # < the fast window; shrinking the window to an intermediate value would end
+    # the fast cadence prematurely. Pin the documented window.
     assert _SUBMIT_QUEUE_PROBE_FAST_WINDOW_SECONDS >= 2.0
 
-    probe_gap = queue_probe_times[1] - queue_probe_times[0]
-    fast_slow_midpoint = (
-        _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS + _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS
-    ) / 2
-    assert probe_gap < fast_slow_midpoint, (
-        "second queue probe used the slow {:.3f}s poll instead of the fast "
-        "{:.3f}s retry; inter-probe gap was {:.3f}s".format(
+    probe_interval_waits = [
+        timeout
+        for timeout in recorded_probe_waits
+        if timeout
+        in (
+            _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS,
+            _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
+        )
+    ]
+    assert probe_interval_waits, "probe worker never paced a reprobe"
+    assert _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS not in probe_interval_waits, (
+        "reprobe used the slow {:.3f}s poll interval instead of the fast {:.3f}s "
+        "retry; intervals waited={}".format(
             _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
             _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS,
-            probe_gap,
+            probe_interval_waits,
         )
     )
     # Structural proof (load-independent): the second queue probe's hit is
@@ -7315,12 +7323,20 @@ def test_poll_until_ready_rechecks_completed_webdav_before_full_poll_interval(
     assert url == "http://webdav/content/uncategorized/movie/movie.mkv"
     assert headers == {"Authorization": "Basic primary"}
     # Completed-WebDAV recheck guard (replaces a flake-prone wall-clock bound).
-    # The first find_video_file miss must recheck inline on the graduated
-    # 0.025s fast recheck delay -- it returns the video on that recheck rather
-    # than letting the poll loop fall through and wait a full poll_interval (1s)
-    # tick before re-polling. If the inline recheck regressed away, this fast
-    # recheck delay is never requested and the assertion fails.
-    monitor.waitForAbort.assert_any_call(0.025)
+    # The first find_video_file miss must recheck inline on the graduated 0.025s
+    # fast recheck delay AND return the video on that recheck -- it must NOT fall
+    # through to a full poll_interval (1s) tick before consuming the second
+    # lookup.
+    wait_delays = [c.args[0] for c in monitor.waitForAbort.call_args_list if c.args]
+    assert 0.025 in wait_delays, "inline 0.025s fast recheck was not requested"
+    # Ordering guard (Codex P2): a 0.025s recheck followed by a full poll wait
+    # would still satisfy the assert_any_call above yet delay playback ~1s, which
+    # the removed total-latency bound caught. Assert no full poll tick ran before
+    # resolving -- load-independent (call-args, not wall-clock).
+    assert 1 not in wait_delays, (
+        "completed-WebDAV path waited a full poll tick before consuming the "
+        "recheck result; waitForAbort delays={}".format(wait_delays)
+    )
 
 
 @patch("resources.lib.resolver._existing_completed_stream", return_value=None)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2404,7 +2404,7 @@ def test_resolve_overlaps_bookmark_cleanup_with_post_submit_poll(
     assert timing["cleanup_end"] <= timing["play"]
     # Intervals [cleanup_start, cleanup_end] and [poll_start, poll_end] intersect
     # => cleanup ran in parallel with the post-submit poll (serial would not overlap).
-    assert timing["cleanup_start"] < timing["poll_end"]
+    # cleanup_start < poll_end is already asserted (with a message) above.
     assert timing["poll_start"] < timing["cleanup_end"]
 
 
@@ -2613,7 +2613,7 @@ def test_resolve_overlaps_proxy_prepare_with_bookmark_cleanup_after_ready(
     assert timing["cleanup_end"] <= timing["resolved"]
     # Intervals [prepare_start, prepare_end] and [cleanup_start, cleanup_end]
     # intersect => proxy prepare overlapped the in-flight cleanup (not serial).
-    assert timing["prepare_start"] < timing["cleanup_end"]
+    # prepare_start < cleanup_end is already asserted above.
     assert timing["cleanup_start"] < timing["prepare_end"]
 
 
@@ -3884,7 +3884,12 @@ def test_start_direct_playback_prepare_snapshots_settings_in_worker(
         calls.append(key)
         if len(calls) == 1:
             slow_started.set()
-            release_settings.wait(0.2)
+            # Block on a test-controlled gate released ONLY in the finally below
+            # (AFTER the snapshot), NOT a self-releasing timer: the worker stays
+            # in-flight until then, so ``done`` cannot be set before the snapshot.
+            # A self-releasing wait here would let the worker finish on its own
+            # under load and false-fail the snapshot.
+            release_settings.wait(timeout=2)
         return default
 
     state = _start_direct_playback_prepare(
@@ -3895,10 +3900,12 @@ def test_start_direct_playback_prepare_snapshots_settings_in_worker(
     )
 
     try:
-        # Prepare returns while the worker is still blocked in the slow settings
-        # getter => the work was dispatched to a background thread, not awaited.
+        # The worker is genuinely in-flight (it has entered the blocked settings
+        # read) but cannot have finished prepare while the gate above is closed
+        # => structural proof prepare runs off the caller's thread. A
+        # synchronous-prepare regression sets ``done`` before this point.
+        assert slow_started.wait(2)
         assert not state["done"].is_set()
-        assert slow_started.wait(0.2)
         release_settings.set()
         prepared = _wait_direct_playback_prepare(state)
     finally:
@@ -5005,18 +5012,26 @@ def test_submit_ui_pump_terminal_error_does_not_wait_for_probe_cleanup(
     monitor.abortRequested.return_value = False
 
     try:
+        started = _time.monotonic()
         nzo_id, submit_error = _submit_nzb_with_ui_pump(
             "http://hydra/getnzb/rate-limited",
             "movie.mkv",
             dialog,
             monitor,
         )
+        elapsed = _time.monotonic() - started
         # Load-independent proof: the terminal error returned WHILE the probe is
         # still mid-flight (blocked) -- it was NOT awaited, so no slow_probe ran
-        # past its block and the completed list is still empty at return. A
-        # regression that awaits the probe would block until the 2s timeout, then
-        # record a completion, making this list non-empty and failing the assert.
+        # past its block and the completed list is still empty at return. Catches
+        # an UNBOUNDED await of the still-parked probe threads.
         assert not probe_completed
+        # Bounded-join guard (test-analyzer): dropping the terminal-error
+        # early-skip would let cleanup fall through to t.join(timeout=1) on each
+        # still-parked probe, pinning the return at ~1-2s. The healthy terminal
+        # path returns in ~ms (>=10x margin); this generous 0.5s ceiling sits
+        # well below the ~1s+ regression, staying load-independent while still
+        # going red on the bounded join that `not probe_completed` alone misses.
+        assert elapsed < 0.5
         assert nzo_id is None
         assert submit_error == {"status": 400, "message": "TooManyRequests"}
     finally:
@@ -5169,6 +5184,7 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
     queue_seen = threading.Event()
     submit_can_finish = threading.Event()
     submit_completed = [False]
+    first_probe_at = []
 
     def delayed_submit(_nzb_url, _title):
         assert queue_seen.wait(timeout=1)
@@ -5181,6 +5197,8 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
         return "SABnzbd_nzo_submitted_late", None
 
     def queued_job(_title):
+        if not first_probe_at:
+            first_probe_at.append(_time.perf_counter())
         queue_seen.set()
         return {
             "nzo_id": "SABnzbd_nzo_existing_queue",
@@ -5195,6 +5213,7 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
     monitor = MagicMock()
     monitor.waitForAbort.side_effect = lambda seconds: (_time.sleep(seconds) or False)
 
+    started = _time.perf_counter()
     try:
         nzo_id, submit_error = _submit_nzb_with_ui_pump(
             "http://hydra/getnzb/abc", "movie.mkv", dialog, monitor
@@ -5211,6 +5230,19 @@ def test_submit_ui_pump_adopts_existing_queue_without_initial_probe_delay(
     # a fixed grace, delayed_submit would finish its bounded wait and set
     # submit_completed -> submit_completed_at_return True.
     assert submit_completed_at_return is False
+    # No-initial-probe-delay guard (CodeRabbit Major): a reintroduced non-zero
+    # _SUBMIT_QUEUE_PROBE_INITIAL_DELAY_SECONDS pushes the FIRST queue probe out
+    # by that delay (the worker does `queue_stop.wait(delay)` before its first
+    # find_queued_by_name). Healthy path issues it in ~ms; this generous 0.1s
+    # ceiling sits far below any meaningful reintroduced delay yet well above
+    # scheduling jitter, catching what the submit_completed snapshot cannot.
+    assert first_probe_at, "queue probe never ran"
+    first_probe_delay = first_probe_at[0] - started
+    assert (
+        first_probe_delay < 0.1
+    ), "first queue probe was delayed {:.3f}s (initial grace reintroduced?)".format(
+        first_probe_delay
+    )
 
 
 @patch("resources.lib.resolver._existing_completed_stream", return_value=None)
@@ -5261,6 +5293,32 @@ def test_submit_ui_pump_rechecks_queue_quickly_after_initial_fast_miss(
 
     assert (nzo_id, submit_error) == ("SABnzbd_nzo_second_fast_probe", None)
     assert len(queue_probe_times) == 2
+    # Cadence guard (CodeRabbit Major): two probes happening is not enough -- the
+    # second probe must have been paced by the FAST retry interval, not the
+    # normal slow poll. A regression dropping the recheck to the slow poll (still
+    # < the 0.75s submit timeout) keeps len == 2 and the submit-not-completed
+    # snapshot green. The probe worker waits via queue_stop.wait(interval) (a
+    # real Event, not mockable), so the inter-probe GAP is the only observable
+    # signal; pin it below the fast/slow midpoint, derived from the production
+    # constants so it tracks them and tolerates load overrun up to ~3x the fast
+    # interval while still going red on a slow-interval regression.
+    from resources.lib.resolver import (  # pylint: disable=import-outside-toplevel
+        _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS,
+        _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
+    )
+
+    probe_gap = queue_probe_times[1] - queue_probe_times[0]
+    fast_slow_midpoint = (
+        _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS + _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS
+    ) / 2
+    assert probe_gap < fast_slow_midpoint, (
+        "second queue probe used the slow {:.3f}s poll instead of the fast "
+        "{:.3f}s retry; inter-probe gap was {:.3f}s".format(
+            _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
+            _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS,
+            probe_gap,
+        )
+    )
     # Structural proof (load-independent): the second queue probe's hit is
     # adopted and returned while the submit worker is still blocked on
     # submit_can_finish (released only in the finally above, after this
@@ -6879,8 +6937,13 @@ def test_poll_until_ready_waits_for_full_progress_history_before_poll_tick(
 
     def get_history(_nzo_id):
         history_calls.append(_time.perf_counter())
+        # Simulate a small history-arrival latency that lands comfortably inside
+        # _POLL_FULL_PROGRESS_HISTORY_GRACE_SECONDS (0.14). The earlier 0.12 sleep
+        # sat only 0.02s under the grace, so under CPU load it stretched past 0.14
+        # and forced a false 2nd poll. ~0.02 keeps a wide margin while still
+        # exercising the grace-wait path.
         if len(history_calls) == 1:
-            _time.sleep(0.12)
+            _time.sleep(0.02)
         return completed_history
 
     monitor = MagicMock()
@@ -6896,12 +6959,18 @@ def test_poll_until_ready_waits_for_full_progress_history_before_poll_tick(
 
     assert url == "http://webdav/movie.mkv"
     assert headers == {"Authorization": "x"}
-    # Structural guard (replaces a flake-prone wall-clock bound that sat only
-    # ~0.05s above the 0.12s history latency + 0.14s grace): get_history returns
-    # the completed row immediately on every call, so finishing with exactly one
-    # history call proves the 100% row caught history inside the full-progress
-    # grace on the first poll. A missed grace forces a second poll -> 2 calls.
+    # Structural red-on-regression signal (load-independent): the 100% grace
+    # caught completed history on the FIRST poll, so history was fetched once and
+    # no poll-tick / fast-repoll waitForAbort ran before resolving. If the
+    # full-progress grace regresses (shrinks below the history latency), the 100%
+    # row misses history on poll 1 and the loop sleeps a poll wait then re-fetches
+    # history -> len(history_calls) == 2 and a poll wait appears.
     assert len(history_calls) == 1
+    poll_waits = [c.args[0] for c in monitor.waitForAbort.call_args_list if c.args]
+    assert not poll_waits, (
+        "full-progress grace missed history on poll 1 and slept a poll wait "
+        "before resolving; waitForAbort delays={}".format(poll_waits)
+    )
 
 
 @patch("resources.lib.resolver._existing_completed_stream", return_value=None)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -5334,22 +5334,27 @@ def test_submit_ui_pump_rechecks_queue_quickly_after_initial_fast_miss(
     # the fast cadence prematurely. Pin the documented window.
     assert _SUBMIT_QUEUE_PROBE_FAST_WINDOW_SECONDS >= 2.0
 
-    probe_interval_waits = [
+    # Every reprobe-pacing wait must be the fast interval. Waits below it (the
+    # 0.0 initial-delay wait and the <=0.01 history-probe coordination polls) are
+    # not cadence; any wait at or above the fast interval that isn't exactly the
+    # fast interval -- the slow poll OR an intermediate value like 0.1 -- is a
+    # cadence regression (CodeRabbit). The healthy run records only [~0.003, 0.01,
+    # 0.05], so the fast interval is the sole >= -fast value.
+    reprobe_interval_waits = [
         timeout
         for timeout in recorded_probe_waits
-        if timeout
-        in (
-            _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS,
-            _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
-        )
+        if timeout and timeout >= _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS
     ]
-    assert probe_interval_waits, "probe worker never paced a reprobe"
-    assert _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS not in probe_interval_waits, (
-        "reprobe used the slow {:.3f}s poll interval instead of the fast {:.3f}s "
-        "retry; intervals waited={}".format(
-            _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
+    assert reprobe_interval_waits, "probe worker never paced a reprobe"
+    assert all(
+        timeout == _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS
+        for timeout in reprobe_interval_waits
+    ), (
+        "reprobe used a non-fast interval (slow poll or intermediate value); "
+        "intervals >= fast were {} (fast={:.3f}s, slow={:.3f}s)".format(
+            reprobe_interval_waits,
             _SUBMIT_QUEUE_PROBE_FAST_INTERVAL_SECONDS,
-            probe_interval_waits,
+            _SUBMIT_QUEUE_PROBE_INTERVAL_SECONDS,
         )
     )
     # Structural proof (load-independent): the second queue probe's hit is
@@ -7316,26 +7321,42 @@ def test_poll_until_ready_rechecks_completed_webdav_before_full_poll_interval(
         {"Authorization": "Basic primary"},
     )
 
-    url, headers = _poll_until_ready(
-        "http://hydra/nzb", "movie", _make_dialog(), 1, 3600
-    )
+    from resources.lib import (
+        resolver as _resolver,
+    )  # pylint: disable=import-outside-toplevel
+
+    helper_poll_waits = []
+    _real_wait_for_abort = _resolver._wait_for_abort_or_timeout
+
+    def _spy_wait_for_abort(mon, wait_seconds, *args, **kwargs):
+        helper_poll_waits.append(wait_seconds)
+        return _real_wait_for_abort(mon, wait_seconds, *args, **kwargs)
+
+    with patch.object(_resolver, "_wait_for_abort_or_timeout", _spy_wait_for_abort):
+        url, headers = _poll_until_ready(
+            "http://hydra/nzb", "movie", _make_dialog(), 1, 3600
+        )
 
     assert url == "http://webdav/content/uncategorized/movie/movie.mkv"
     assert headers == {"Authorization": "Basic primary"}
     # Completed-WebDAV recheck guard (replaces a flake-prone wall-clock bound).
     # The first find_video_file miss must recheck inline on the graduated 0.025s
     # fast recheck delay AND return the video on that recheck -- it must NOT fall
-    # through to a full poll_interval (1s) tick before consuming the second
-    # lookup.
+    # through to a full poll_interval (1s) tick before consuming the second lookup.
     wait_delays = [c.args[0] for c in monitor.waitForAbort.call_args_list if c.args]
     assert 0.025 in wait_delays, "inline 0.025s fast recheck was not requested"
-    # Ordering guard (Codex P2): a 0.025s recheck followed by a full poll wait
-    # would still satisfy the assert_any_call above yet delay playback ~1s, which
-    # the removed total-latency bound caught. Assert no full poll tick ran before
-    # resolving -- load-independent (call-args, not wall-clock).
+    # The full poll tick is requested two ways and BOTH must be absent before the
+    # recheck resolves (Codex P2): monitor.waitForAbort(poll_interval), and the
+    # helper _wait_for_abort_or_timeout(monitor, poll_interval), which waits on a
+    # threading.Event rather than waitForAbort. A 0.025s recheck followed by
+    # either would delay playback ~1s while still returning the right URL.
     assert 1 not in wait_delays, (
-        "completed-WebDAV path waited a full poll tick before consuming the "
-        "recheck result; waitForAbort delays={}".format(wait_delays)
+        "completed-WebDAV path waited a full poll tick (waitForAbort) before "
+        "consuming the recheck result; delays={}".format(wait_delays)
+    )
+    assert 1 not in helper_poll_waits, (
+        "completed-WebDAV path waited a full poll tick via "
+        "_wait_for_abort_or_timeout; helper waits={}".format(helper_poll_waits)
     )
 
 

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -6170,25 +6170,34 @@ def test_hls_producer_close_wait_false_kills_without_waiting(tmp_path):
     alive_proc.poll.return_value = None
     wait_entered = threading.Event()
     release_wait = threading.Event()
+    wait_thread = []
 
     def slow_wait(timeout=None):
         assert timeout == 5
+        wait_thread.append(threading.current_thread())
         wait_entered.set()
         release_wait.wait(timeout=1)
 
     alive_proc.wait.side_effect = slow_wait
     producer._proc = alive_proc
 
-    started = time.perf_counter()
+    calling_thread = threading.current_thread()
     try:
         producer.close(wait_for_process=False)
-        elapsed = time.perf_counter() - started
         alive_proc.kill.assert_called_once()
         assert wait_entered.wait(timeout=1)
     finally:
         release_wait.set()
 
-    assert elapsed < 0.13, "nonblocking HLS close waited {:.3f}s".format(elapsed)
+    # Structural guard (load-independent): the deferred wait() must run on a
+    # background thread, NOT the caller of close(wait_for_process=False). A
+    # regression to a synchronous wait would run slow_wait on this calling
+    # thread (blocking until the 1s release), which the thread-identity check
+    # catches without any flake-prone wall-clock bound.
+    assert wait_thread, "ffmpeg wait() never ran"
+    assert (
+        wait_thread[0] is not calling_thread
+    ), "nonblocking HLS close waited on the calling thread"
 
 
 def test_hls_producer_opens_ffmpeg_log_in_init(tmp_path):
@@ -9338,11 +9347,15 @@ def test_live_fallback_selection_pipelines_fingerprint_reads_before_cutover():
     assert source["validated"] is True
     assert len(calls) == 1 + len(ranges) * 2
     sequential_floor = len(calls) * delay
+    # Structural proof of pipelining (load-independent): at least two fingerprint
+    # reads were in flight at once. The old `elapsed < sequential_floor * 0.75`
+    # wall-clock bound proved the same overlap-saves-time property but flaked under
+    # heavy load (CPU starvation serialises the reads), so max_active is the sole
+    # guard -- a regression that serialises the reads keeps max_active at 1.
     assert max_active[0] > 1, (
         "expected overlapped fingerprint reads; max_active={} elapsed={:.3f}s "
         "sequential_floor={:.3f}s".format(max_active[0], elapsed, sequential_floor)
     )
-    assert elapsed < sequential_floor * 0.75
 
 
 def test_live_fallback_selection_tries_ready_source_before_standby_refresh():

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -4406,9 +4406,11 @@ def test_prepare_stream_does_not_block_new_url_on_old_ffmpeg_wait():
 
     wait_entered = threading.Event()
     release_wait = threading.Event()
+    wait_thread = []
 
     def slow_wait(timeout=None):
         assert timeout == 5
+        wait_thread.append(threading.current_thread())
         wait_entered.set()
         release_wait.wait(timeout=1)
 
@@ -4418,20 +4420,25 @@ def test_prepare_stream_does_not_block_new_url_on_old_ffmpeg_wait():
 
     timer = threading.Timer(0.18, release_wait.set)
     timer.start()
-    started = time.perf_counter()
+    calling_thread = threading.current_thread()
     try:
         with patch.object(sp, "_get_content_length", return_value=200000):
             sp.prepare_stream("http://host/two.mkv")
-        elapsed = time.perf_counter() - started
         assert old_proc.kill.called
         assert wait_entered.wait(timeout=1)
     finally:
         release_wait.set()
         timer.cancel()
 
-    assert elapsed < 0.13, "old ffmpeg wait blocked new proxy URL for {:.3f}s".format(
-        elapsed
-    )
+    # Structural guard (load-independent): the old ffmpeg's blocking wait() must
+    # run on the background reap thread, NOT on the thread that returns the new
+    # proxy URL. If teardown regressed to a synchronous wait on the prepare
+    # path, slow_wait would run on this calling thread and prepare_stream would
+    # block until the 0.18 s timer released it.
+    assert wait_thread, "old ffmpeg wait() never ran"
+    assert (
+        wait_thread[0] is not calling_thread
+    ), "old ffmpeg wait blocked the new proxy URL on the calling thread"
     assert len(sp._server.stream_sessions) == 1
 
 
@@ -6403,7 +6410,12 @@ def test_hls_producer_prepare_returns_when_init_and_first_segment_appear(
             started = time.perf_counter()
             producer.prepare()  # must not raise
             elapsed = time.perf_counter() - started
-        assert elapsed < 0.30, "fmp4 prepare waited {:.3f}s after early output".format(
+        # Bound sits between the ~0.1 s file-write delay (plus 0.05 s poll
+        # granularity) and the 0.5 s argv-rejection window: a regression that
+        # stopped returning early when init.mp4 + seg_000000.m4s are on disk
+        # would wait the full argv window (>= 0.5 s). 0.40 stays red on that
+        # regression while tolerating CI load spikes.
+        assert elapsed < 0.40, "fmp4 prepare waited {:.3f}s after early output".format(
             elapsed
         )
     finally:

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2026 nzbdav contributors
 
 import time
+from threading import Lock
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError
 
@@ -635,29 +636,41 @@ def test_find_video_file_parallelizes_sibling_subfolders_for_post_picker_start(
         ]
     )
 
+    spans = {}
+    spans_lock = Lock()
+
+    def _slow(key, response, delay):
+        with spans_lock:
+            spans.setdefault(key, {})["start"] = time.perf_counter()
+        time.sleep(delay)
+        with spans_lock:
+            spans[key]["end"] = time.perf_counter()
+        return _webdav_response(response)
+
     def propfind(req, **_kwargs):
         url = req.full_url
         if url.endswith("/Serial/"):
             return _webdav_response(parent)
         if url.endswith("/Serial/A/"):
-            time.sleep(0.08)
-            return _webdav_response(empty_a)
+            return _slow("A", empty_a, 0.08)
         if url.endswith("/Serial/B/"):
-            time.sleep(0.18)
-            return _webdav_response(empty_b)
+            return _slow("B", empty_b, 0.18)
         if url.endswith("/Serial/C/"):
-            time.sleep(0.18)
-            return _webdav_response(with_video)
+            return _slow("C", with_video, 0.18)
         raise AssertionError("unexpected PROPFIND URL: {}".format(url))
 
     mock_urlopen.side_effect = propfind
 
-    started = time.perf_counter()
     path = find_video_file("/content/uncategorized/Serial/")
-    elapsed = time.perf_counter() - started
 
     assert path == "/content/uncategorized/Serial/C/Movie.mkv"
-    assert elapsed < 0.30, "WebDAV sibling discovery took {:.3f}s".format(elapsed)
+    # Structural overlap proof: the two equally-slow siblings B and C must be
+    # in-flight at the same time (parallel fan-out). Serial probing would make
+    # B finish before C starts (B_end <= C_start) -> no overlap -> failure.
+    b, c = spans["B"], spans["C"]
+    assert (
+        b["start"] < c["end"] and c["start"] < b["end"]
+    ), "sibling probes B and C did not overlap: " "B={B} C={C}".format(B=b, C=c)
 
 
 @patch("resources.lib.webdav._get_settings")
@@ -695,31 +708,41 @@ def test_find_video_file_overlaps_first_sibling_probe_for_post_picker_start(
         ]
     )
 
+    spans = {}
+    spans_lock = Lock()
+
+    def _slow(key, response, delay):
+        with spans_lock:
+            spans.setdefault(key, {})["start"] = time.perf_counter()
+        time.sleep(delay)
+        with spans_lock:
+            spans[key]["end"] = time.perf_counter()
+        return _webdav_response(response)
+
     def propfind(req, **_kwargs):
         url = req.full_url
         if url.endswith("/Overlap/"):
             return _webdav_response(parent)
         if url.endswith("/Overlap/A/"):
-            time.sleep(0.16)
-            return _webdav_response(empty_a)
+            return _slow("A", empty_a, 0.16)
         if url.endswith("/Overlap/B/"):
-            time.sleep(0.16)
-            return _webdav_response(with_video_b)
+            return _slow("B", with_video_b, 0.16)
         if url.endswith("/Overlap/C/"):
-            time.sleep(0.6)
-            return _webdav_response(slow_c)
+            return _slow("C", slow_c, 0.6)
         raise AssertionError("unexpected PROPFIND URL: {}".format(url))
 
     mock_urlopen.side_effect = propfind
 
-    started = time.perf_counter()
     path = find_video_file("/content/uncategorized/Overlap/")
-    elapsed = time.perf_counter() - started
 
     assert path == "/content/uncategorized/Overlap/B/Movie.mkv"
-    # Overlapped: near the slowest sibling (~0.6s), well under the serial sum
-    # (0.16 + 0.16 + 0.6 = 0.92s).
-    assert elapsed < 0.85, "first-sibling WebDAV overlap took {:.3f}s".format(elapsed)
+    # Structural overlap proof: the fast winner B and the slowest sibling C must
+    # be in-flight simultaneously (probes overlap). Serial probing would make B
+    # finish before C starts (B_end <= C_start) -> no overlap -> failure.
+    b, c = spans["B"], spans["C"]
+    assert (
+        b["start"] < c["end"] and c["start"] < b["end"]
+    ), "first-sibling probes B and C did not overlap: " "B={B} C={C}".format(B=b, C=c)
 
 
 @patch("resources.lib.webdav._get_settings")


### PR DESCRIPTION
## What

A follow-up to #301: 18 timing tests still flaked on loaded CI runners because they gated behavior on tight wall-clock bounds (e.g. `assert elapsed < 0.2`) whose floor sat only ~0.05s below the bound. Under CPU load the real work + thread scheduling exceeded the bound → spurious failure. This PR makes them **load-robust while staying red-on-regression** (every rewrite still fails if the behavior it guards actually breaks — none was neutered into a no-op or a bound so wide it proves nothing).

## How

A workflow empirically measured every wall-clock timing assert in the suite under load, identified the behavior each one guards, and replaced the flaky/tight ones using whichever structural guard fits:

| Strategy | Asserts instead of `elapsed < X` | Tests |
|---|---|---|
| **mock-call** | the skipped op never ran (counter/event/`not done`) | stuck-dialog, prepare-in-worker, 2× fallback "does-not-wait", 2× indexer timeouts |
| **interval-overlap** | two recorded `[start,end]` intervals intersect (parallelism) | 3× resolver overlaps, 2× webdav sibling probes |
| **thread-identity** | the blocking wait ran on the reap thread, not the caller | old-ffmpeg teardown |
| **drop-redundant** | a stronger structural assert already present subsumes it | fan-out concurrency, 2× fallback list, full-progress one-call |
| **widen-the-gap** | push the would-be-slow path far above a wide bound | poll_once, 2× indexer timeouts, fmp4-prepare 0.30→0.40 |

Two fallback "does-not-wait" rewrites originally snapshotted a completion counter against a `threading.Timer` release; under heavy load the snapshot could be preempted past the timer, polluting the count. Fixed by releasing the blocked fetch **only in the `finally`** (after the snapshot), with a self-timeout bounding the regression case — fully timer-independent.

## Verification

- All 18 rewritten tests pass **25/25 under 10-core CPU load** (the fallback pair 50/50).
- **Red-on-regression proven** by injecting a real serial regression (`_WEBDAV_SUBDIR_SCAN_WORKERS` 4→1) → both overlap tests fail; reverted.
- Full suite **2140 passed / 2 skipped**; lint 10/10.
- **Production code untouched** — tests-only diff across 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)