### PR TITLE
ci: fix CodeQL version skew + stop Codacy tooling from failing the pipeline

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -17,6 +17,14 @@ engines:
     exclude_paths:
       - "tests/**"
       - "plugin.video.nzbdav/resources/lib/ptt/**"
+  # Codacy enables Trivy (dependency/vuln scanner) by default, but no patterns are
+  # configured for it in this project, so it aborts ("Failed to configure Codacy
+  # Trivy: no patterns configured") and reds both the Codacy Security Scan workflow
+  # AND the app-side Codacy Static Code Analysis check. Our security coverage is
+  # pylint/prospector/bandit here plus bandit.yml, semgrep.yml and codeql.yml in
+  # CI, so disable the misconfigured engine rather than let it fail the pipeline.
+  trivy:
+    enabled: false
 exclude_paths:
   - "plugin.video.nzbdav/resources/lib/ptt/**"
   - "tests/**"

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -40,6 +40,14 @@ jobs:
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
+        # Codacy bundles tools (e.g. Trivy) whose patterns are configured
+        # server-side, outside this repo. When such a tool fails to configure
+        # ("Failed to configure Codacy Trivy: no patterns configured") or emits
+        # output the CLI can't parse, the action exits non-zero and reds the whole
+        # pipeline -- even though our own security gates (bandit, semgrep, codeql)
+        # all pass. Treat Codacy as INFORMATIONAL: its tooling must never break
+        # CI; it still uploads whatever SARIF it produced in the step below.
+        continue-on-error: true
         uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
@@ -56,6 +64,10 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
+        # Only upload when Codacy actually produced a SARIF (the step above may
+        # abort before writing it), and never fail the job on the upload itself.
+        if: ${{ hashFiles('results.sarif') != '' }}
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -53,6 +53,9 @@ jobs:
             - repo/plugin.video.nzbdav/resources/lib/ptt
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+      # Must match the init action's release exactly: a version skew (init wrote
+      # a 4.36.2 config, analyze ran 4.36.0) makes the analyze post-step abort
+      # with "Loaded a configuration file for version X, but running version Y".
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Two persistently-red CI-infra checks (not code findings).

**CodeQL "Analyze (python)"**: `init` was v4.36.2 (8aad20d) but `analyze` v4.36.0 (7211b7c); the version skew makes analyze's post-step reject init's config ("Loaded a configuration file for version 4.36.2, but running version 4.36.0"). Fix: pin `analyze` to the same v4.36.2 SHA.

**Codacy "Security Scan"**: the Codacy CLI's bundled Trivy ("no patterns configured", server-side) + an unparseable tool output exit non-zero and fail the job, though bandit/semgrep/codeql all pass. Fix: mark the Codacy step `continue-on-error` and guard the SARIF upload — Codacy stays informational and never breaks CI.

Out of scope: the app-side "Codacy Static Code Analysis" status check is posted by the Codacy GitHub App and must be adjusted in app.codacy.com (disable Trivy / the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
