### PR TITLE
refactor: resolver PollContext + long-function splits (Lizard A2)

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -299,6 +299,10 @@ from resources.lib.resolver_completed import (  # noqa: E402,F401
     _submit_error_with_indexer,
 )
 from resources.lib.resolver_entry import (  # noqa: E402,F401
+    _resolve_acquire_stream,
+    _resolve_and_play_acquire_stream,
+    _resolve_and_play_make_effects,
+    _ResolveSideEffects,
     resolve,
     resolve_and_play,
 )
@@ -425,6 +429,7 @@ from resources.lib.resolver_poll import (  # noqa: E402,F401
     _wait_for_nearly_complete_history,
 )
 from resources.lib.resolver_pollloop import (  # noqa: E402,F401
+    PollContext,
     _cancel_job_on_shutdown,
     _job_status_is_dead,
     _mark_dead_on_failed_history,
@@ -432,6 +437,7 @@ from resources.lib.resolver_pollloop import (  # noqa: E402,F401
     _notify_primary_submitted,
     _poll_until_ready,
     _record_download_soft,
+    _submit_and_announce,
     _wait_between_polls,
 )
 from resources.lib.resolver_prepare import (  # noqa: E402,F401
@@ -488,6 +494,7 @@ from resources.lib.resolver_submit import (  # noqa: E402,F401
     _report_all_submit_attempts_failed,
     _safe_probe_by_name,
     _start_probe_thread_or_run,
+    _start_submit_worker,
     _submit_nzb_with_retries,
     _submit_nzb_with_ui_pump,
     _submit_probe_interval,

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_entry.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_entry.py
@@ -16,6 +16,144 @@ moved name is re-exported from ``resolver``.
 import resources.lib.resolver as _resolver  # noqa: F401  pylint: disable=unused-import
 
 
+class _ResolveSideEffects:
+    """Once-only playback-cleanup and fallback-worker starters shared by
+    both resolve entry paths. Replaces per-function nonlocal closures."""
+
+    def __init__(
+        self,
+        params,
+        fallback_candidates,
+        candidate_loader,
+        nzb_url,
+        dead,
+        settings_getter=None,
+    ):
+        self._params = params
+        self._candidates = fallback_candidates
+        self._loader = candidate_loader
+        self._nzb_url = nzb_url
+        self._dead = dead
+        self._settings_getter = settings_getter
+        self.cleanup_state = None
+        self.fallback_state = None
+
+    def start_cleanup_once(self):
+        if self.cleanup_state is None:
+            self.cleanup_state = _resolver._start_playback_state_cleanup(self._params)
+
+    def poll_context(self, selected_indexer, rejected_completed_ids):
+        """Bundle the once-only hooks + per-attempt hints into a PollContext."""
+        return _resolver.PollContext(
+            on_primary_submitted=self.start_fallback_after_primary,
+            on_existing_completed=self.start_cleanup_once,
+            settings_getter=self._settings_getter,
+            selected_indexer=selected_indexer,
+            rejected_completed_ids=rejected_completed_ids,
+            dead=self._dead,
+        )
+
+    def start_fallback_after_primary(self, _nzo_id):
+        self.start_cleanup_once()
+        if self.fallback_state is None:
+            kwargs = {
+                "candidate_loader": self._loader,
+                "prewarm_delay": _resolver._get_fallback_submit_delay_seconds(
+                    self._settings_getter
+                ),
+                "wait_for_playback": True,
+                "dead": self._dead,
+                "primary_nzb_url": self._nzb_url,
+            }
+            kwargs.update(_resolver._settings_getter_kwargs(self._settings_getter))
+            self.fallback_state = _resolver._start_fallback_submit_worker(
+                self._candidates, **kwargs
+            )
+        return self.fallback_state
+
+
+def _resolve_acquire_stream(nzb_url, title, params, rejected_completed_ids, effects):
+    """Acquire the stream for the handle-based ``resolve`` path.
+
+    Returns ``(stream_url, stream_headers, dialog)``: the completed fast-path
+    (``dialog`` is ``None``) or the submit+poll result. Extracted verbatim from
+    ``resolve``."""
+    selected_indexer = params.get("_selected_indexer", "")
+    picker_completed_lookup_done = _resolver._picker_completed_lookup_done(params)
+    completed_stream = _resolver._picker_completed_stream(
+        title,
+        params,
+        on_existing_completed=effects.start_cleanup_once,
+        rejected_completed_ids=rejected_completed_ids,
+    )
+    if completed_stream is not None:
+        stream_url, stream_headers = completed_stream
+        return stream_url, stream_headers, None
+    return _resolver._resolve_submit_and_poll(
+        nzb_url,
+        title,
+        params,
+        picker_completed_lookup_done,
+        effects.poll_context(selected_indexer, rejected_completed_ids),
+    )
+
+
+def _resolve_and_play_make_effects(params, resolve_params, nzb_url, settings_getter):
+    """Build the ``_ResolveSideEffects`` for the handle-less path.
+
+    Prefetches the fallback candidate loader and emits the deferred-lookup
+    resolve stages verbatim. Extracted from ``resolve_and_play``."""
+    fallback_candidates = resolve_params.get("_fallback_candidates", [])
+    fallback_candidate_loader = _resolver._prefetch_fallback_candidate_loader(
+        resolve_params.get("_fallback_candidate_loader")
+    )
+    _resolver._resolve_stage("fallback lookup deferred")
+    _resolver._resolve_stage("service config lookup deferred")
+    return _ResolveSideEffects(
+        params,
+        fallback_candidates,
+        fallback_candidate_loader,
+        nzb_url,
+        _resolver.DeadCandidates(),
+        settings_getter=settings_getter,
+    )
+
+
+def _resolve_and_play_acquire_stream(
+    nzb_url, title, resolve_params, settings_getter, effects
+):
+    """Acquire the stream for the handle-less ``resolve_and_play`` path.
+
+    Returns ``(stream_url, stream_headers, dialog)``: the completed fast-path
+    (``dialog`` is ``None``) or the submit+poll result, with the resolve-stage
+    logging woven in verbatim. Extracted verbatim from ``resolve_and_play``."""
+    selected_indexer = resolve_params.get("_selected_indexer", "")
+    picker_completed_lookup_done = _resolver._picker_completed_lookup_done(
+        resolve_params
+    )
+    # One rejected-id set per resolve attempt, shared so a Completed row the
+    # picker body probe rejects is honored by the submit/poll paths.
+    rejected_completed_ids = set()
+    completed_stream = _resolver._picker_completed_stream(
+        title,
+        resolve_params,
+        on_existing_completed=effects.start_cleanup_once,
+        settings_getter=settings_getter,
+        rejected_completed_ids=rejected_completed_ids,
+    )
+    _resolver._resolve_stage("picker completed stream checked")
+    if completed_stream is not None:
+        stream_url, stream_headers = completed_stream
+        return stream_url, stream_headers, None
+    return _resolver._resolve_and_play_submit_and_poll(
+        nzb_url,
+        title,
+        resolve_params,
+        picker_completed_lookup_done,
+        effects.poll_context(selected_indexer, rejected_completed_ids),
+    )
+
+
 def resolve(handle, params):
     """Handle plugin:// URL resolution (TMDBHelper integration).
 
@@ -33,8 +171,7 @@ def resolve(handle, params):
     """
     nzb_url = _resolver.unquote(params.get("nzburl", ""))
     title = _resolver.unquote(params.get("title", ""))
-    fallback_state = None
-    playback_cleanup_state = None
+    effects = None
 
     if not nzb_url:
         _resolver._reject_resolve_handle(
@@ -53,67 +190,33 @@ def resolve(handle, params):
     dialog = None
     try:
         fallback_candidates = params.get("_fallback_candidates", [])
-        selected_indexer = params.get("_selected_indexer", "")
         fallback_candidate_loader = _resolver._prefetch_fallback_candidate_loader(
             params.get("_fallback_candidate_loader")
         )
-        picker_completed_lookup_done = _resolver._picker_completed_lookup_done(params)
-
-        def _start_playback_cleanup_once():
-            nonlocal playback_cleanup_state
-            # nosemgrep
-            if playback_cleanup_state is None:
-                playback_cleanup_state = _resolver._start_playback_state_cleanup(params)
-
-        def _start_fallback_after_primary(_nzo_id):
-            nonlocal fallback_state
-            _start_playback_cleanup_once()
-            # nosemgrep
-            if fallback_state is None:
-                fallback_state = _resolver._start_fallback_submit_worker(
-                    fallback_candidates,
-                    candidate_loader=fallback_candidate_loader,
-                    prewarm_delay=_resolver._get_fallback_submit_delay_seconds(),
-                    wait_for_playback=True,
-                    dead=dead,
-                    primary_nzb_url=nzb_url,
-                )
-            return fallback_state
-
         # One rejected-id set per resolve attempt, shared so a Completed row
         # the picker body probe rejects is honored by the submit/poll paths.
         rejected_completed_ids = set()
         dead = _resolver.DeadCandidates()
-        completed_stream = _resolver._picker_completed_stream(
-            title,
-            params,
-            on_existing_completed=_start_playback_cleanup_once,
-            rejected_completed_ids=rejected_completed_ids,
+        effects = _ResolveSideEffects(
+            params, fallback_candidates, fallback_candidate_loader, nzb_url, dead
         )
-        if completed_stream is not None:
-            stream_url, stream_headers = completed_stream
-        else:
-            stream_url, stream_headers, dialog = _resolver._resolve_submit_and_poll(
-                nzb_url,
-                title,
-                params,
-                picker_completed_lookup_done,
-                selected_indexer,
-                rejected_completed_ids,
-                dead,
-                (_start_fallback_after_primary, _start_playback_cleanup_once),
-            )
+        stream_url, stream_headers, dialog = _resolve_acquire_stream(
+            nzb_url, title, params, rejected_completed_ids, effects
+        )
         dialog = _resolver._resolve_finish_or_reject(
             handle,
             params,
             (stream_url, stream_headers, dead),
-            (fallback_state, _start_fallback_after_primary),
-            playback_cleanup_state,
+            (effects.fallback_state, effects.start_fallback_after_primary),
+            effects.cleanup_state,
             dialog,
         )
     except _resolver._RESOLVE_RUNTIME_ERRORS as error:
         _resolver._resolve_stage("resolve_exception {}".format(error))
-        _resolver._stop_fallback_submit_worker(fallback_state, cancel_submitted=True)
+        _resolver._stop_fallback_submit_worker(
+            effects.fallback_state if effects is not None else None,
+            cancel_submitted=True,
+        )
         _resolver._handle_resolve_exception("resolve", error, handle=handle)
     finally:
         if dialog is not None:
@@ -139,8 +242,7 @@ def resolve_and_play(nzb_url, title, params=None):
     on the RunPlugin path. Same fix as `resolve()` — TODO.md §H.2-H9.
     """
     dialog = None
-    fallback_state = None
-    playback_cleanup_state = None
+    effects = None
     try:
         _resolver._resolve_stage("enter resolve_and_play")
         # NZBGet backend toggle (handle-less path). resolve_and_play has no
@@ -155,87 +257,25 @@ def resolve_and_play(nzb_url, title, params=None):
                 nzb_url, title, params, resolve_params
             )
             return
-        selected_indexer = resolve_params.get("_selected_indexer", "")
-        fallback_candidates = resolve_params.get("_fallback_candidates", [])
-        fallback_candidate_loader = _resolver._prefetch_fallback_candidate_loader(
-            resolve_params.get("_fallback_candidate_loader")
+        effects = _resolve_and_play_make_effects(
+            params, resolve_params, nzb_url, settings_getter
         )
-        _resolver._resolve_stage("fallback lookup deferred")
-        _resolver._resolve_stage("service config lookup deferred")
-        picker_completed_lookup_done = _resolver._picker_completed_lookup_done(
-            resolve_params
+        stream_url, stream_headers, dialog = _resolve_and_play_acquire_stream(
+            nzb_url, title, resolve_params, settings_getter, effects
         )
-
-        def _start_playback_cleanup_once():
-            nonlocal playback_cleanup_state
-            # nosemgrep
-            if playback_cleanup_state is None:
-                playback_cleanup_state = _resolver._start_playback_state_cleanup(params)
-
-        def _start_fallback_after_primary(_nzo_id):
-            nonlocal fallback_state
-            _start_playback_cleanup_once()
-            # nosemgrep
-            if fallback_state is None:
-                fallback_submit_kwargs = {
-                    "candidate_loader": fallback_candidate_loader,
-                    "prewarm_delay": _resolver._get_fallback_submit_delay_seconds(
-                        settings_getter
-                    ),
-                    "wait_for_playback": True,
-                    "dead": dead,
-                    "primary_nzb_url": nzb_url,
-                }
-                fallback_submit_kwargs.update(
-                    _resolver._settings_getter_kwargs(settings_getter)
-                )
-                fallback_state = _resolver._start_fallback_submit_worker(
-                    fallback_candidates,
-                    **fallback_submit_kwargs,
-                )
-            return fallback_state
-
-        # One rejected-id set per resolve attempt, shared so a Completed row
-        # the picker body probe rejects is honored by the submit/poll paths.
-        rejected_completed_ids = set()
-        dead = _resolver.DeadCandidates()
-        completed_stream = _resolver._picker_completed_stream(
-            title,
-            resolve_params,
-            on_existing_completed=_start_playback_cleanup_once,
-            settings_getter=settings_getter,
-            rejected_completed_ids=rejected_completed_ids,
-        )
-        _resolver._resolve_stage("picker completed stream checked")
-        if completed_stream is not None:
-            stream_url, stream_headers = completed_stream
-        else:
-            stream_url, stream_headers, dialog = (
-                _resolver._resolve_and_play_submit_and_poll(
-                    nzb_url,
-                    title,
-                    resolve_params,
-                    picker_completed_lookup_done,
-                    selected_indexer,
-                    rejected_completed_ids,
-                    dead,
-                    (
-                        _start_fallback_after_primary,
-                        _start_playback_cleanup_once,
-                        settings_getter,
-                    ),
-                )
-            )
         dialog = _resolver._resolve_and_play_finish_or_stop(
             _resolver._resume_params_with_title(resolve_params, title),
-            (stream_url, stream_headers, dead),
-            (fallback_state, _start_fallback_after_primary),
+            (stream_url, stream_headers, effects._dead),
+            (effects.fallback_state, effects.start_fallback_after_primary),
             settings_getter,
-            playback_cleanup_state,
+            effects.cleanup_state,
             dialog,
         )
     except _resolver._RESOLVE_RUNTIME_ERRORS as error:
-        _resolver._stop_fallback_submit_worker(fallback_state, cancel_submitted=True)
+        _resolver._stop_fallback_submit_worker(
+            effects.fallback_state if effects is not None else None,
+            cancel_submitted=True,
+        )
         _resolver._handle_resolve_exception("resolve_and_play", error)
     finally:
         if dialog is not None:

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
@@ -178,28 +178,25 @@ def _invoke_poll_until_ready(
     download_timeout,
     params_src,
     picker_completed_lookup_done,
-    extras,
+    poll_ctx,
 ):
     """Verbatim ``_poll_until_ready`` invocation shared by both submit helpers.
 
     ``params_src`` is the params/resolve_params dict whose ``_completed_job`` /
-    ``_download_pubdate`` / ``_download_size`` are threaded through, and
-    ``extras`` is ``(on_primary_submitted, on_existing_completed,
-    selected_indexer, rejected_completed_ids, dead, settings_getter)``. The
-    resolve path passes ``settings_getter=None`` (its default), so this stays
-    byte-identical to the original handle-based call. Returns
+    ``_download_pubdate`` / ``_download_size`` are folded into ``poll_ctx``, the
+    ``PollContext`` bundling the hooks/hints constructed at the resolve entry.
+    The resolve path leaves ``settings_getter`` at its ``None`` default, so this
+    stays byte-identical to the original handle-based call. Returns
     ``(stream_url, stream_headers)``.
     """
-    (
-        on_primary_submitted,
-        on_existing_completed,
-        selected_indexer,
-        rejected_completed_ids,
-        dead,
-        settings_getter,
-    ) = extras
     completed_job_hint = (
         None if picker_completed_lookup_done else params_src.get("_completed_job")
+    )
+    poll_ctx = poll_ctx._replace(
+        completed_job_hint=completed_job_hint,
+        completed_job_lookup_done=picker_completed_lookup_done,
+        download_pubdate=params_src.get("_download_pubdate"),
+        download_size=params_src.get("_download_size"),
     )
     return _resolver._poll_until_ready(
         nzb_url,
@@ -207,16 +204,7 @@ def _invoke_poll_until_ready(
         dialog,
         poll_interval,
         download_timeout,
-        on_primary_submitted=on_primary_submitted,
-        on_existing_completed=on_existing_completed,
-        completed_job_hint=completed_job_hint,
-        completed_job_lookup_done=picker_completed_lookup_done,
-        settings_getter=settings_getter,
-        selected_indexer=selected_indexer,
-        rejected_completed_ids=rejected_completed_ids,
-        download_pubdate=params_src.get("_download_pubdate"),
-        download_size=params_src.get("_download_size"),
-        dead=dead,
+        poll_ctx=poll_ctx,
     )
 
 
@@ -225,19 +213,16 @@ def _resolve_submit_and_poll(
     title,
     params,
     picker_completed_lookup_done,
-    selected_indexer,
-    rejected_completed_ids,
-    dead,
-    callbacks,
+    poll_ctx,
 ):
     """Submit + poll for the handle-based ``resolve`` path (no completed hit).
 
-    Extracted verbatim from the ``else`` branch of ``resolve``. ``callbacks`` is
-    ``(on_primary_submitted, on_existing_completed)``. See
+    Extracted verbatim from the ``else`` branch of ``resolve``. ``poll_ctx`` is
+    the ``PollContext`` bundling the hooks/hints built at the entry (its
+    ``settings_getter`` stays ``None`` on this path). See
     ``_resolve_and_play_submit_and_poll`` for the bookmark-cleanup timing
     rationale. Returns ``(stream_url, stream_headers, dialog)``.
     """
-    on_primary_submitted, on_existing_completed = callbacks
     poll_interval, download_timeout = _resolver._get_poll_settings()
     # Offer the pre-submit queue clear before the dialog so the yes/no prompt
     # is never stacked behind a modal DialogProgress.
@@ -252,7 +237,7 @@ def _resolve_submit_and_poll(
     owner = dialog
     try:
         if not picker_completed_lookup_done:
-            on_existing_completed()
+            poll_ctx.on_existing_completed()
         stream_url, stream_headers = _invoke_poll_until_ready(
             nzb_url,
             title,
@@ -261,14 +246,7 @@ def _resolve_submit_and_poll(
             download_timeout,
             params,
             picker_completed_lookup_done,
-            (
-                on_primary_submitted,
-                on_existing_completed,
-                selected_indexer,
-                rejected_completed_ids,
-                dead,
-                None,
-            ),
+            poll_ctx,
         )
         owner = None
         return stream_url, stream_headers, dialog
@@ -399,18 +377,15 @@ def _resolve_and_play_submit_and_poll(
     title,
     resolve_params,
     picker_completed_lookup_done,
-    selected_indexer,
-    rejected_completed_ids,
-    dead,
-    callbacks,
+    poll_ctx,
 ):
     """Submit + poll (handle-less path); verbatim ``resolve_and_play`` ``else``.
 
     Mirrors ``_resolve_submit_and_poll`` with resolve-stage logging and a
-    threaded ``settings_getter``. ``callbacks`` is ``(on_primary_submitted,
-    on_existing_completed, settings_getter)``.
+    threaded ``settings_getter``. ``poll_ctx`` is the ``PollContext`` bundling
+    the hooks/hints built at the entry (including its ``settings_getter``).
     """
-    on_primary_submitted, on_existing_completed, settings_getter = callbacks
+    settings_getter = poll_ctx.settings_getter
     _resolver._resolve_stage("poll settings start")
     poll_interval, download_timeout = _resolver._get_poll_settings(
         settings_getter=settings_getter
@@ -429,7 +404,7 @@ def _resolve_and_play_submit_and_poll(
     owner = dialog
     try:
         if not picker_completed_lookup_done:
-            on_existing_completed()
+            poll_ctx.on_existing_completed()
         _resolver._resolve_stage("poll until ready start")
         stream_url, stream_headers = _invoke_poll_until_ready(
             nzb_url,
@@ -439,14 +414,7 @@ def _resolve_and_play_submit_and_poll(
             download_timeout,
             resolve_params,
             picker_completed_lookup_done,
-            (
-                on_primary_submitted,
-                on_existing_completed,
-                selected_indexer,
-                rejected_completed_ids,
-                dead,
-                settings_getter,
-            ),
+            poll_ctx,
         )
         _resolver._resolve_stage(
             "poll until ready done stream={}".format(bool(stream_url))

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_pollloop.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_pollloop.py
@@ -13,7 +13,24 @@ top-level import cycle; same-module sibling helpers are called directly. Every
 moved name is re-exported from ``resolver``.
 """
 
+from typing import NamedTuple
+
 import resources.lib.resolver as _resolver  # noqa: F401  pylint: disable=unused-import
+
+
+class PollContext(NamedTuple):
+    """Optional hooks/hints threaded from resolve entry into the poll loop."""
+
+    on_primary_submitted: object = None
+    on_existing_completed: object = None
+    completed_job_hint: object = None
+    completed_job_lookup_done: bool = False
+    settings_getter: object = None
+    selected_indexer: str = ""
+    rejected_completed_ids: object = None
+    download_pubdate: object = None
+    download_size: object = None
+    dead: object = None
 
 
 def _record_download_soft(title, download_pubdate, download_size):
@@ -86,45 +103,52 @@ def _cancel_job_on_shutdown(nzo_id, settings_getter):
         _resolver.cancel_job(nzo_id, settings_getter=settings_getter)
 
 
+def _submit_and_announce(nzb_url, title, dialog, monitor, poll_ctx):
+    """Submit the NZB (with retries) and fire the primary-submitted hook.
+
+    Returns nzo_id or None. Extracted verbatim from _poll_until_ready."""
+    nzo_id = _resolver._submit_nzb_with_retries(
+        nzb_url,
+        title,
+        dialog,
+        monitor,
+        settings_getter=poll_ctx.settings_getter,
+        selected_indexer=poll_ctx.selected_indexer,
+        rejected_completed_ids=poll_ctx.rejected_completed_ids,
+    )
+    if not nzo_id:
+        return None
+    _notify_primary_submitted(poll_ctx.on_primary_submitted, nzo_id)
+    return nzo_id
+
+
 def _poll_until_ready(
-    nzb_url,
-    title,
-    dialog,
-    poll_interval,
-    download_timeout,
-    on_primary_submitted=None,
-    on_existing_completed=None,
-    completed_job_hint=None,
-    completed_job_lookup_done=False,
-    settings_getter=None,
-    selected_indexer=None,
-    rejected_completed_ids=None,
-    download_pubdate=None,
-    download_size=None,
-    dead=None,
+    nzb_url, title, dialog, poll_interval, download_timeout, poll_ctx=None
 ):
     """Submit NZB and poll until download completes.
 
     Returns ``(stream_url, stream_headers)`` on success, or ``(None, None)``
     on failure (timeout, cancellation, server error, etc.).  All user
     notifications are issued inside this function; the caller only needs to
-    decide what to do with the resulting stream URL.
+    decide what to do with the resulting stream URL. ``poll_ctx`` bundles the
+    optional hooks/hints; ``None`` means ``PollContext()`` (all defaults).
     """
+    poll_ctx = poll_ctx or PollContext()
     # Completed rows the body probe rejects (Completed but mid-file body
     # unavailable) are collected here so neither the submit/adoption path nor
     # the poll-loop by-name fallback re-adopts the very row we just rejected
     # and bypasses the intended re-download. The caller may pass a shared set
     # so a picker-probe rejection (recorded before this call) is honored too.
-    if rejected_completed_ids is None:
-        rejected_completed_ids = set()
+    if poll_ctx.rejected_completed_ids is None:
+        poll_ctx = poll_ctx._replace(rejected_completed_ids=set())
     existing_stream = _resolver._existing_completed_stream(
         title,
-        on_existing_completed=on_existing_completed,
-        completed_job_hint=completed_job_hint,
-        completed_job_lookup_done=completed_job_lookup_done,
-        settings_getter=settings_getter,
-        rejected_completed_ids=rejected_completed_ids,
-        download_size=download_size,
+        on_existing_completed=poll_ctx.on_existing_completed,
+        completed_job_hint=poll_ctx.completed_job_hint,
+        completed_job_lookup_done=poll_ctx.completed_job_lookup_done,
+        settings_getter=poll_ctx.settings_getter,
+        rejected_completed_ids=poll_ctx.rejected_completed_ids,
+        download_size=poll_ctx.download_size,
     )
     if existing_stream is not None:
         return existing_stream
@@ -134,18 +158,9 @@ def _poll_until_ready(
     # fallback in _poll_once compares this against a slot's ``completed``
     # epoch to suppress stale prior-attempt false positives on resubmit.
     submit_started_wall = _resolver.time.time()
-    nzo_id = _resolver._submit_nzb_with_retries(
-        nzb_url,
-        title,
-        dialog,
-        monitor,
-        settings_getter=settings_getter,
-        selected_indexer=selected_indexer,
-        rejected_completed_ids=rejected_completed_ids,
-    )
+    nzo_id = _submit_and_announce(nzb_url, title, dialog, monitor, poll_ctx)
     if not nzo_id:
         return None, None
-    _notify_primary_submitted(on_primary_submitted, nzo_id)
 
     _resolver.xbmc.log(
         "NZB-DAV: NZB submitted, nzo_id={}, polling every {}s (timeout={}s)".format(
@@ -166,8 +181,8 @@ def _poll_until_ready(
     near_complete_fast_repolls = 0
 
     def _mark_dead(nzo):
-        if dead is not None:
-            dead.add(nzb_url=nzb_url, nzo_id=nzo)
+        if poll_ctx.dead is not None:
+            poll_ctx.dead.add(nzb_url=nzb_url, nzo_id=nzo)
 
     def _run_one_poll():
         """Run one poll iteration.
@@ -180,9 +195,9 @@ def _poll_until_ready(
             nzo_id,
             title,
             monitor,
-            settings_getter=settings_getter,
+            settings_getter=poll_ctx.settings_getter,
             submit_started_wall=submit_started_wall,
-            rejected_completed_ids=rejected_completed_ids,
+            rejected_completed_ids=poll_ctx.rejected_completed_ids,
         )
 
         should_stop, last_status = _resolver._handle_job_status(
@@ -199,13 +214,15 @@ def _poll_until_ready(
                 no_video_retries,
                 max_no_video_retries,
                 monitor=monitor,
-                settings_getter=settings_getter,
-                modal_failures=settings_getter is None,
-                download_size=download_size,
+                settings_getter=poll_ctx.settings_getter,
+                modal_failures=poll_ctx.settings_getter is None,
+                download_size=poll_ctx.download_size,
             )
         )
         if stream_url:
-            _record_download_soft(title, download_pubdate, download_size)
+            _record_download_soft(
+                title, poll_ctx.download_pubdate, poll_ctx.download_size
+            )
             return stream_url, stream_headers
         if should_stop:
             _mark_dead_on_failed_history(history, nzo_id, _mark_dead)
@@ -223,7 +240,9 @@ def _poll_until_ready(
         wait_seconds, near_complete_fast_repolls = _resolver._poll_wait_after_status(
             job_status, poll_interval, near_complete_fast_repolls
         )
-        return _wait_between_polls(monitor, wait_seconds, nzo_id, settings_getter)
+        return _wait_between_polls(
+            monitor, wait_seconds, nzo_id, poll_ctx.settings_getter
+        )
 
     while True:
         iteration += 1

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_submit.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_submit.py
@@ -159,6 +159,55 @@ def _cancel_late_accepted_submit(nzo_id, title, settings_getter):
         )
 
 
+def _start_submit_worker(
+    nzb_url, title, settings_getter, submit_timeout_seconds, activity_ready
+):
+    """Build the submit worker + its events; return the daemon thread.
+
+    Extracted verbatim from ``_submit_nzb_with_ui_pump``. ``activity_ready`` is
+    owned by the caller (the concurrent queue/history probes also set it), so it
+    is threaded in rather than created here. Returns
+    ``(submit_result, submit_done, cancel_after_submit, thread)``; the caller
+    starts the thread (or runs it inline via ``thread.run()`` as a fallback).
+    """
+    submit_result = [None, None]
+    submit_done = _resolver.threading.Event()
+    # Set when the user cancels or Kodi aborts while the (uninterruptible)
+    # addurl worker is still in flight. The worker re-checks this AFTER
+    # submit_nzb returns and cancels a late-accepted nzo_id so a user-cancelled
+    # download is never left running in nzbdav.
+    cancel_after_submit = _resolver.threading.Event()
+
+    def _submit_worker():
+        try:
+            submit_kwargs = _resolver._settings_getter_kwargs(settings_getter)
+            if settings_getter is not None:
+                submit_kwargs["submit_timeout"] = submit_timeout_seconds
+            submit_result[0], submit_result[1] = _resolver.submit_nzb(
+                nzb_url,
+                title,
+                **submit_kwargs,
+            )
+            if submit_result[0] and cancel_after_submit.is_set():
+                _cancel_late_accepted_submit(submit_result[0], title, settings_getter)
+        except Exception as e:  # pylint: disable=broad-except
+            _resolver.xbmc.log(
+                "NZB-DAV: submit_nzb worker raised: {}".format(
+                    _resolver._redact_log(e)
+                ),
+                _resolver.xbmc.LOGERROR,
+            )
+            submit_result[0], submit_result[1] = None, None
+        finally:
+            submit_done.set()
+            activity_ready.set()
+
+    thread = _resolver.threading.Thread(
+        target=_submit_worker, name="nzbdav-submit", daemon=True
+    )
+    return submit_result, submit_done, cancel_after_submit, thread
+
+
 def _submit_nzb_with_ui_pump(
     nzb_url, title, dialog, monitor, settings_getter=None, rejected_completed_ids=None
 ):
@@ -191,44 +240,16 @@ def _submit_nzb_with_ui_pump(
     # re-adopted by the concurrent history probe (finding #7); a tuple keeps
     # the `in` test cheap and never None.
     rejected_ids = tuple(rejected_completed_ids or ())
-    submit_result = [None, None]
-    submit_done = _resolver.threading.Event()
     activity_ready = _resolver.threading.Event()
-    # Set when the user cancels or Kodi aborts while the (uninterruptible)
-    # addurl worker is still in flight. The worker re-checks this AFTER
-    # submit_nzb returns and cancels a late-accepted nzo_id so a user-cancelled
-    # download is never left running in nzbdav.
-    cancel_after_submit = _resolver.threading.Event()
     submit_timeout_seconds = max(
         _resolver._get_submit_timeout_seconds(
             **_resolver._settings_getter_kwargs(settings_getter)
         ),
         1,
     )
-
-    def _submit_worker():
-        try:
-            submit_kwargs = _resolver._settings_getter_kwargs(settings_getter)
-            if settings_getter is not None:
-                submit_kwargs["submit_timeout"] = submit_timeout_seconds
-            submit_result[0], submit_result[1] = _resolver.submit_nzb(
-                nzb_url,
-                title,
-                **submit_kwargs,
-            )
-            if submit_result[0] and cancel_after_submit.is_set():
-                _cancel_late_accepted_submit(submit_result[0], title, settings_getter)
-        except Exception as e:  # pylint: disable=broad-except
-            _resolver.xbmc.log(
-                "NZB-DAV: submit_nzb worker raised: {}".format(
-                    _resolver._redact_log(e)
-                ),
-                _resolver.xbmc.LOGERROR,
-            )
-            submit_result[0], submit_result[1] = None, None
-        finally:
-            submit_done.set()
-            activity_ready.set()
+    submit_result, submit_done, cancel_after_submit, submit_t = _start_submit_worker(
+        nzb_url, title, settings_getter, submit_timeout_seconds, activity_ready
+    )
 
     queue_hit = [None]
     adoption_status = [""]
@@ -312,40 +333,46 @@ def _submit_nzb_with_ui_pump(
             if queue_stop.wait(_submit_probe_interval(probe_started)):
                 return
 
-    submit_t = _resolver.threading.Thread(
-        target=_submit_worker, name="nzbdav-submit", daemon=True
-    )
     probe_t = _resolver.threading.Thread(
         target=_queue_probe_worker, name="nzbdav-submit-probe", daemon=True
     )
     history_probe_t = _resolver.threading.Thread(
         target=_history_probe_worker, name="nzbdav-submit-history-probe", daemon=True
     )
-    started_threads = []
 
-    def _start_submit_thread(thread, label):
-        try:
-            thread.start()
-        except RuntimeError as error:
+    def _start_all_threads():
+        """Start submit + probe threads (inline submit fallback on failure).
+
+        Returns the list of threads that actually started, for the join
+        cleanup. Extracted verbatim from the parent."""
+        started = []
+
+        def _start_submit_thread(thread, label):
+            try:
+                thread.start()
+            except RuntimeError as error:
+                _resolver.xbmc.log(
+                    "NZB-DAV: Could not start {} thread for '{}': {}".format(
+                        label, title, error
+                    ),
+                    _resolver.xbmc.LOGWARNING,
+                )
+                return False
+            started.append(thread)
+            return True
+
+        if not _start_submit_thread(submit_t, "submit"):
             _resolver.xbmc.log(
-                "NZB-DAV: Could not start {} thread for '{}': {}".format(
-                    label, title, error
-                ),
+                "NZB-DAV: Falling back to synchronous submit for '{}'".format(title),
                 _resolver.xbmc.LOGWARNING,
             )
-            return False
-        started_threads.append(thread)
-        return True
+            submit_t.run()
+        elif not submit_done.is_set():
+            _start_submit_thread(probe_t, "queue probe")
+            _start_submit_thread(history_probe_t, "history probe")
+        return started
 
-    if not _start_submit_thread(submit_t, "submit"):
-        _resolver.xbmc.log(
-            "NZB-DAV: Falling back to synchronous submit for '{}'".format(title),
-            _resolver.xbmc.LOGWARNING,
-        )
-        _submit_worker()
-    elif not submit_done.is_set():
-        _start_submit_thread(probe_t, "queue probe")
-        _start_submit_thread(history_probe_t, "history probe")
+    started_threads = _start_all_threads()
 
     # Anchor elapsed to wall-clock via time.monotonic() instead of
     # accumulating _SUBMIT_UI_PUMP_INTERVAL_SECONDS per loop; the per-loop

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -14,6 +14,7 @@ from resources.lib.resolver import (
     _POLL_INTERVAL_MAX,
     _POLL_INTERVAL_MIN,
     MAX_POLL_ITERATIONS,
+    PollContext,
     _cache_bust_url,
     _clear_kodi_playback_state,
     _completed_job_stream,
@@ -2061,7 +2062,7 @@ def test_resolve_starts_fallback_worker_after_primary_submit_and_uses_snapshot(
     def poll_ready(*args, **kwargs):
         call_order.append("poll")
         assert mock_start_fallback.call_count == 0
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         mock_start_fallback.assert_called_once_with(
             fallback_candidates,
             candidate_loader=None,
@@ -2317,7 +2318,7 @@ def test_resolve_prefetches_fallback_loader_before_primary_submit(
 
     def poll_ready(*_args, **kwargs):
         assert loader_started.wait(timeout=1)
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         assert mock_start_fallback.call_args.args == ([],)
         loader_kwarg = mock_start_fallback.call_args.kwargs["candidate_loader"]
         assert loader_kwarg is not slow_loader
@@ -2381,7 +2382,7 @@ def test_resolve_overlaps_bookmark_cleanup_with_post_submit_poll(
 
     def poll_ready(*_args, **kwargs):
         timing["poll_start"] = _time.perf_counter()
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         _time.sleep(0.2)
         timing["poll_end"] = _time.perf_counter()
         return (
@@ -2458,7 +2459,7 @@ def test_resolve_starts_bookmark_cleanup_before_primary_submit_wait(
         timing["poll_start"] = _time.perf_counter()
         _time.sleep(0.16)
         timing["primary_submitted"] = _time.perf_counter()
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         timing["ready"] = _time.perf_counter()
         return (
             "http://webdav/content/primary/movie.mkv",
@@ -2585,7 +2586,7 @@ def test_resolve_overlaps_proxy_prepare_with_bookmark_cleanup_after_ready(
 
     def poll_ready(*_args, **kwargs):
         timing["poll_start"] = _time.perf_counter()
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         _time.sleep(0.02)
         timing["ready"] = _time.perf_counter()
         return (
@@ -2923,7 +2924,7 @@ def test_resolve_and_play_overlaps_proxy_prepare_with_bookmark_cleanup_after_rea
 
     def poll_ready(*_args, **kwargs):
         timing["poll_start"] = _time.perf_counter()
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         _time.sleep(0.02)
         timing["ready"] = _time.perf_counter()
         return (
@@ -3633,7 +3634,7 @@ def test_resolve_and_play_defers_fallback_loader_until_primary_accept(
 
     def poll_ready(*_args, **kwargs):
         assert mock_start_fallback.call_count == 0
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         return (
             "http://webdav/content/primary/movie.mkv",
             {"Authorization": "Basic primary"},
@@ -3744,7 +3745,7 @@ def test_resolve_and_play_passes_settings_getter_to_fallback_worker(
         return [{"title": "Fallback A", "link": "http://hydra/getnzb/fallback"}]
 
     def poll_ready(*_args, **kwargs):
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         return (
             "http://webdav/content/primary/movie.mkv",
             {"Authorization": "Basic primary"},
@@ -4181,7 +4182,7 @@ def test_resolve_cancels_fallback_worker_jobs_when_primary_fails(
     mock_start_fallback.return_value = fallback_state
 
     def poll_not_ready(*args, **kwargs):
-        kwargs["on_primary_submitted"]("SABnzbd_nzo_primary")
+        kwargs["poll_ctx"].on_primary_submitted("SABnzbd_nzo_primary")
         return None, {}
 
     mock_poll_until_ready.side_effect = poll_not_ready
@@ -6767,8 +6768,10 @@ def test_poll_until_ready_records_pubdate_on_submit_success(
         _make_dialog(),
         2,
         3600,
-        download_pubdate="Wed, 15 Dec 2021 12:00:00 +0000",
-        download_size="1000",
+        poll_ctx=PollContext(
+            download_pubdate="Wed, 15 Dec 2021 12:00:00 +0000",
+            download_size="1000",
+        ),
     )
 
     assert url == "http://webdav/movie.mkv"
@@ -6797,7 +6800,9 @@ def test_poll_until_ready_cache_hit_does_not_record(
         _make_dialog(),
         2,
         3600,
-        download_pubdate="Wed, 15 Dec 2021 12:00:00 +0000",
+        poll_ctx=PollContext(
+            download_pubdate="Wed, 15 Dec 2021 12:00:00 +0000",
+        ),
     )
 
     assert url == "http://webdav/cached.mkv"
@@ -8960,8 +8965,10 @@ def test_poll_until_ready_records_ledger_only_on_playable_success(
         _poll_dialog(),
         poll_interval=1,
         download_timeout=60,
-        download_pubdate="2026-01-02",
-        download_size=12345,
+        poll_ctx=PollContext(
+            download_pubdate="2026-01-02",
+            download_size=12345,
+        ),
     )
 
     assert result == ("http://webdav/movie.mkv", {"H": "1"})
@@ -8998,8 +9005,10 @@ def test_poll_until_ready_does_not_record_ledger_when_poll_fails(
         _poll_dialog(),
         poll_interval=1,
         download_timeout=60,
-        download_pubdate="2026-01-02",
-        download_size=12345,
+        poll_ctx=PollContext(
+            download_pubdate="2026-01-02",
+            download_size=12345,
+        ),
     )
 
     assert result == (None, None)

--- a/tests/test_resolver_errors.py
+++ b/tests/test_resolver_errors.py
@@ -196,7 +196,7 @@ def test_poll_until_ready_records_dead_on_job_failed(resolver_mocks):
                 resolver_mocks.dialog,
                 1,
                 60,
-                dead=dead,
+                poll_ctx=resolver.PollContext(dead=dead),
             )
 
     assert stream_url is None
@@ -228,7 +228,7 @@ def test_poll_until_ready_does_not_record_dead_on_timeout(resolver_mocks):
                 resolver_mocks.dialog,
                 1,
                 60,
-                dead=dead,
+                poll_ctx=resolver.PollContext(dead=dead),
             )
 
     assert stream_url is None
@@ -345,7 +345,7 @@ def test_playback_fallback_sources_excludes_dead_url():
     assert [s["nzo_id"] for s in sources] == ["nzo_ok"]
 
 
-def _dialog_close_called_when_poll_raises(helper_name, callbacks):
+def _dialog_close_called_when_poll_raises(helper_name, poll_ctx):
     """Shared body: a raise in the submit/poll helper must close the locally
     created DialogProgress before propagating (no-hang invariant). The split
     into _resolve_*_submit_and_poll returns the dialog to the caller, so a raise
@@ -370,17 +370,30 @@ def _dialog_close_called_when_poll_raises(helper_name, callbacks):
         gui.DialogProgress.return_value = dialog
         helper = getattr(resolver, helper_name)
         with pytest.raises(RuntimeError):
-            helper("http://nzb", "Title", {}, True, "", set(), None, callbacks)
+            helper("http://nzb", "Title", {}, True, poll_ctx)
     dialog.close.assert_called_once()
 
 
 def test_resolve_submit_and_poll_closes_dialog_when_poll_raises():
+    from resources.lib import resolver
+
     _dialog_close_called_when_poll_raises(
-        "_resolve_submit_and_poll", (lambda nzo: None, lambda: None)
+        "_resolve_submit_and_poll",
+        resolver.PollContext(
+            on_primary_submitted=lambda nzo: None,
+            on_existing_completed=lambda: None,
+        ),
     )
 
 
 def test_resolve_and_play_submit_and_poll_closes_dialog_when_poll_raises():
+    from resources.lib import resolver
+
     _dialog_close_called_when_poll_raises(
-        "_resolve_and_play_submit_and_poll", (lambda nzo: None, lambda: None, None)
+        "_resolve_and_play_submit_and_poll",
+        resolver.PollContext(
+            on_primary_submitted=lambda nzo: None,
+            on_existing_completed=lambda: None,
+            settings_getter=None,
+        ),
     )


### PR DESCRIPTION
Bundles \`_poll_until_ready\`'s 10 optional hook/hint params into a \`PollContext\` NamedTuple, replaces the anonymous callback tuples in \`resolver_flow\` on both the handle and handle-less paths, deduplicates the entry-path once-only closures into a shared \`_ResolveSideEffects\` class, and splits the overlong resolver functions by pure code motion. Part 2 of the complexity-reduction campaign (Phase A cluster A2). Independent of #378.

## What changed
- \`resolver_pollloop.py\`: \`PollContext\` (10 fields) + \`_submit_and_announce\` extraction; \`_poll_until_ready\` 15 params/68 nloc → 6 params/44 nloc.
- \`resolver_flow.py\`: positional 6-tuple and \`callbacks\` tuples replaced by \`PollContext\` end-to-end.
- \`resolver_entry.py\`: \`_ResolveSideEffects\` replaces the duplicated closure pairs in \`resolve()\` and \`resolve_and_play()\` (DRY win); both functions now <50 nloc.
- \`resolver_submit.py\`: worker-thread setup extracted verbatim to \`_start_submit_worker\`.

## Complexity delta (codacy-cli lizard)
- shipped-lib function-nloc findings: **7 → 2**; \`_poll_until_ready\` parameter-count finding gone. No findings added anywhere.

## Safety (fable contract review passed)
- Every resolve path still reaches \`setResolvedUrl\` (exception path traced explicitly).
- Once-only cleanup/fallback-worker guards structurally identical; \`dead\` constructed before the effects object.
- \`download_pubdate\` → history identity flow byte-equivalent; cancel-after-submit path a verbatim move.
- \`just lint\` clean; \`just test\` 2234 passed / 2 skipped; no assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)