### PR TITLE
refactor: fingerprint probe cfg adoption (Lizard A1)

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy.py
@@ -237,7 +237,8 @@ from resources.lib.stream_proxy_const import (  # noqa: F401,E402  pylint: disab
 # MRO. These imports sit after the module-level constants the mixins capture
 # in default arguments (e.g. _AUTH_HEADER_NOT_PROVIDED) so the partially
 # initialized module already exposes them when each mixin class body runs.
-from resources.lib.stream_proxy_handler_cutover import (  # noqa: E402
+from resources.lib.stream_proxy_handler_cutover import (  # noqa: E402,F401  pylint: disable=unused-import
+    FirstCandidateProbe,
     _FallbackCutoverMixin,
 )
 from resources.lib.stream_proxy_handler_dispatch import _DispatchMixin  # noqa: E402
@@ -254,7 +255,8 @@ from resources.lib.stream_proxy_handler_proxyserve import (  # noqa: E402
 from resources.lib.stream_proxy_handler_proxyserve2 import (  # noqa: E402
     _ProxyServeStallMixin,
 )
-from resources.lib.stream_proxy_handler_rangecache import (  # noqa: E402
+from resources.lib.stream_proxy_handler_rangecache import (  # noqa: E402,F401  pylint: disable=unused-import
+    FallbackRangeProbe,
     _RangeCacheMixin,
 )
 from resources.lib.stream_proxy_handler_rangeparse import (  # noqa: E402

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_cutover.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_cutover.py
@@ -11,7 +11,18 @@ reached at call time via ``_sp.<name>`` so test monkeypatches on
 ``_StreamHandler``; they keep using ``self`` for handler state and methods.
 """
 
+from typing import NamedTuple
+
 import resources.lib.stream_proxy as _sp  # noqa: E402
+
+
+class FirstCandidateProbe(NamedTuple):
+    """Pre-probed first-candidate results forwarded into fallback selection."""
+
+    stream_url: str = None
+    failed: bool = None
+    nzo_id: str = None
+    standby: dict = None
 
 
 class _FallbackCutoverMixin:  # pylint: disable=too-few-public-methods
@@ -190,10 +201,12 @@ class _FallbackCutoverMixin:  # pylint: disable=too-few-public-methods
             failed_byte,
             range_end,
             start_index=first_selectable_index,
-            first_stream_url=first_selectable_stream_url,
-            first_failed=False,
-            first_nzo_id=first_selectable_nzo_id,
-            first_standby=first_standby,
+            first=FirstCandidateProbe(
+                stream_url=first_selectable_stream_url,
+                failed=False,
+                nzo_id=first_selectable_nzo_id,
+                standby=first_standby,
+            ),
             expected_length=expected_length,
         )
         if source:
@@ -319,13 +332,17 @@ class _FallbackCutoverMixin:  # pylint: disable=too-few-public-methods
         failed_byte,
         range_end,
         start_index=0,
-        first_stream_url=None,
-        first_failed=None,
-        first_nzo_id=None,
-        first_standby=None,
+        first=None,
         expected_length=None,
     ):
-        """Return a validated already-resolved fallback source, if any."""
+        """Return a validated already-resolved fallback source, if any.
+
+        ``first`` is a :class:`FirstCandidateProbe` carrying the pre-probed
+        stream URL / failed flag / nzo_id / standby dict for the first
+        selectable candidate (all ``None`` when not supplied).
+        """
+        if first is None:
+            first = FirstCandidateProbe()
         sources = ctx.get("fallback_sources", [])
         start_index = max(0, start_index)
         if expected_length is None:
@@ -335,10 +352,10 @@ class _FallbackCutoverMixin:  # pylint: disable=too-few-public-methods
             "failed_byte": failed_byte,
             "range_end": range_end,
             "expected_length": expected_length,
-            "first_stream_url": first_stream_url,
-            "first_failed": first_failed,
-            "first_nzo_id": first_nzo_id,
-            "first_standby": first_standby,
+            "first_stream_url": first.stream_url,
+            "first_failed": first.failed,
+            "first_nzo_id": first.nzo_id,
+            "first_standby": first.standby,
         }
         state = {
             "primary_url": _sp._FALLBACK_SOURCE_STATE_NOT_PROVIDED,

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_fingerprint.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_fingerprint.py
@@ -27,41 +27,18 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
             cache[content_length] = tuple(fingerprint_ranges(content_length))
         return cache[content_length]
 
-    def _validate_fallback_fingerprint(
-        self,
-        ctx,
-        source,
-        content_length,
-        probe_bases,
-        current_range=None,
-        primary_url=None,
-        fallback_url=None,
-        fallback_auth=_sp._AUTH_HEADER_NOT_PROVIDED,
-        primary_auth=_sp._AUTH_HEADER_NOT_PROVIDED,
-        cache_fallback_range_bytes=False,
-    ):
+    def _validate_fallback_fingerprint(self, ctx, source, cfg):
         """Return True only when every sampled range provably matches.
 
         Bool wrapper over :meth:`_classify_fallback_fingerprint`. A
         transient INCONCLUSIVE probe is treated as a non-match here — the
         prevalidation caller only wants to mark a source ``validated`` when
         it is byte-proven, and a transient miss simply stays unvalidated to
-        be retried later.
+        be retried later. ``cfg`` is the bundled probe config from
+        :meth:`_fingerprint_probe_cfg`.
         """
         return (
-            self._classify_fallback_fingerprint(
-                ctx,
-                source,
-                content_length,
-                probe_bases,
-                current_range,
-                primary_url,
-                fallback_url,
-                fallback_auth,
-                primary_auth,
-                cache_fallback_range_bytes,
-            )
-            is _sp._FALLBACK_MATCH
+            self._classify_fallback_fingerprint(ctx, source, cfg) is _sp._FALLBACK_MATCH
         )
 
     def _resolve_fingerprint_identity(
@@ -76,62 +53,37 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
             fallback_auth = self._fallback_source_auth(source)
         return primary_auth, fallback_url, fallback_auth
 
-    def _classify_fallback_fingerprint(
-        self,
-        ctx,
-        source,
-        content_length,
-        probe_bases,
-        current_range=None,
-        primary_url=None,
-        fallback_url=None,
-        fallback_auth=_sp._AUTH_HEADER_NOT_PROVIDED,
-        primary_auth=_sp._AUTH_HEADER_NOT_PROVIDED,
-        cache_fallback_range_bytes=False,
-    ):
+    def _classify_fallback_fingerprint(self, ctx, source, cfg):
         """Classify sampled bytes as MATCH / MISMATCH / INCONCLUSIVE.
 
         A digest that is PRESENT on both sides and differs is a definitive
         MISMATCH (wrong file). A digest that cannot be fetched (empty body,
         probe 5xx / timeout) is INCONCLUSIVE — we can't prove same-or-
-        different yet, so the caller keeps the source eligible.
+        different yet, so the caller keeps the source eligible. ``cfg`` is
+        the bundled probe config from :meth:`_fingerprint_probe_cfg`.
         """
         primary_auth, fallback_url, fallback_auth = self._resolve_fingerprint_identity(
-            ctx, source, primary_auth, fallback_url, fallback_auth
+            ctx, source, cfg["primary_auth"], cfg["fallback_url"], cfg["fallback_auth"]
         )
-        ranges = tuple(self._fallback_fingerprint_ranges(ctx, content_length))
+        content_length = cfg["content_length"]
         cfg = self._fingerprint_probe_cfg(
             content_length,
-            probe_bases,
-            current_range,
-            primary_url,
+            cfg["probe_bases"],
+            cfg["current_range"],
+            cfg["primary_url"],
             fallback_url,
             fallback_auth,
             primary_auth,
-            cache_fallback_range_bytes,
+            cfg["cache_fallback_range_bytes"],
         )
+        ranges = tuple(self._fallback_fingerprint_ranges(ctx, content_length))
         if len(ranges) > 1 and _sp._FALLBACK_FINGERPRINT_WORKERS > 1:
-            return self._classify_parallel_from_cfg(ctx, ranges, cfg)
+            return self._classify_fallback_fingerprint_parallel(ctx, ranges, cfg)
         for start, end in ranges:
             verdict = self._classify_one_fingerprint_range(start, end, ctx, cfg)
             if verdict != _sp._FALLBACK_MATCH:
                 return verdict
         return _sp._FALLBACK_MATCH
-
-    def _classify_parallel_from_cfg(self, ctx, ranges, cfg):
-        """Dispatch to the parallel classifier, unpacking the shared cfg dict."""
-        return self._classify_fallback_fingerprint_parallel(
-            ctx,
-            ranges,
-            cfg["content_length"],
-            cfg["probe_bases"],
-            cfg["current_range"],
-            cfg["primary_url"],
-            cfg["fallback_url"],
-            cfg["fallback_auth"],
-            cfg["primary_auth"],
-            cfg["cache_fallback_range_bytes"],
-        )
 
     @staticmethod
     def _fingerprint_probe_cfg(
@@ -163,14 +115,7 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
         current-range short circuit, byte-caching flag).
         """
         fallback_digest = self._fetch_fallback_fingerprint_digest(
-            (start, end),
-            cfg["content_length"],
-            cfg["probe_bases"],
-            cfg["current_range"],
-            cfg["fallback_url"],
-            cfg["fallback_auth"],
-            cache_ctx=ctx,
-            cache_range_bytes=cfg["cache_fallback_range_bytes"],
+            (start, end), cfg, cache_ctx=ctx
         )
         if not fallback_digest:
             return _sp._FALLBACK_INCONCLUSIVE
@@ -189,18 +134,17 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
             return _sp._FALLBACK_MISMATCH
         return _sp._FALLBACK_MATCH
 
-    def _fetch_fallback_fingerprint_digest(
-        self,
-        byte_range,
-        content_length,
-        probe_bases,
-        current_range,
-        fallback_url,
-        fallback_auth,
-        cache_ctx=None,
-        cache_range_bytes=False,
-    ):
-        """Return the fallback digest for one sampled byte range."""
+    def _fetch_fallback_fingerprint_digest(self, byte_range, cfg, cache_ctx):
+        """Return the fallback digest for one sampled byte range.
+
+        ``cfg`` is the bundled probe config from :meth:`_fingerprint_probe_cfg`.
+        """
+        content_length = cfg["content_length"]
+        probe_bases = cfg["probe_bases"]
+        current_range = cfg["current_range"]
+        fallback_url = cfg["fallback_url"]
+        fallback_auth = cfg["fallback_auth"]
+        cache_range_bytes = cfg["cache_fallback_range_bytes"]
         start, end = byte_range
         if current_range and current_range[:2] == (start, end):
             return current_range[2]
@@ -233,42 +177,27 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
         )
 
     def _primary_fingerprint_range_matches(
-        self,
-        ctx,
-        start,
-        end,
-        fallback_digest,
-        content_length,
-        probe_bases,
-        primary_url,
-        primary_auth,
-        cache_lock,
+        self, ctx, start, end, fallback_digest, cfg, cache_lock
     ):
-        """Return whether one sampled primary range matches fallback."""
+        """Return whether one sampled primary range matches fallback.
+
+        ``cfg`` is the bundled probe config from :meth:`_fingerprint_probe_cfg`.
+        """
         primary_digest = self._fetch_primary_fallback_range_digest_threadsafe(
-            ctx,
-            primary_auth,
-            start,
-            end,
-            content_length,
-            probe_bases,
-            primary_url,
-            cache_lock,
+            ctx, cfg["primary_auth"], start, end, cfg, cache_lock
         )
         return bool(primary_digest and primary_digest == fallback_digest)
 
     def _fetch_primary_fallback_range_digest_threadsafe(
-        self,
-        ctx,
-        auth_header,
-        start,
-        end,
-        content_length,
-        probe_bases,
-        primary_url,
-        cache_lock,
+        self, ctx, auth_header, start, end, cfg, cache_lock
     ):
-        """Return a primary digest while preserving the shared selection cache."""
+        """Return a primary digest while preserving the shared selection cache.
+
+        ``cfg`` is the bundled probe config from :meth:`_fingerprint_probe_cfg`.
+        """
+        content_length = cfg["content_length"]
+        probe_bases = cfg["probe_bases"]
+        primary_url = cfg["primary_url"]
         if cache_lock is None:
             return self._fetch_primary_fallback_range_digest(
                 ctx, auth_header, start, end, content_length, probe_bases, primary_url
@@ -325,53 +254,22 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
         except TypeError:
             executor.shutdown(wait=False)
 
-    def _validate_fallback_fingerprint_parallel(
-        self,
-        ctx,
-        ranges,
-        content_length,
-        probe_bases,
-        current_range,
-        primary_url,
-        fallback_url,
-        fallback_auth,
-        primary_auth,
-        cache_fallback_range_bytes=False,
-    ):
+    def _validate_fallback_fingerprint_parallel(self, ctx, ranges, cfg):
         """Return True only when every parallel-probed range provably matches.
 
         Bool wrapper over :meth:`_classify_fallback_fingerprint_parallel`.
+        ``cfg`` is the bundled probe config from :meth:`_fingerprint_probe_cfg`.
         """
         return (
-            self._classify_fallback_fingerprint_parallel(
-                ctx,
-                ranges,
-                content_length,
-                probe_bases,
-                current_range,
-                primary_url,
-                fallback_url,
-                fallback_auth,
-                primary_auth,
-                cache_fallback_range_bytes,
-            )
+            self._classify_fallback_fingerprint_parallel(ctx, ranges, cfg)
             is _sp._FALLBACK_MATCH
         )
 
-    def _classify_fallback_fingerprint_parallel(
-        self,
-        ctx,
-        ranges,
-        content_length,
-        probe_bases,
-        current_range,
-        primary_url,
-        fallback_url,
-        fallback_auth,
-        primary_auth,
-        cache_fallback_range_bytes=False,
-    ):
-        """Classify fingerprint ranges with bounded parallel range probes."""
+    def _classify_fallback_fingerprint_parallel(self, ctx, ranges, cfg):
+        """Classify fingerprint ranges with bounded parallel range probes.
+
+        ``cfg`` is the bundled probe config from :meth:`_fingerprint_probe_cfg`.
+        """
         workers = min(_sp._FALLBACK_FINGERPRINT_WORKERS, len(ranges))
         fallback_digests = {}
         # Shared lock for the primary-digest cache: parallel workers
@@ -384,17 +282,6 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
         # A single mismatched range otherwise pays full latency for all
         # in-flight probes.
         executor = _sp.ThreadPoolExecutor(max_workers=workers)
-
-        cfg = self._fingerprint_probe_cfg(
-            content_length,
-            probe_bases,
-            current_range,
-            primary_url,
-            fallback_url,
-            fallback_auth,
-            primary_auth,
-            cache_fallback_range_bytes,
-        )
         return self._run_parallel_fingerprint_probes(
             ctx, ranges, cfg, executor, cache_lock, fallback_digests
         )
@@ -439,13 +326,8 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
             future = executor.submit(
                 self._fetch_fallback_fingerprint_digest,
                 (start, end),
-                cfg["content_length"],
-                cfg["probe_bases"],
-                current_range,
-                cfg["fallback_url"],
-                cfg["fallback_auth"],
+                cfg,
                 cache_ctx=ctx,
-                cache_range_bytes=cfg["cache_fallback_range_bytes"],
             )
             fallback_futures[future] = (start, end)
 
@@ -461,9 +343,7 @@ class _FingerprintMixin:  # pylint: disable=too-few-public-methods
                     cfg["primary_auth"],
                     start,
                     end,
-                    cfg["content_length"],
-                    cfg["probe_bases"],
-                    cfg["primary_url"],
+                    cfg,
                     cache_lock,
                 )
             ] = (start, end)

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_probe.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_probe.py
@@ -61,10 +61,9 @@ class _FallbackProbeMixin:  # pylint: disable=too-few-public-methods
             # downloaded THIS offset yet), not a wrong-file mismatch.
             if self._probe_fallback_current_range(
                 source,
-                failed_byte,
-                range_end,
-                expected_length,
-                probe_bases,
+                _sp.FallbackRangeProbe(
+                    failed_byte, range_end, expected_length, probe_bases
+                ),
                 auth_header=source_auth,
                 stream_url=source_url,
                 cache_ctx=ctx,
@@ -104,17 +103,17 @@ class _FallbackProbeMixin:  # pylint: disable=too-few-public-methods
             # Range not yet available on the peer (still downloading) or a
             # probe hiccup — transient, do not condemn the source.
             return _sp._FALLBACK_INCONCLUSIVE
-        classification = self._classify_fallback_fingerprint(
-            ctx,
-            source,
+        cfg = self._fingerprint_probe_cfg(
             expected_length,
             probe_bases,
             current_range,
             primary_url,
-            fallback_url=source_url,
-            fallback_auth=source_auth,
-            primary_auth=primary_auth,
+            source_url,
+            source_auth,
+            primary_auth,
+            False,
         )
+        classification = self._classify_fallback_fingerprint(ctx, source, cfg)
         if classification is _sp._FALLBACK_INCONCLUSIVE:
             # A probe couldn't be completed (5xx / timeout / empty body) so
             # we can't PROVE same-or-different yet. Stay eligible.
@@ -144,10 +143,9 @@ class _FallbackProbeMixin:  # pylint: disable=too-few-public-methods
         source_url, source_auth = identity[0], identity[1]
         current_digest = self._fetch_fallback_current_range_digest(
             source,
-            failed_byte,
-            range_end,
-            expected_length,
-            probe_bases,
+            _sp.FallbackRangeProbe(
+                failed_byte, range_end, expected_length, probe_bases
+            ),
             auth_header=source_auth,
             stream_url=source_url,
             cache_ctx=ctx,
@@ -254,17 +252,17 @@ class _FallbackProbeMixin:  # pylint: disable=too-few-public-methods
         ctx[auth_hint_key] = (id(source), identity["source_auth"])
         ctx[primary_auth_hint_key] = identity["primary_auth"]
         try:
-            if self._validate_fallback_fingerprint(
-                ctx,
-                source,
+            cfg = self._fingerprint_probe_cfg(
                 expected_length,
                 probe_bases,
-                primary_url=identity["primary_url"],
-                fallback_url=identity["source_url"],
-                fallback_auth=identity["source_auth"],
-                primary_auth=identity["primary_auth"],
-                cache_fallback_range_bytes=True,
-            ):
+                None,
+                identity["primary_url"],
+                identity["source_url"],
+                identity["source_auth"],
+                identity["primary_auth"],
+                True,
+            )
+            if self._validate_fallback_fingerprint(ctx, source, cfg):
                 source["validated"] = True
                 # Prevalidation succeeded after earlier INCONCLUSIVE probes
                 # (still-downloading at first contact): clear any transient

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_rangecache.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_rangecache.py
@@ -11,7 +11,18 @@ reached at call time via ``_sp.<name>`` so test monkeypatches on
 ``_StreamHandler``; they keep using ``self`` for handler state and methods.
 """
 
+from typing import NamedTuple
+
 import resources.lib.stream_proxy as _sp  # noqa: E402
+
+
+class FallbackRangeProbe(NamedTuple):
+    """Byte-span + sizing values threaded through fallback range probes."""
+
+    failed_byte: int
+    range_end: int
+    content_length: int
+    probe_bases: tuple = None
 
 
 class _RangeCacheMixin:  # pylint: disable=too-few-public-methods
@@ -52,22 +63,20 @@ class _RangeCacheMixin:  # pylint: disable=too-few-public-methods
     def _probe_fallback_current_range(
         self,
         source,
-        failed_byte,
-        range_end,
-        content_length,
-        probe_bases=None,
+        probe,
         auth_header=_sp._AUTH_HEADER_NOT_PROVIDED,
         stream_url=None,
         cache_ctx=None,
     ):
-        """Verify fallback can serve bytes at the failing offset."""
+        """Verify fallback can serve bytes at the failing offset.
+
+        ``probe`` is a :class:`FallbackRangeProbe` carrying the byte span and
+        sizing values for the current-range check.
+        """
         return bool(
             self._fetch_fallback_current_range_digest(
                 source,
-                failed_byte,
-                range_end,
-                content_length,
-                probe_bases,
+                probe,
                 auth_header=auth_header,
                 stream_url=stream_url,
                 cache_ctx=cache_ctx,
@@ -77,15 +86,20 @@ class _RangeCacheMixin:  # pylint: disable=too-few-public-methods
     def _fetch_fallback_current_range_digest(
         self,
         source,
-        failed_byte,
-        range_end,
-        content_length,
-        probe_bases=None,
+        probe,
         auth_header=_sp._AUTH_HEADER_NOT_PROVIDED,
         stream_url=None,
         cache_ctx=None,
     ):
-        """Return the digest proving fallback can serve bytes at the failing offset."""
+        """Return the digest proving fallback can serve bytes at the failing offset.
+
+        ``probe`` is a :class:`FallbackRangeProbe` carrying the byte span and
+        sizing values for the current-range check.
+        """
+        failed_byte = probe.failed_byte
+        range_end = probe.range_end
+        content_length = probe.content_length
+        probe_bases = probe.probe_bases
         probe_end = min(range_end, failed_byte + 4095)
         if auth_header is _sp._AUTH_HEADER_NOT_PROVIDED:
             auth_header = self._fallback_source_auth(source)

--- a/scripts/lizard_scope_report.py
+++ b/scripts/lizard_scope_report.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Summarize a codacy-cli Lizard SARIF file by repo scope and rule.
+
+SARIF artifactLocation URIs from codacy-cli's lizard runner contain only
+basenames, so paths are recovered via `git ls-files '*.py'`. Ambiguous
+basenames are reported under AMBIG:<basename> rather than guessed.
+"""
+
+import json
+import subprocess
+import sys
+from collections import Counter, defaultdict
+
+RULES = ("ccn", "nloc", "parameter-count", "file-nloc")
+
+
+def classify_scope(path):
+    if "/ptt/" in path:
+        return "vendored-ptt"
+    if path.startswith("tests/"):
+        return "tests"
+    if path.startswith("tests-extensive/"):
+        return "tests-extensive"
+    if path.startswith("scripts/"):
+        return "scripts"
+    if "resources/lib" in path:
+        return "shipped-lib"
+    return "other"
+
+
+def _basename_map():
+    files = subprocess.check_output(["git", "ls-files", "*.py"], text=True).split()
+    bymap = defaultdict(list)
+    for f in files:
+        bymap[f.rsplit("/", 1)[-1]].append(f)
+    return bymap
+
+
+def summarize(sarif_path):
+    with open(sarif_path) as fh:
+        doc = json.load(fh)
+    bymap = _basename_map()
+    counts = Counter()
+    for run in doc.get("runs", []):
+        for result in run.get("results", []):
+            uri = result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+            rule = (
+                result.get("ruleId", "").replace("Lizard_", "").replace("-medium", "")
+            )
+            candidates = bymap.get(uri, [uri])
+            if len(candidates) > 1:
+                scope = "AMBIG:" + uri
+            else:
+                scope = classify_scope(candidates[0])
+            counts[(scope, rule)] += 1
+    return counts
+
+
+def main(argv):
+    if len(argv) != 2:
+        print("usage: lizard_scope_report.py <lizard.sarif>", file=sys.stderr)
+        return 2
+    counts = summarize(argv[1])
+    scopes = sorted({scope for scope, _ in counts})
+    header = (
+        "{:<28}".format("scope")
+        + "".join("{:>16}".format(rule) for rule in RULES)
+        + "{:>8}".format("TOTAL")
+    )
+    print(header)
+    for scope in scopes:
+        total = sum(counts[(scope, rule)] for rule in RULES)
+        print(
+            "{:<28}".format(scope)
+            + "".join("{:>16}".format(counts[(scope, rule)]) for rule in RULES)
+            + "{:>8}".format(total)
+        )
+    print("{:<28}{:>8}".format("ALL", sum(counts.values())))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_lizard_scope_report.py
+++ b/tests/test_lizard_scope_report.py
@@ -1,0 +1,32 @@
+"""Tests for scripts/lizard_scope_report.py scope classification."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from lizard_scope_report import classify_scope  # noqa: E402
+
+
+def test_classify_shipped_lib():
+    assert (
+        classify_scope("repo/plugin.video.nzbdav/resources/lib/router.py")
+        == "shipped-lib"
+    )
+
+
+def test_classify_vendored_ptt_wins_over_lib():
+    assert (
+        classify_scope("repo/plugin.video.nzbdav/resources/lib/ptt/handlers.py")
+        == "vendored-ptt"
+    )
+
+
+def test_classify_tests_and_extensive():
+    assert classify_scope("tests/test_router.py") == "tests"
+    assert classify_scope("tests-extensive/test_live_services.py") == "tests-extensive"
+
+
+def test_classify_scripts_and_other():
+    assert classify_scope("scripts/generate_repo.py") == "scripts"
+    assert classify_scope("setup_something.py") == "other"

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -139,13 +139,16 @@ def test_parallel_fallback_fingerprint_shutdown_works_on_python38_executor():
         assert handler._validate_fallback_fingerprint_parallel(
             ctx,
             ranges,
-            content_length=8,
-            probe_bases=(),
-            current_range=None,
-            primary_url="http://primary/video.mkv",
-            fallback_url="http://fallback/video.mkv",
-            fallback_auth=None,
-            primary_auth=None,
+            handler._fingerprint_probe_cfg(
+                content_length=8,
+                probe_bases=(),
+                current_range=None,
+                primary_url="http://primary/video.mkv",
+                fallback_url="http://fallback/video.mkv",
+                fallback_auth=None,
+                primary_auth=None,
+                cache_fallback_range_bytes=False,
+            ),
         )
 
     assert created


### PR DESCRIPTION
Finishes the \`_fingerprint_probe_cfg\` adoption so the fingerprint, rangecache, and cutover fallback helpers take one bundled config instead of 9–11 positional params. Behavior-preserving refactor — part 1 of the complexity-reduction campaign (spec: Codacy complexity reduction, Phase A cluster A1).

## What changed
- \`stream_proxy_handler_fingerprint.py\`: 7 helpers now take \`(self, ctx, source|ranges, cfg)\`; removed the redundant \`_classify_parallel_from_cfg\` shim.
- \`stream_proxy_handler_rangecache.py\`: new \`FallbackRangeProbe\` NamedTuple bundles \`(failed_byte, range_end, content_length, probe_bases)\`.
- \`stream_proxy_handler_cutover.py\`: new \`FirstCandidateProbe\` bundles the pre-probed first-candidate results.
- \`scripts/lizard_scope_report.py\` (+test): measurement harness used by this campaign.

## Complexity delta (codacy-cli lizard)
- shipped-lib parameter-count findings: **17 → 7** (shipped-lib total 29 → 19; repo-wide 207 → 197)

## Safety
- No change to which values participate in fallback fingerprint identity, probe ordering, or cache keying (fable contract review passed; \`cache_lock\` placement untouched).
- \`just lint\` clean, \`just test\` 2238 passed / 2 skipped. No test assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)