### PR TITLE
ci: notify Appz4Fun Kodi repository on release (instant updates)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
             echo "REPO_DISPATCH_TOKEN not set; skipping (Kodi repo still rebuilds on its daily schedule)."
             exit 0
           fi
-          curl -sf -X POST \
+          curl -sS -f -X POST \
             -H "Authorization: Bearer $DISPATCH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/Appz4Fun/Appz4Fun-Kodi-Repo/dispatches \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,23 @@ jobs:
         with:
           files: plugin.video.nzbdav-${{ steps.version.outputs.version }}.zip
           generate_release_notes: true
+
+      # Ping the Appz4Fun Kodi repository so it rebuilds within seconds instead
+      # of waiting for its daily schedule. Needs a fine-grained PAT with
+      # Contents: read+write on Appz4Fun/Appz4Fun-Kodi-Repo, stored here as the
+      # secret REPO_DISPATCH_TOKEN. Best-effort: never fails the release.
+      - name: Notify Appz4Fun Kodi repository
+        continue-on-error: true
+        env:
+          DISPATCH_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$DISPATCH_TOKEN" ]; then
+            echo "REPO_DISPATCH_TOKEN not set; skipping (Kodi repo still rebuilds on its daily schedule)."
+            exit 0
+          fi
+          curl -sf -X POST \
+            -H "Authorization: Bearer $DISPATCH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/Appz4Fun/Appz4Fun-Kodi-Repo/dispatches \
+            -d '{"event_type":"addon-released"}' \
+            && echo "Triggered Appz4Fun-Kodi-Repo rebuild."


### PR DESCRIPTION
## Summary
Adds a best-effort step at the end of the **Release** workflow that fires a `repository_dispatch` (event type `addon-released`) to **Appz4Fun/Appz4Fun-Kodi-Repo**, so the Kodi add-on repository rebuilds within seconds of a release instead of waiting for its daily 04:17 UTC schedule.

## Required to activate (one-time)
A secret in **this** repo:
1. Create a **fine-grained PAT** with **Contents: read and write** scoped to `Appz4Fun/Appz4Fun-Kodi-Repo` only.
2. Add it here as repo secret **`REPO_DISPATCH_TOKEN`** (Settings → Secrets and variables → Actions).

Until that secret exists the step **skips cleanly** (logs, exits 0), and it's `continue-on-error`, so it can never fail a release. The Kodi repo also rebuilds daily regardless — this is purely a latency improvement.

## Safety
The token is read via `env:` (not interpolated into the shell) and the dispatch body is a static literal — no injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)