### PR TITLE
⚡ Bolt: [performance improvement] Pre-compile regex in resolver_playback

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,0 @@
-1. **Identify the optimization opportunity:** In `repo/plugin.video.nzbdav/resources/lib/resolver_playback.py`, the `_kodi_video_db_version` function compiles the regex `r"MyVideos(\d+)\.db$"` on every invocation using `re.search`.
-2. **Apply optimization:** Pre-compile the regular expression at the module level (e.g. `_MY_VIDEOS_DB_RE = re.compile(r"MyVideos(\d+)\.db$")`) and use `_MY_VIDEOS_DB_RE.search(...)` inside `_kodi_video_db_version`. This avoids recompiling the regex on every database file lookup.
-3. **Verify:** Run format, lint checks, and the test suite using `just`.
-4. **Document:** Ensure comments explain the performance optimization. Create `.jules/bolt.md` entry if this is a novel finding.
-5. **Pre-commit and PR:** Create the PR following Bolt's specific formatting requirements.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. **Identify the optimization opportunity:** In `repo/plugin.video.nzbdav/resources/lib/resolver_playback.py`, the `_kodi_video_db_version` function compiles the regex `r"MyVideos(\d+)\.db$"` on every invocation using `re.search`.
+2. **Apply optimization:** Pre-compile the regular expression at the module level (e.g. `_MY_VIDEOS_DB_RE = re.compile(r"MyVideos(\d+)\.db$")`) and use `_MY_VIDEOS_DB_RE.search(...)` inside `_kodi_video_db_version`. This avoids recompiling the regex on every database file lookup.
+3. **Verify:** Run format, lint checks, and the test suite using `just`.
+4. **Document:** Ensure comments explain the performance optimization. Create `.jules/bolt.md` entry if this is a novel finding.
+5. **Pre-commit and PR:** Create the PR following Bolt's specific formatting requirements.

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_playback.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_playback.py
@@ -13,7 +13,12 @@ top-level import cycle; same-module sibling helpers are called directly. Every
 moved name is re-exported from ``resolver``.
 """
 
+import re
+
 import resources.lib.resolver as _resolver  # noqa: F401  pylint: disable=unused-import
+
+# Pre-compile regex for performance
+_MY_VIDEOS_DB_RE = re.compile(r"MyVideos(\d+)\.db$")
 
 
 def _resolve_stage(message):
@@ -413,9 +418,8 @@ def _kodi_video_db_version(path):
     installs, which would target a stale DB for bookmark cleanup.
     """
     import os
-    import re
 
-    match = re.search(r"MyVideos(\d+)\.db$", os.path.basename(path))
+    match = _MY_VIDEOS_DB_RE.search(os.path.basename(path))
     return int(match.group(1)) if match else -1
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_playback.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_playback.py
@@ -479,7 +479,6 @@ def _add_own_plugin_target_ids(cur, target_ids):
 
 def _add_tmdb_helper_target_ids(cur, target_ids, params):
     """Add bookmark targets for matching TMDBHelper URLs."""
-    import re
     from urllib.parse import parse_qs, urlsplit
 
     tmdb_id = (params or {}).get("tmdb_id", "")


### PR DESCRIPTION
💡 **What:** Moved the compilation of the `MyVideos(\d+)\.db$` regular expression to the module level in `repo/plugin.video.nzbdav/resources/lib/resolver_playback.py` and modified `_kodi_video_db_version` to use the pre-compiled pattern.

🎯 **Why:** `_kodi_video_db_version` is used as a sort key predicate (`key=_kodi_video_db_version`) when iterating over the globbed database files. Calling `re.search()` on every invocation incurs the overhead of CPython's internal caching dictionary lookup. Pre-compiling it using `re.compile()` at the module level completely bypasses this lookup overhead.

📊 **Impact:** Reduces execution time for sorting database file paths, removing unnecessary boundary overhead for a frequently repeated operation.

🔬 **Measurement:** Verify by running the Python test suite (`pytest tests/ -m "not integration and not functional and not extreme"`) to ensure sorting functionality remains unbroken.

---
*PR created automatically by Jules for task [11292029255019518409](https://jules.google.com/task/11292029255019518409) started by @xbmc4lyfe*