### PR TITLE
fix: pre-existing code-quality & security findings (redaction, robustness, correctness)

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/cache.py
+++ b/repo/plugin.video.nzbdav/resources/lib/cache.py
@@ -93,12 +93,18 @@ def get_cached(search_type, title, **kwargs):
             try:
                 os.remove(path)
             except OSError:
+                # Best-effort cleanup of a corrupt cache entry; a failed
+                # delete (perms/race) is non-fatal since we return None
+                # and the stale file is simply ignored / overwritten later.
                 pass
             return None
         if time.time() - timestamp > cache_ttl:
             try:
                 os.remove(path)
             except OSError:
+                # Best-effort eviction of an expired entry; a failed delete
+                # (perms/race) is non-fatal since we return None and the
+                # stale file is ignored until the next write or eviction.
                 pass
             return None
         try:

--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams.py
@@ -7,6 +7,7 @@
 import copy
 import hashlib
 import os
+import posixpath
 import re
 import threading
 import time
@@ -15,7 +16,7 @@ from functools import lru_cache
 from queue import Empty, Queue
 from types import SimpleNamespace
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
 try:
@@ -263,9 +264,34 @@ def _origin_key(parts):
     return scheme, parts.hostname.lower(), port
 
 
+def _canonical_probe_path(path):
+    """Return a decoded, normalized absolute path for allow-list checks.
+
+    Percent-encoded traversal (``/dav/%2e%2e/admin``) survives a raw-prefix
+    match but many WebDAV servers decode/normalize it back outside the base
+    path, which would forward the Authorization header to an escaped path. Decode
+    the path and reject anything containing a ``..`` segment or a backslash so the
+    containment check sees what the server will actually resolve.
+    """
+    try:
+        decoded = unquote(path or "/", errors="strict")
+    except (UnicodeDecodeError, ValueError):
+        return None
+    if "\\" in decoded or any(part == ".." for part in decoded.split("/")):
+        return None
+    normalized = posixpath.normpath(decoded)
+    if not normalized.startswith("/"):
+        normalized = "/" + normalized
+    return normalized
+
+
 def _path_is_under_base(path, base_path):
     """Return whether a URL path is within the configured base path."""
-    prefix = (base_path or "").rstrip("/")
+    path = _canonical_probe_path(path)
+    base_path = _canonical_probe_path(base_path or "/")
+    if path is None or base_path is None:
+        return False
+    prefix = base_path.rstrip("/")
     if not prefix:
         return True
     return path == prefix or path.startswith(prefix + "/")
@@ -602,7 +628,7 @@ def _titles_core_related(primary_title, candidate_title, corroborated=False):
         return corroborated
     if left == right:
         return True
-    if left <= right or right <= left:
+    if left < right or right < left:
         if corroborated:
             return True
         # Accept only a junk-SUFFIX repost: the longer title's extra tokens are

--- a/repo/plugin.video.nzbdav/resources/lib/filter.py
+++ b/repo/plugin.video.nzbdav/resources/lib/filter.py
@@ -116,8 +116,29 @@ ALL_RELEASE_GROUPS = [
     "ZAX",
 ]
 
+# The complete set of keys produced by ``parse_title_metadata``. A cached
+# ``_meta`` dict is only safe to reuse (skipping a reparse) when it satisfies
+# this FULL contract — downstream consumers such as
+# ``fallback_streams_identity`` trust any dict found in ``_meta`` and never
+# reparse, so a partial dict would silently drop quality/edition/year/
+# upscaled/container/etc. from the fallback pipeline.
+_FILTER_META_STR_KEYS = (
+    "resolution",
+    "codec",
+    "group",
+    "quality",
+    "edition",
+    "channels",
+    "container",
+)
+_FILTER_META_LIST_KEYS = ("hdr", "audio", "languages")
+_FILTER_META_BOOL_KEYS = ("proper", "repack", "upscaled")
+_FILTER_META_INT_KEYS = ("year",)
 _FILTER_META_KEYS = frozenset(
-    ("resolution", "hdr", "audio", "codec", "languages", "group")
+    _FILTER_META_STR_KEYS
+    + _FILTER_META_LIST_KEYS
+    + _FILTER_META_BOOL_KEYS
+    + _FILTER_META_INT_KEYS
 )
 
 DEFAULT_PREFERRED_GROUPS = {
@@ -738,17 +759,31 @@ def matches_filters(result, meta, settings):
 
 
 def _has_filter_metadata_shape(meta):
-    """Return True when cached metadata has keys filter_results indexes."""
+    """Return True when cached metadata satisfies the full parse contract.
+
+    Validates the complete set of fields produced by
+    ``parse_title_metadata`` (not just the ones ``filter_results`` indexes)
+    so a partial cached ``_meta`` is reparsed instead of being blindly
+    reused and propagated to ``fallback_streams_identity``.
+    """
     if not isinstance(meta, dict) or not _FILTER_META_KEYS <= set(meta):
         return False
-    for key in ("resolution", "codec", "group"):
+    for key in _FILTER_META_STR_KEYS:
         if not isinstance(meta.get(key), str):
             return False
-    for key in ("hdr", "audio", "languages"):
+    for key in _FILTER_META_LIST_KEYS:
         value = meta.get(key)
         if not isinstance(value, list):
             return False
         if any(not isinstance(item, str) for item in value):
+            return False
+    for key in _FILTER_META_BOOL_KEYS:
+        if not isinstance(meta.get(key), bool):
+            return False
+    for key in _FILTER_META_INT_KEYS:
+        value = meta.get(key)
+        # bool is a subclass of int; reject it so a stray bool year fails.
+        if not isinstance(value, int) or isinstance(value, bool):
             return False
     return True
 

--- a/repo/plugin.video.nzbdav/resources/lib/hydra.py
+++ b/repo/plugin.video.nzbdav/resources/lib/hydra.py
@@ -350,7 +350,11 @@ def fetch_release_duplicate_uploads(picked, settings_getter=None):
         )
         return []
 
-    raw_results = data.get("searchResults", []) if isinstance(data, dict) else []
+    if not isinstance(data, dict):
+        raw_results = []
+    else:
+        search_results = data.get("searchResults", [])
+        raw_results = search_results if isinstance(search_results, list) else []
     picked_link = picked.get("link", "") if isinstance(picked, dict) else ""
     uploads = []
     for raw in raw_results:

--- a/repo/plugin.video.nzbdav/resources/lib/nzbdav_api.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzbdav_api.py
@@ -50,7 +50,9 @@ def _response_slots(response, section_name):
     if not isinstance(section, dict):
         return []
     slots = section.get("slots", [])
-    return slots if isinstance(slots, list) else []
+    if not isinstance(slots, list):
+        return []
+    return [slot for slot in slots if isinstance(slot, dict)]
 
 
 def _sanitize_server_message(raw):
@@ -318,7 +320,9 @@ def submit_nzb(nzb_url, nzb_name="", settings_getter=None, submit_timeout=None):
     )
     return None, {
         "status": "rejected",
-        "message": str(error_msg) if error_msg else "nzbdav rejected the NZB",
+        "message": (
+            _redact_text(str(error_msg)) if error_msg else "nzbdav rejected the NZB"
+        ),
     }
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/prowlarr.py
+++ b/repo/plugin.video.nzbdav/resources/lib/prowlarr.py
@@ -356,9 +356,12 @@ def _parse_json_results(text):
 
     if not isinstance(data, list):
         # Prowlarr error bodies are JSON objects ({"error": ...}), not arrays.
+        from resources.lib.http_util import redact_text
+
         message = ""
         if isinstance(data, dict):
-            message = data.get("error") or data.get("message") or ""
+            raw_message = data.get("error") or data.get("message") or ""
+            message = redact_text(str(raw_message)) if raw_message else ""
         xbmc.log(
             "NZB-DAV: Unexpected Prowlarr JSON payload (not an array): {}".format(
                 message or type(data).__name__

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -120,7 +120,22 @@ def _resolve_stage(message):
             stage_file.flush()
             os.fsync(stage_file.fileno())
     except OSError:
+        # Best-effort stage breadcrumb only (debug aid). The xbmc.log line
+        # above is the real record; a missing/unwritable temp path must never
+        # break resolve.
         pass
+
+
+def _redact_log(value):
+    """Redact URLs/credentials out of a value before it reaches Kodi logs.
+
+    Backend/WebDAV exception strings and stream URLs can embed signed query
+    strings or inline credentials; mirror the lower-level API helpers'
+    redaction (see http_util.redact_text / direct_indexers / hydra).
+    """
+    from resources.lib.http_util import redact_text
+
+    return redact_text(str(value))
 
 
 def _clamp_int_setting(setting_id, value, lo, hi):
@@ -425,6 +440,8 @@ def _captured_bookmark_resume_seconds(cur, id_file, bookmark_columns):
         try:
             resume_seconds = max(resume_seconds, float(time_in_seconds))
         except (TypeError, ValueError):
+            # A non-numeric/NULL bookmark row is simply skipped; resume falls
+            # back to other rows (or 0.0). Best-effort — never abort cleanup.
             pass
     return resume_seconds
 
@@ -486,6 +503,20 @@ def _coerce_resume_seconds(value):
     return max(0.0, float(value))
 
 
+def _kodi_video_db_version(path):
+    """Numeric MyVideos schema version from a DB filename (-1 if unparseable).
+
+    Used as a sort key so the NEWEST DB wins by integer version; a plain
+    lexicographic sort picks MyVideos99.db over MyVideos131.db on upgraded
+    installs, which would target a stale DB for bookmark cleanup.
+    """
+    import os
+    import re
+
+    match = re.search(r"MyVideos(\d+)\.db$", os.path.basename(path))
+    return int(match.group(1)) if match else -1
+
+
 def _locate_kodi_video_db():
     """Return the newest MyVideos DB path, or None when unavailable."""
     try:
@@ -503,7 +534,10 @@ def _locate_kodi_video_db():
         import os
 
         db_dir = xbmcvfs.translatePath("special://database/")
-        db_files = sorted(glob.glob(os.path.join(db_dir, "MyVideos*.db")))
+        db_files = sorted(
+            glob.glob(os.path.join(db_dir, "MyVideos*.db")),
+            key=_kodi_video_db_version,
+        )
     except _DB_DISCOVERY_ERRORS as error:
         xbmc.log(
             "NZB-DAV: Failed to locate MyVideos DB for bookmark cleanup: {}".format(
@@ -1302,7 +1336,9 @@ def _finish_direct_playback(handle, prepared, resume_key="", resume_seconds=0.0)
         home = xbmcgui.Window(10000)
         if stream_info.get("direct"):
             xbmc.log(
-                "NZB-DAV: MP4 already faststart, direct play: {}".format(stream_url),
+                "NZB-DAV: MP4 already faststart, direct play: {}".format(
+                    _redact_log(stream_url)
+                ),
                 xbmc.LOGINFO,
             )
             bust_url = _cache_bust_url(stream_url)
@@ -1329,7 +1365,9 @@ def _finish_direct_playback(handle, prepared, resume_key="", resume_seconds=0.0)
     bust_url = _cache_bust_url(stream_url)
     play_url = _build_play_url(bust_url, stream_headers)
     xbmc.log(
-        "NZB-DAV: Playing direct (no proxy) (handle={}): {}".format(handle, bust_url),
+        "NZB-DAV: Playing direct (no proxy) (handle={}): {}".format(
+            handle, _redact_log(bust_url)
+        ),
         xbmc.LOGINFO,
     )
 
@@ -1365,7 +1403,9 @@ def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
 
         if stream_info.get("direct"):
             xbmc.log(
-                "NZB-DAV: MP4 already faststart, direct play: {}".format(stream_url),
+                "NZB-DAV: MP4 already faststart, direct play: {}".format(
+                    _redact_log(stream_url)
+                ),
                 xbmc.LOGINFO,
             )
             bust_url = _cache_bust_url(stream_url)
@@ -1393,7 +1433,10 @@ def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
     li = _make_playable_listitem(bust_url, stream_headers)
     _apply_resume_start_offset(li, resume_seconds)
     play_url = _build_play_url(bust_url, stream_headers)
-    xbmc.log("NZB-DAV: Playing direct (no proxy): {}".format(stream_url), xbmc.LOGINFO)
+    xbmc.log(
+        "NZB-DAV: Playing direct (no proxy): {}".format(_redact_log(stream_url)),
+        xbmc.LOGINFO,
+    )
     _set_playback_monitor_properties(
         home, play_url, stream_url, monitor_key, resume_seconds
     )
@@ -1708,6 +1751,13 @@ def _poll_once(
                             "storage": by_name.get("storage", ""),
                             "name": by_name.get("name", ""),
                             "fail_message": by_name.get("fail_message", ""),
+                            # Thread the validated terminal timestamp through
+                            # so the synthesized row carries the same
+                            # ``completed`` contract as a real history slot
+                            # (downstream consumers can re-apply the
+                            # stale-row guard without it being silently
+                            # absent).
+                            "completed": completed_ts,
                         }
             if _history_status_is_terminal(history_status[0]):
                 history_ready.set()
@@ -1884,6 +1934,8 @@ def _find_video_stream_for_folder(
                 )
             return video_path, stream_url, stream_headers
     except (AttributeError, ImportError):
+        # Optional fast-path helper is absent/incompatible on this build;
+        # fall through to the canonical find_video_file path below.
         pass
 
     kwargs = _settings_getter_kwargs(settings_getter)
@@ -2239,6 +2291,11 @@ def _submit_nzb_with_ui_pump(
     submit_result = [None, None]
     submit_done = threading.Event()
     activity_ready = threading.Event()
+    # Set when the user cancels or Kodi aborts while the (uninterruptible)
+    # addurl worker is still in flight. The worker re-checks this AFTER
+    # submit_nzb returns and cancels a late-accepted nzo_id so a user-cancelled
+    # download is never left running in nzbdav.
+    cancel_after_submit = threading.Event()
     submit_timeout_seconds = max(
         _get_submit_timeout_seconds(**_settings_getter_kwargs(settings_getter)), 1
     )
@@ -2253,6 +2310,28 @@ def _submit_nzb_with_ui_pump(
                 title,
                 **submit_kwargs,
             )
+            if submit_result[0] and cancel_after_submit.is_set():
+                # The user cancelled / Kodi aborted while addurl was still
+                # blocked; this nzo_id was accepted too late. Cancel it so the
+                # download does not keep running unattended in nzbdav.
+                try:
+                    cancel_job(
+                        submit_result[0],
+                        **_settings_getter_kwargs(settings_getter),
+                    )
+                    xbmc.log(
+                        "NZB-DAV: Cancelled late-accepted submit nzo_id={} for "
+                        "'{}' after user abort".format(submit_result[0], title),
+                        xbmc.LOGINFO,
+                    )
+                except Exception as cancel_error:  # pylint: disable=broad-except
+                    xbmc.log(
+                        "NZB-DAV: Failed to cancel late-accepted submit "
+                        "nzo_id={}: {}".format(
+                            submit_result[0], _redact_log(cancel_error)
+                        ),
+                        xbmc.LOGWARNING,
+                    )
         except Exception as e:  # pylint: disable=broad-except
             xbmc.log(
                 "NZB-DAV: submit_nzb worker raised: {}".format(e),
@@ -2465,10 +2544,12 @@ def _submit_nzb_with_ui_pump(
                     "NZB-DAV: User cancelled during submit for '{}'".format(title),
                     xbmc.LOGINFO,
                 )
+                cancel_after_submit.set()
                 return None, {"status": "cancelled", "message": ""}
             if _wait_for_submit_activity_or_abort(
                 _SUBMIT_ADOPTION_CHECK_INTERVAL_SECONDS
             ):
+                cancel_after_submit.set()
                 return None, {"status": "shutdown", "message": ""}
             probe_result = _probe_adoption_result()
             if probe_result:
@@ -2705,7 +2786,7 @@ def _completed_copy_blocks_clear(title, settings_getter):
     if result.get("error") is not None:
         xbmc.log(
             "NZB-DAV: completed-adopt probe failed before clearing the queue; "
-            "leaving queue intact: {}".format(result["error"]),
+            "leaving queue intact: {}".format(_redact_log(result["error"])),
             xbmc.LOGWARNING,
         )
         return True
@@ -2743,7 +2824,7 @@ def _maybe_clear_queue_before_submit(
     except Exception as error:  # pylint: disable=broad-except
         xbmc.log(
             "NZB-DAV: queue probe before submit failed; leaving queue intact: "
-            "{}".format(error),
+            "{}".format(_redact_log(error)),
             xbmc.LOGWARNING,
         )
         return
@@ -2890,7 +2971,10 @@ def _submit_nzb_with_retries(
             elif status in _TRANSIENT_HTTP_STATUSES:
                 xbmc.log(
                     "NZB-DAV: Submit attempt {}/{} hit transient HTTP {}: {}".format(
-                        attempt, max_submit_retries, status, submit_error["message"]
+                        attempt,
+                        max_submit_retries,
+                        status,
+                        _redact_log(submit_error["message"]),
                     ),
                     xbmc.LOGWARNING,
                 )
@@ -2901,7 +2985,7 @@ def _submit_nzb_with_retries(
                 # showing a generic failure.
                 xbmc.log(
                     "NZB-DAV: nzbdav rejected the NZB for '{}': {}".format(
-                        title, submit_error["message"]
+                        title, _redact_log(submit_error["message"])
                     ),
                     xbmc.LOGERROR,
                 )
@@ -2917,7 +3001,7 @@ def _submit_nzb_with_retries(
                 # probing queue/history just leaves the progress dialog stuck.
                 xbmc.log(
                     "NZB-DAV: Submit failed with HTTP {}, not probing queue: "
-                    "{}".format(status, submit_error["message"]),
+                    "{}".format(status, _redact_log(submit_error["message"])),
                     xbmc.LOGERROR,
                 )
                 _close_dialog_before_submit_error(dialog)
@@ -2948,7 +3032,7 @@ def _submit_nzb_with_retries(
                     return adopted_nzo_id
                 xbmc.log(
                     "NZB-DAV: Submit failed with HTTP {}, not retrying: {}".format(
-                        status, submit_error["message"]
+                        status, _redact_log(submit_error["message"])
                     ),
                     xbmc.LOGERROR,
                 )
@@ -3435,6 +3519,9 @@ def _start_fallback_submit_worker(
                     try:
                         _notify(_addon_name(), _string(30187), 4000)
                     except (RuntimeError, OSError):
+                        # The "no fallback candidates" toast is cosmetic; a UI
+                        # failure (e.g. during shutdown) must not break the
+                        # best-effort fallback worker's clean return.
                         pass
                 return
             _submit_fallback_candidates(
@@ -3459,7 +3546,18 @@ def _start_fallback_submit_worker(
         target=_worker, name="nzbdav-fallback-submit", daemon=True
     )
     state["thread"] = thread
-    thread.start()
+    try:
+        thread.start()
+    except RuntimeError as error:
+        # Thread creation can fail during Kodi shutdown / interpreter
+        # teardown. Fallbacks are best-effort, so fail soft: mark the worker
+        # finished and let the resolve path continue instead of propagating.
+        state["thread"] = None
+        state["finished"].set()
+        xbmc.log(
+            "NZB-DAV: Fallback submit worker did not start: {}".format(error),
+            xbmc.LOGWARNING,
+        )
     return state
 
 
@@ -3981,7 +4079,15 @@ def _handle_resolve_exception(label, error, handle=None):
     xbmc.log(
         "NZB-DAV: Unexpected error in {}: {}".format(label, message), xbmc.LOGERROR
     )
-    xbmcgui.Dialog().ok(_addon_name(), "Error: {}".format(message))
+    # The error dialog is best-effort UI; if it raises, the handle-based
+    # resolve must still receive its False resolution below or Kodi hangs.
+    try:
+        xbmcgui.Dialog().ok(_addon_name(), "Error: {}".format(message))
+    except (RuntimeError, OSError, TypeError) as dialog_error:
+        xbmc.log(
+            "NZB-DAV: resolve error dialog failed: {}".format(dialog_error),
+            xbmc.LOGWARNING,
+        )
     if handle is not None:
         xbmcplugin.setResolvedUrl(handle, False, xbmcgui.ListItem())
         xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
@@ -4205,7 +4311,16 @@ def resolve(handle, params):
     playback_cleanup_state = None
 
     if not nzb_url:
-        xbmcgui.Dialog().ok(_addon_name(), _string(30096))
+        # The notification is optional UI; if Dialog().ok() raises (e.g. during
+        # shutdown) the handle-based resolve must still receive its False
+        # resolution or Kodi hangs (TODO.md §H.2-H9 no-hang guarantee).
+        try:
+            xbmcgui.Dialog().ok(_addon_name(), _string(30096))
+        except (RuntimeError, OSError, TypeError) as error:
+            xbmc.log(
+                "NZB-DAV: missing-URL notification failed: {}".format(error),
+                xbmc.LOGWARNING,
+            )
         xbmcplugin.setResolvedUrl(handle, False, xbmcgui.ListItem())
         xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
         return

--- a/repo/plugin.video.nzbdav/resources/lib/resume_store.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resume_store.py
@@ -105,11 +105,17 @@ def _write(path, payload):
             try:
                 os.close(fd)
             except OSError:
+                # Best-effort cleanup after a failed write; closing the
+                # dangling descriptor is non-fatal (the write already
+                # failed and was logged above) so swallow any close error.
                 pass
         if tmp_path:
             try:
                 os.unlink(tmp_path)
             except OSError:
+                # Best-effort removal of the orphaned temp file; an unlink
+                # failure (perms/race/already-gone) is non-fatal cleanup,
+                # so swallow it rather than masking the original error.
                 pass
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -611,6 +611,19 @@ def _script_completed_job_for_selection(selected):
         return None
 
 
+def _provider_error_message(provider_label, error):
+    """Format a provider failure, redacting any secrets the exception leaked.
+
+    urllib/provider exceptions routinely embed the full request URL (apikey
+    and all) in ``str(error)``. router.py later logs this and surfaces it to
+    the UI, so it must pass through the same ``redact_text`` scrub the
+    connection tests use before any provider error escapes.
+    """
+    from resources.lib.http_util import redact_text
+
+    return "{} search failed: {}".format(provider_label, redact_text(str(error)))
+
+
 def _search_all_providers(
     search_type,
     title,
@@ -811,7 +824,7 @@ def _search_all_providers(
                 kwargs,
             )
         except Exception as error:  # pylint: disable=broad-exception-caught
-            outcome = ([], "{} search failed: {}".format(provider_label, error))
+            outcome = ([], _provider_error_message(provider_label, error))
         provider_outcomes = [
             (
                 provider_label,
@@ -850,7 +863,7 @@ def _search_all_providers(
                             provider_label,
                             (
                                 [],
-                                "{} search failed: {}".format(provider_label, error),
+                                _provider_error_message(provider_label, error),
                             ),
                         )
                     )
@@ -1261,7 +1274,16 @@ def _handle_direct_play(handle, params):
             opener = urllib_request.urlopen if urlopen is _ORIGINAL_URLOPEN else urlopen
             with opener(req, timeout=10) as resp:  # nosec B310
                 headers = getattr(resp, "headers", {}) or {}
-                length = int(headers.get("Content-Length", "1") or 1)
+                raw_length = headers.get("Content-Length")
+                if raw_length in (None, ""):
+                    # A HEAD without Content-Length is an UNKNOWN size, not a
+                    # 1-byte body; fabricating length 1 would hand the proxy a
+                    # bogus content length. Surface it as a failure instead.
+                    return 0, "missing-length"
+                try:
+                    length = int(raw_length)
+                except (TypeError, ValueError):
+                    return 0, "invalid-length"
                 if length <= 0:
                     return 0, "missing-length"
                 return length, ""
@@ -2162,13 +2184,44 @@ def _json_object(response):
     return data if isinstance(data, dict) else {}
 
 
+def _build_xxe_safe_xml_parser(element_tree):
+    """Return an ElementTree XMLParser with external entities disabled.
+
+    Mirrors ``prowlarr._build_xxe_safe_parser`` / ``hydra``: a hostile or
+    compromised Hydra/Newznab instance could otherwise coerce us into reading
+    arbitrary local files via an XXE payload in its (user-configured) response.
+    """
+    parser = element_tree.XMLParser()  # nosec B314 — entities disabled below
+    try:
+        parser.parser.DefaultHandler = lambda _d: None
+        parser.parser.ExternalEntityRefHandler = lambda *_: False
+    except AttributeError:  # pragma: no cover — non-expat parser backend
+        pass
+    return parser
+
+
 def _xml_root_name(response):
-    """Return the unqualified root XML tag name, lowercased."""
-    import xml.etree.ElementTree as ET  # nosec B405 - trusted service response
+    """Return the unqualified root XML tag name, lowercased.
+
+    The payload is a user-configured Hydra/Newznab service response, so it is
+    parsed with external entity resolution disabled (defusedxml when bundled,
+    otherwise an XXE-hardened stdlib parser) to keep parity with the other XML
+    clients. ``defusedxml``'s ``DefusedXmlException`` subclasses ``ValueError``,
+    so a hostile payload falls through to the empty-string fallback.
+    """
+    try:
+        from defusedxml import ElementTree as element_tree
+    except ImportError:  # pragma: no cover - Kodi installs may not bundle defusedxml
+        from xml.etree import ElementTree as element_tree
 
     try:
-        root = ET.fromstring(response)  # nosec B314 - trusted service response
-    except (TypeError, ET.ParseError):
+        if getattr(element_tree, "__name__", "").startswith("defusedxml."):
+            root = element_tree.fromstring(response)
+        else:
+            root = element_tree.fromstring(  # nosec B314 — XXE-safe parser below
+                response, parser=_build_xxe_safe_xml_parser(element_tree)
+            )
+    except (TypeError, ValueError, element_tree.ParseError):
         return ""
     return root.tag.rsplit("}", 1)[-1].lower()
 

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -5050,3 +5050,65 @@ def test_rank_fallback_candidates_dedupes_same_postdate():
     assert "https://distinct/nzb" in links
     assert ("https://early/nzb" in links) != ("https://dupe/nzb" in links)
     assert len(ranked) == 2
+
+
+def test_path_is_under_base_rejects_encoded_traversal():
+    """FS: canonicalize decoded paths before the base-path allow-list check.
+
+    A percent-encoded traversal like ``/dav/%2e%2e/admin`` passes a raw-prefix
+    match against base ``/dav`` but resolves outside it once the server decodes
+    it, which would leak the forwarded Authorization header to an escaped path.
+    The containment check must decode and reject the escape.
+    """
+    from resources.lib import fallback_streams as fs
+
+    # Legitimate in-base paths still pass (encoded and plain).
+    assert fs._path_is_under_base("/dav", "/dav") is True
+    assert fs._path_is_under_base("/dav/movie.mkv", "/dav") is True
+    assert fs._path_is_under_base("/dav/a%20b/movie.mkv", "/dav") is True
+    # Encoded ".." traversal under the base must be rejected.
+    assert fs._path_is_under_base("/dav/%2e%2e/admin", "/dav") is False
+    assert fs._path_is_under_base("/dav/sub/%2e%2e/%2e%2e/etc", "/dav") is False
+    # Raw ".." segments and backslash escapes are rejected too.
+    assert fs._path_is_under_base("/dav/../admin", "/dav") is False
+    assert fs._path_is_under_base("/dav\\..\\admin", "/dav") is False
+    # A sibling that merely shares the base prefix string is not "under" it.
+    assert fs._path_is_under_base("/davother/file", "/dav") is False
+
+
+def test_validated_probe_url_rejects_encoded_traversal():
+    """FS: encoded traversal must not survive probe-URL validation.
+
+    The Authorization-forwarding probe path (fetch_content_length /
+    fetch_range_digest) only runs on a URL that passes _validated_probe_url, so a
+    traversal that escapes the configured base must validate to None.
+    """
+    from resources.lib import fallback_streams as fs
+    from resources.lib.fallback_streams import _split_http_url
+
+    base = _split_http_url("https://host/dav")
+    assert base is not None
+
+    good = fs._validated_probe_url("https://host/dav/movie.mkv", probe_bases=[base])
+    assert good == "https://host/dav/movie.mkv"
+
+    escaped = fs._validated_probe_url(
+        "https://host/dav/%2e%2e/admin", probe_bases=[base]
+    )
+    assert escaped is None
+
+
+def test_titles_core_related_strict_subset_after_equality_fast_path():
+    """FS: the subset branch uses strict subsets (equality handled earlier).
+
+    The ``left == right`` fast path returns before the subset test, so the
+    subset comparison must be a strict subset on each side; a disjoint pair
+    (neither a subset of the other) is rejected without corroboration.
+    """
+    from resources.lib import fallback_streams as fs
+
+    # Proper-subset (junk suffix) repost still accepted in both directions.
+    assert fs._titles_core_related("the matrix", "the matrix mirror") is True
+    assert fs._titles_core_related("the matrix mirror", "the matrix") is True
+    # Identical titles still take the equality fast path.
+    assert fs._titles_core_related("the matrix", "the matrix") is True

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from resources.lib.filter import (
+    _has_filter_metadata_shape,
     _sort_results,
     filter_results,
     matches_filters,
@@ -637,14 +638,7 @@ def test_filter_results_attaches_meta_key(mock_settings):
 def test_filter_results_reuses_prefilled_meta(mock_settings):
     """filter_results should not reparse results that already have metadata."""
     mock_settings.return_value = _all_pass_settings()
-    meta = {
-        "resolution": "1080p",
-        "hdr": [],
-        "audio": [],
-        "codec": "x264/AVC",
-        "languages": [],
-        "group": "GRP",
-    }
+    meta = _complete_meta("Movie.2024.1080p.BluRay.x264-GRP")
     result = _make_result("Movie.2024.1080p.BluRay.x264-GRP")
     result["_meta"] = meta
 
@@ -782,14 +776,7 @@ def test_filter_results_seeds_duplicate_title_cache_from_prefilled_meta(mock_set
     """A valid prefilled _meta should satisfy later duplicate titles."""
     mock_settings.return_value = _all_pass_settings()
     title = "Movie.2024.1080p.BluRay.x264-GRP"
-    meta = {
-        "resolution": "1080p",
-        "hdr": [],
-        "audio": [],
-        "codec": "x264/AVC",
-        "languages": [],
-        "group": "GRP",
-    }
+    meta = _complete_meta(title)
     first = _make_result(title, link="http://example.com/one.nzb")
     first["_meta"] = meta
     second = _make_result(title, link="http://example.com/two.nzb")
@@ -1410,3 +1397,71 @@ def test_release_is_pack_false_for_last_final_season_movie_titles():
     # Numeric/positional season packs are unaffected.
     assert release_is_pack("Some.Show.First.Season.1080p-GRP") is True
     assert release_is_pack("Some.Show.Season.Two.1080p-GRP") is True
+
+
+# --- Cached _meta contract validation (PR #358 / CodeRabbit filter.py#413) ---
+
+
+def _complete_meta(title="Movie.2024.1080p.BluRay.x264-GROUP"):
+    """A fully-parsed _meta dict (the complete parse_title_metadata contract)."""
+    return parse_title_metadata(title)
+
+
+def test_complete_parsed_meta_passes_shape_check():
+    """A full parse_title_metadata() result satisfies the reuse contract."""
+    assert _has_filter_metadata_shape(_complete_meta()) is True
+
+
+def test_partial_cached_meta_fails_shape_check():
+    """A cached dict carrying only the six filter_results-indexed fields must
+    NOT be treated as reusable: it omits quality/edition/year/upscaled/
+    container/etc., which downstream fallback_streams_identity would silently
+    drop because it trusts any dict in _meta and skips reparsing."""
+    partial = {
+        "resolution": "1080p",
+        "hdr": [],
+        "audio": [],
+        "codec": "x264/AVC",
+        "languages": [],
+        "group": "GROUP",
+    }
+    assert _has_filter_metadata_shape(partial) is False
+
+
+def test_wrong_typed_meta_fields_fail_shape_check():
+    """Each field must match its contract type. bool is rejected for the int
+    year field (bool is an int subclass in Python)."""
+    bad_year = _complete_meta()
+    bad_year["year"] = True  # bool, not a real int year
+    assert _has_filter_metadata_shape(bad_year) is False
+
+    bad_upscaled = _complete_meta()
+    bad_upscaled["upscaled"] = "no"  # str, not bool
+    assert _has_filter_metadata_shape(bad_upscaled) is False
+
+
+@patch("resources.lib.filter._get_filter_settings")
+def test_partial_cached_meta_is_reparsed_not_reused(mock_settings):
+    """Regression: filter_results must reparse a result whose _meta is an
+    incomplete dict instead of blindly reusing it, so the full metadata
+    contract reaches the downstream fallback pipeline."""
+    mock_settings.return_value = _all_pass_settings()
+    title = "Movie.2024.2160p.BluRay.x265-GROUP"
+    result = _make_result(title)
+    # Pre-seed a partial _meta missing the downstream-only fields.
+    result["_meta"] = {
+        "resolution": "1080p",  # deliberately wrong to prove a reparse happened
+        "hdr": [],
+        "audio": [],
+        "codec": "x264/AVC",
+        "languages": [],
+        "group": "GROUP",
+    }
+    filtered, all_parsed = filter_results([result])
+    meta = all_parsed[0]["_meta"]
+    # Reparsed: the full contract keys are now present...
+    for key in ("quality", "edition", "year", "upscaled", "container"):
+        assert key in meta
+    # ...and the values reflect the real title, not the stale partial dict.
+    assert meta["resolution"] == "2160p"
+    assert _has_filter_metadata_shape(meta) is True

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -922,3 +922,21 @@ def test_resolve_indexer_returns_empty_when_no_source_at_all():
 
     item = ET.fromstring("<item><title>No source info</title></item>")
     assert _resolve_indexer(item, "") == ""
+
+
+@patch("resources.lib.hydra._get_settings")
+def test_fetch_release_duplicate_uploads_tolerates_null_search_results(mock_settings):
+    """Hydra returning {"searchResults": null} (or any non-list shape) must
+    yield [] rather than crashing fallback peer discovery on a non-iterable.
+    """
+    mock_settings.return_value = ("http://hydra:5076", "key")
+    fake_resp = MagicMock()
+    fake_resp.read.return_value = b'{"searchResults": null}'
+    fake_resp.__enter__.return_value = fake_resp
+    fake_resp.__exit__.return_value = False
+    with patch("urllib.request.urlopen", return_value=fake_resp):
+        uploads = hydra.fetch_release_duplicate_uploads(
+            {"title": "The Matrix", "link": "http://x"}
+        )
+    assert isinstance(uploads, list)
+    assert not uploads

--- a/tests/test_nzbdav_api.py
+++ b/tests/test_nzbdav_api.py
@@ -9,6 +9,7 @@ from urllib.error import URLError
 from resources.lib.nzbdav_api import (
     _DEFAULT_SUBMIT_TIMEOUT,
     _get_submit_timeout,
+    _response_slots,
     _sanitize_server_message,
     cancel_job,
     completed_jobs_lookup_done,
@@ -185,6 +186,35 @@ def test_submit_nzb_failure_returns_rejected_error(mock_http, mock_settings):
     assert nzo_id is None
     assert error is not None
     assert error["status"] == "rejected"
+
+
+@patch("resources.lib.nzbdav_api._get_settings")
+@patch("resources.lib.nzbdav_api._http_get")
+def test_submit_nzb_rejected_message_redacts_apikey(mock_http, mock_settings):
+    """A rejection that echoes the failing indexer URL (with apikey) must be
+    redacted in the returned ``message`` too — not just the log line — since
+    the resolver can surface it in a dialog or recovery log.
+    """
+    mock_settings.return_value = ("http://nzbdav:3000", "testkey")
+    mock_http.return_value = json.dumps(
+        {
+            "status": False,
+            "error": "Failed to fetch http://idx/getnzb?apikey=SECRET123",
+        }
+    )
+    nzo_id, error = submit_nzb("http://hydra:5076/getnzb/abc123", "The.Matrix")
+    assert nzo_id is None
+    assert error["status"] == "rejected"
+    assert "SECRET123" not in error["message"]
+    assert "REDACTED" in error["message"]
+
+
+def test_response_slots_filters_non_dict_entries():
+    """Malformed nzbdav JSON (None / str / scalar slot entries) must be
+    dropped at the boundary so downstream ``slot.get(...)`` walkers can't crash.
+    """
+    response = {"queue": {"slots": [{"nzo_id": "a"}, None, "junk", 5, {"nzo_id": "b"}]}}
+    assert _response_slots(response, "queue") == [{"nzo_id": "a"}, {"nzo_id": "b"}]
 
 
 @patch("resources.lib.nzbdav_api._get_settings")

--- a/tests/test_prowlarr.py
+++ b/tests/test_prowlarr.py
@@ -180,6 +180,20 @@ def test_parse_results_non_rss_root_returns_empty():
     assert not results
 
 
+def test_parse_json_results_redacts_apikey_in_error_payload():
+    """A Prowlarr JSON error body can echo the indexer apikey; it must be
+    redacted before it lands in the returned error string (and the log).
+    """
+    from resources.lib.prowlarr import _parse_json_results
+
+    body = '{"error": "bad request to http://idx?apikey=SECRET123"}'
+    results, error = _parse_json_results(body)
+    assert isinstance(results, list)
+    assert not results
+    assert "SECRET123" not in error
+    assert "REDACTED" in error
+
+
 # --- search_prowlarr URL-building tests ---
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -28,7 +28,10 @@ from resources.lib.resolver import (
     _handle_history_result,
     _handle_job_status,
     _handle_resolve_exception,
+    _kodi_video_db_version,
+    _locate_kodi_video_db,
     _make_playable_listitem,
+    _maybe_clear_queue_before_submit,
     _play_direct,
     _play_via_proxy,
     _poll_once,
@@ -8807,3 +8810,186 @@ def test_resolve_and_play_reads_toggle_via_injected_getter():
     play_entry.assert_called_once_with(
         "http://i/x.nzb", "X", params, resume_seconds=0.0, resume_key=""
     )
+
+
+# --- CodeRabbit PR #358 quality-fix regression tests ---
+
+
+def _joined_log(xbmc_mock):
+    """Concatenate every xbmc.log() message for substring assertions."""
+    return " ".join(str(c) for c in xbmc_mock.log.call_args_list)
+
+
+def test_queue_probe_exception_redacted_before_logging():
+    """Finding 1: queue-probe exception strings are redacted before logging."""
+    secret_url = "http://nzbdav/api?apikey=SUPERSECRET123"
+    with patch("resources.lib.resolver.xbmc") as xbmc_mock, patch(
+        "resources.lib.resolver._clear_queue_on_submit_mode", return_value="ask"
+    ), patch(
+        "resources.lib.resolver.get_queue_slots",
+        side_effect=Exception("probe failed " + secret_url),
+    ):
+        _maybe_clear_queue_before_submit(
+            "Some.Title", settings_getter=lambda k, d=None: "0"
+        )
+    logged = _joined_log(xbmc_mock)
+    assert "SUPERSECRET123" not in logged
+    assert "apikey=REDACTED" in logged
+
+
+def test_resume_stream_url_redacted_before_logging():
+    """Finding 2: direct-play stream URLs are redacted in INFO logs."""
+    secret_url = "http://host/stream.mp4?apikey=SUPERSECRET123"
+    with patch("resources.lib.resolver.xbmc") as xbmc_mock, patch(
+        "resources.lib.resolver.xbmcgui"
+    ):
+        _finish_player_playback({"stream_url": secret_url, "stream_headers": {}})
+    logged = _joined_log(xbmc_mock)
+    assert "SUPERSECRET123" not in logged
+    assert "apikey=REDACTED" in logged
+
+
+def test_submit_error_message_redacted_before_logging():
+    """Finding 3: backend submit-error messages are redacted before logging."""
+    submit_error = {
+        "status": "rejected",
+        "message": "rejected http://indexer/getnzb?apikey=SUPERSECRET123",
+    }
+    with patch("resources.lib.resolver.xbmc") as xbmc_mock, patch(
+        "resources.lib.resolver.xbmcgui"
+    ), patch(
+        "resources.lib.resolver._submit_nzb_with_ui_pump",
+        return_value=(None, submit_error),
+    ), patch(
+        "resources.lib.resolver._show_submit_error_dialog"
+    ):
+        result = _submit_nzb_with_retries(
+            "nzburl", "Title", MagicMock(), MagicMock(), max_submit_retries=1
+        )
+    assert result is None
+    logged = _joined_log(xbmc_mock)
+    assert "SUPERSECRET123" not in logged
+    assert "apikey=REDACTED" in logged
+
+
+def test_fallback_worker_thread_start_failure_fails_soft():
+    """Finding 4: a RuntimeError from thread.start() is caught, not propagated."""
+    with patch("resources.lib.resolver.xbmc"), patch(
+        "resources.lib.resolver.threading.Thread"
+    ) as thread_cls:
+        thread = MagicMock()
+        thread.start.side_effect = RuntimeError("can't start new thread")
+        thread_cls.return_value = thread
+        state = _start_fallback_submit_worker(
+            candidates=[{"nzburl": "http://i/x.nzb", "title": "X"}]
+        )
+    assert state["thread"] is None
+    assert state["finished"].is_set()
+
+
+def test_resolve_missing_url_resolves_false_even_if_dialog_raises():
+    """Finding 5: setResolvedUrl(False) still runs if the notification raises."""
+    with patch("resources.lib.resolver.xbmc"), patch(
+        "resources.lib.resolver.xbmcgui"
+    ) as gui, patch("resources.lib.resolver.xbmcplugin") as plugin:
+        gui.Dialog.return_value.ok.side_effect = RuntimeError("no UI")
+        resolve(7, {})
+    plugin.setResolvedUrl.assert_called_once()
+    args = plugin.setResolvedUrl.call_args[0]
+    assert args[0] == 7 and args[1] is False
+
+
+def test_handle_resolve_exception_resolves_false_even_if_dialog_raises():
+    """Finding 6: an exception-path dialog must not block the False resolution."""
+    with patch("resources.lib.resolver.xbmc"), patch(
+        "resources.lib.resolver.xbmcgui"
+    ) as gui, patch("resources.lib.resolver.xbmcplugin") as plugin:
+        gui.Dialog.return_value.ok.side_effect = RuntimeError("no UI")
+        _handle_resolve_exception("label", Exception("boom"), handle=9)
+    plugin.setResolvedUrl.assert_called_once()
+    args = plugin.setResolvedUrl.call_args[0]
+    assert args[0] == 9 and args[1] is False
+
+
+def test_poll_once_by_name_terminal_threads_completed_timestamp():
+    """Finding 7: the synthesized by-name terminal row carries ``completed``."""
+    completed_ts = 1_000_000
+    slot = {
+        "status": "Failed",
+        "storage": "",
+        "name": "My.Title",
+        "nzo_id": "nzo-new",
+        "fail_message": "boom",
+        "completed": completed_ts,
+    }
+    with patch("resources.lib.resolver.xbmc"), patch(
+        "resources.lib.resolver.get_job_status", return_value=None
+    ), patch("resources.lib.resolver.get_job_history", return_value=None), patch(
+        "resources.lib.nzbdav_api.find_terminal_by_name", return_value=slot
+    ):
+        _, history_status, _ = _poll_once(
+            "nzo-old", "My.Title", MagicMock(), submit_started_wall=completed_ts
+        )
+    assert history_status is not None
+    assert history_status.get("status") == "Failed"
+    assert history_status.get("completed") == completed_ts
+
+
+def test_late_accepted_submit_is_cancelled_after_user_abort():
+    """Finding 8: an nzo_id accepted after user cancel is cancelled in nzbdav."""
+    submit_release = threading.Event()
+    cancelled = threading.Event()
+
+    def fake_submit(nzb_url, title, **kwargs):
+        submit_release.wait(2)
+        return "nzo-late", None
+
+    def fake_cancel(nzo_id, **kwargs):
+        cancelled.set()
+        return True
+
+    dialog = MagicMock()
+    dialog.iscanceled.return_value = True
+    monitor = MagicMock()
+    monitor.waitForAbort.return_value = False
+    monitor.abortRequested.return_value = False
+
+    with patch("resources.lib.resolver.xbmc"), patch(
+        "resources.lib.resolver.xbmcgui"
+    ), patch("resources.lib.resolver.submit_nzb", side_effect=fake_submit), patch(
+        "resources.lib.resolver.cancel_job", side_effect=fake_cancel
+    ), patch(
+        "resources.lib.resolver._get_submit_timeout_seconds", return_value=60
+    ):
+        nzo_id, submit_error = _submit_nzb_with_ui_pump(
+            "http://i/x.nzb", "Title", dialog, monitor
+        )
+        assert nzo_id is None
+        assert submit_error["status"] == "cancelled"
+        # Release the still-blocked addurl worker so it returns its late nzo_id.
+        submit_release.set()
+        assert cancelled.wait(2), "late-accepted submit was not cancelled"
+
+
+def test_kodi_video_db_version_parses_numeric_version():
+    """Finding 9: version key parses the integer schema version."""
+    assert _kodi_video_db_version("/db/MyVideos131.db") == 131
+    assert _kodi_video_db_version("/db/MyVideos99.db") == 99
+    assert _kodi_video_db_version("/db/Textures13.db") == -1
+
+
+def test_locate_kodi_video_db_picks_highest_numeric_version():
+    """Finding 9: newest DB chosen by numeric version, not lexicographic sort."""
+    with patch("resources.lib.resolver.xbmc") as xbmc_mock, patch(
+        "resources.lib.resolver.xbmcvfs"
+    ) as vfs_mock, patch("glob.glob") as glob_mock:
+        xbmc_mock.Player.return_value.isPlayingVideo.return_value = False
+        vfs_mock.translatePath.return_value = "/db/"
+        # Lexicographic sort would wrongly pick MyVideos99.db.
+        glob_mock.return_value = [
+            "/db/MyVideos99.db",
+            "/db/MyVideos131.db",
+            "/db/MyVideos100.db",
+        ]
+        result = _locate_kodi_video_db()
+    assert result == "/db/MyVideos131.db"

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3201,6 +3201,7 @@ def test_direct_play_decodes_percent_escaped_userinfo_for_basic_auth(
 
     class Response:  # pylint: disable=too-few-public-methods
         status = 200
+        headers = {"Content-Length": "123456"}
 
         def __enter__(self):
             return self
@@ -3726,3 +3727,138 @@ def test_test_nzbget_smb_reports_reachable_when_exists_true():
     msg = str(notified["message"]).lower()
     assert notified["message"] == 30226 or "reachable" in msg
     assert "not reachable" not in msg
+
+
+# --- CodeRabbit PR #358 regression tests ---
+
+
+def test_provider_error_message_redacts_apikey_secrets():
+    """Provider exceptions routinely stringify the request URL (apikey and
+    all); router.py later logs/returns that text, so the message must pass
+    through redact_text before any secret can escape (router_search#115)."""
+    from resources.lib.router import _provider_error_message
+
+    leaky = Exception("HTTP 500 for http://hydra:5076/api?t=search&apikey=s3cr3t")
+    msg = _provider_error_message("NZBHydra2", leaky)
+
+    assert "s3cr3t" not in msg
+    assert "apikey=REDACTED" in msg
+    assert msg.startswith("NZBHydra2 search failed: ")
+
+
+def test_provider_error_message_redacts_embedded_userinfo_password():
+    """A scheme://user:pass@host URL embedded in the exception must have its
+    password half scrubbed before the error is surfaced."""
+    from resources.lib.router import _provider_error_message
+
+    leaky = Exception("connect failed http://user:hunter2@prowlarr:9696/api")
+    msg = _provider_error_message("Prowlarr", leaky)
+
+    assert "hunter2" not in msg
+
+
+@patch("resources.lib.router.xbmcplugin")
+@patch("resources.lib.router.xbmcgui")
+@patch("resources.lib.resolver._prepare_direct_playback")
+@patch("resources.lib.resolver._direct_playback_service_config")
+@patch("resources.lib.router.urlopen")
+def test_direct_play_rejects_primary_without_content_length(
+    mock_urlopen, mock_config, mock_prepare, _mock_gui, mock_xbmcplugin
+):
+    """A HEAD response lacking Content-Length is UNKNOWN size, not 1 byte; the
+    primary must fail rather than be handed to the proxy with a fabricated
+    length of 1 (router_directplay#111)."""
+    from resources.lib.router import _handle_direct_play
+
+    class Response:  # pylint: disable=too-few-public-methods
+        status = 200
+        headers = {}  # no Content-Length
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    mock_urlopen.return_value = Response()
+    mock_config.return_value = {"base_url": "http://127.0.0.1:45678", "token": "tok"}
+    mock_prepare.return_value = "http://127.0.0.1:45678/stream/prepared"
+
+    _handle_direct_play(
+        7,
+        {"primary_url": "http://example.test/movie.mkv", "fallback_urls": "[]"},
+    )
+
+    # Failure path: resolved with success=False, and the proxy/prepare step is
+    # never reached (no bogus length-1 stream handed off).
+    mock_prepare.assert_not_called()
+    assert mock_xbmcplugin.setResolvedUrl.call_args.args[1] is False
+
+
+@patch("resources.lib.router.xbmcplugin")
+@patch("resources.lib.router.xbmcgui")
+@patch("resources.lib.resolver._prepare_direct_playback")
+@patch("resources.lib.resolver._direct_playback_service_config")
+@patch("resources.lib.router.urlopen")
+def test_direct_play_rejects_primary_with_unparseable_content_length(
+    mock_urlopen, mock_config, mock_prepare, _mock_gui, mock_xbmcplugin
+):
+    """A non-integer Content-Length is treated as unknown (failure), never as
+    length 1."""
+    from resources.lib.router import _handle_direct_play
+
+    class Response:  # pylint: disable=too-few-public-methods
+        status = 200
+        headers = {"Content-Length": "not-a-number"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    mock_urlopen.return_value = Response()
+    mock_config.return_value = {"base_url": "http://127.0.0.1:45678", "token": "tok"}
+    mock_prepare.return_value = "http://127.0.0.1:45678/stream/prepared"
+
+    _handle_direct_play(
+        7,
+        {"primary_url": "http://example.test/movie.mkv", "fallback_urls": "[]"},
+    )
+
+    mock_prepare.assert_not_called()
+    assert mock_xbmcplugin.setResolvedUrl.call_args.args[1] is False
+
+
+def test_xml_root_name_parses_well_formed_rss():
+    """Baseline: the hardened parser still reports the root tag (router_conn)."""
+    from resources.lib.router import _xml_root_name
+
+    assert _xml_root_name("<rss version='2.0'><channel/></rss>") == "rss"
+    assert _xml_root_name("<error code='100'/>") == "error"
+    assert _xml_root_name("not xml at all") == ""
+
+
+def test_xml_root_name_does_not_resolve_external_entities():
+    """A hostile/compromised Hydra/Newznab response must not be able to coerce
+    an XXE local-file read; the entity must not expand into the parsed tree
+    (router_conn#73). Either the parser rejects the payload (-> "") or the
+    entity is left unexpanded, but the file contents must never leak."""
+    import tempfile
+
+    from resources.lib.router import _xml_root_name
+
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as handle:
+        handle.write("TOP-SECRET-XXE-CANARY")
+        secret_path = handle.name
+
+    payload = (
+        '<?xml version="1.0"?>'
+        "<!DOCTYPE rss [<!ENTITY xxe SYSTEM "
+        '"file://{}">]>'
+        "<rss>&xxe;</rss>"
+    ).format(secret_path)
+
+    # Must not raise, must not embed the file contents in any result.
+    result = _xml_root_name(payload)
+    assert result in ("rss", "")


### PR DESCRIPTION
## Summary

Independent, **behavior-fixing** sweep of pre-existing issues surfaced by CodeRabbit's
review of the decomposition PR (#358). Branched off `main`, so it stands alone and can
merge regardless of #358. Each functional fix is minimal and covered by a regression test.

This is a quality/correctness pass — separate from the structural decomposition in #358.

## Fixes

**Security / privacy — redact secrets before logging or returning**
- `resolver`: queue-probe exceptions, resume-path stream URLs, submit-error messages
- `nzbdav_api`: rejected-submit message (the *returned* value, not just the log)
- `prowlarr`: JSON error payloads (logged + returned)
- `router`: provider (Hydra/Prowlarr/indexer) exception strings
- `fallback_streams`: canonicalize percent-decoded WebDAV paths before the base-path
  allow-list check — encoded traversal (`/dav/%2e%2e/admin`) can no longer forward the
  Authorization header outside the base path
- `router`: XXE-hardened XML parsing of untrusted Newznab/Hydra responses (prefers
  `defusedxml`, already a repo dependency; else an entity-disabled stdlib parser)

**Stability / availability**
- `resolver`: fail soft when the fallback worker thread can't start; always reach
  `setResolvedUrl(handle, False)` even if the optional / exception-path dialog raises
- `nzbdav_api`: filter non-dict slot entries at the response boundary
- `hydra`: normalize a `null`/non-list `searchResults` to `[]` instead of crashing

**Functional correctness / data integrity**
- `resolver`: pick the Kodi video DB by **numeric** version (`MyVideos131` > `MyVideos99`,
  not lexicographic); thread the validated terminal `completed` timestamp into the
  synthesized by-name history row
- `router`: a HEAD response without `Content-Length` is treated as unknown, not length 1
- `filter`: validate the **full** `parse_title_metadata` contract (typed field groups)
  before reusing a cached `_meta`, so a partial dict is reparsed instead of silently
  dropping `quality`/`edition`/`year`/`upscaled`/`container` downstream
- `fallback_streams`: drop an always-true redundant comparison in `_titles_core_related`

**Documented (comment-only):** the intentional best-effort `except: pass` blocks in
`resolver`, `cache`, `resume_store`.

## Deliberately NOT changed (with rationale)
- **router augmented-pool**: CodeRabbit suggested materializing the single-use `chain()`,
  but the pool is intentionally **lazy** (regression-tested: consumes only until a known
  peer, `iterations == 2`) — materializing breaks that optimization. Left as-is.
- **fallback_streams out-of-order cap (#230)**: the count-based shortcut is load-bearing
  for the non-blocking "skip a slow gap" behavior its tests assert; a safe fix needs a
  settle-window redesign — deferred.
- **`_CompletedJobs.__eq__`**: instances are never value-compared; no unused dunder added.
- **Bandit SQLite-string / CodeQL clear-text-password**: defended false positives on the
  local Kodi DB / settings reads (repo scanning convention).

## Verification
- `just lint`: pylint **10.00/10**, ruff + black + vermin clean
- Unit suite: **2163 passed** (`-m "not integration and not functional and not extreme"`).
  The 2 `fallback_streams` `elapsed<0.18/0.22` failures are **pre-existing wall-clock
  timing flakes** — they fail identically at clean `origin/main` under machine load and
  pass on a free box / CI.
- Integration suite (real ffmpeg): **2 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)