### PR TITLE
🎨 Palette: [UX improvement] Add high-contrast focus indicator to results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -157,6 +157,13 @@
           <colordiffuse>FF182538</colordiffuse>
         </control>
 
+        <!-- High-contrast focus indicator -->
+        <control type="image">
+          <left>0</left><top>0</top><width>4</width><height>66</height>
+          <texture>white.png</texture>
+          <colordiffuse>FF4A9EFF</colordiffuse>
+        </control>
+
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->
         <control type="label">
           <left>6</left><top>4</top><width>32</width><height>30</height>


### PR DESCRIPTION
💡 What: Added an explicit, high-contrast visual focus indicator (a 4px vertical bar) to the currently selected item in the results list dialog.
🎯 Why: Subtle background color shifts for focused items in Kodi XML lists are often insufficient for users relying on keyboard/remote navigation, making it hard to track the active selection.
📸 Before/After: The focused item now has a distinct primary-colored (`FF4A9EFF`) bar on its left edge.
♿ Accessibility: Significantly improves visual focus feedback for keyboard/remote users navigating the search results.

---
*PR created automatically by Jules for task [11321325327965889731](https://jules.google.com/task/11321325327965889731) started by @xbmc4lyfe*