### PR TITLE
🎨 Palette: [UX improvement] Add explicit visual focus indicator to Kodi skin

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -157,6 +157,13 @@
           <colordiffuse>FF182538</colordiffuse>
         </control>
 
+        <!-- Focus Indicator -->
+        <control type="image">
+          <left>0</left><top>0</top><width>4</width><height>66</height>
+          <texture>white.png</texture>
+          <colordiffuse>FF4A9EFF</colordiffuse>
+        </control>
+
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->
         <control type="label">
           <left>6</left><top>4</top><width>32</width><height>30</height>


### PR DESCRIPTION
💡 **What:** Added a solid 4px vertical accent bar on the left edge of focused items in the `results-dialog.xml` skin file using the primary brand color (`FF4A9EFF`).
🎯 **Why:** To make the currently focused item unmistakably clear, which is critical for users navigating with a keyboard or remote control.
📸 **Before/After:** Before, the only indication of focus was a subtle background color shift. After, there is a clear, high-contrast visual focus indicator bar on the side.
♿ **Accessibility:** This ensures the interface meets standard accessibility guidelines for explicit visual focus feedback for non-mouse navigation paradigms.

---
*PR created automatically by Jules for task [16706707469223826077](https://jules.google.com/task/16706707469223826077) started by @xbmc4lyfe*