### PR TITLE
⚡ Bolt: [performance improvement] Optimize regex substitution and compilation

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -141,13 +141,12 @@ def redact_text(text):
     """
     if not text:
         return text
-    redacted = _EMBEDDED_CRED_RE.sub(
-        lambda m: "{}=REDACTED".format(m.group(1)), str(text)
-    )
+    redacted = _EMBEDDED_CRED_RE.sub(r"\1=REDACTED", str(text))
     return _EMBEDDED_URL_RE.sub(_redact_url_userinfo_span, redacted)
 
 
 _WHITESPACE_RE = re.compile(r"\s+")
+_FRACTIONAL_SECONDS_RE = re.compile(r"\.\d+")
 
 
 def clean_search_query(title):
@@ -365,7 +364,7 @@ def iso8601_to_rfc2822(value):
     # .NET (Prowlarr's stack) can emit up to 7 fractional-second digits,
     # which pre-3.11 ``datetime.fromisoformat`` rejects; sub-second
     # precision is irrelevant for identity/sort/age, so drop it.
-    text = re.sub(r"\.\d+", "", text)
+    text = _FRACTIONAL_SECONDS_RE.sub("", text)
     # ``fromisoformat`` only accepts a trailing 'Z' from Python 3.11 on;
     # map it to an explicit UTC offset for older Kodi runtimes (3.8–3.9).
     if text[-1:] in ("Z", "z"):


### PR DESCRIPTION
💡 What: Pre-compiles the `r"\.\d+"` pattern and removes the `lambda` function from the `re.sub` replacement in `http_util.py` (replacing it with the raw backreference string `r"\1=REDACTED"`).

🎯 Why: Avoids re-compiling the regex pattern on every invocation of `iso8601_to_rfc2822` and skips the C-to-Python boundary overhead inherent in using a Python lambda callback for simple `re.sub` string replacements.

📊 Impact: Reduces overhead on `redact_text` and `iso8601_to_rfc2822` functions during execution, yielding more optimal performance especially if heavily hit.

🔬 Measurement: The unit tests covering `test_http_util.py` run perfectly, validating that string formats are correctly identified and replaced with identical behavior. Linters pass as well.

---
*PR created automatically by Jules for task [1459761224684259877](https://jules.google.com/task/1459761224684259877) started by @xbmc4lyfe*