### PR TITLE
refactor: SearchQuery + probe param bundles (Lizard A3)

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/direct_indexers.py
+++ b/repo/plugin.video.nzbdav/resources/lib/direct_indexers.py
@@ -32,7 +32,7 @@ from resources.lib.http_util import (
 )
 from resources.lib.indexer_store import load_indexers
 from resources.lib.newznab_caps import normalize_api_endpoint
-from resources.lib.search_planner import plan_newznab_search
+from resources.lib.search_planner import SearchQuery, plan_newznab_search
 from resources.lib.xml_safety import ParseError as _XmlParseError
 from resources.lib.xml_safety import UnsafeXmlError as _UnsafeXmlError
 from resources.lib.xml_safety import safe_fromstring as _safe_fromstring
@@ -394,19 +394,22 @@ def _fetch_and_parse(indexer, params, error_prefix):
 
 def _plan_indexer_search(indexer, criteria, max_results):
     """Build the Newznab search plan for one indexer from search criteria."""
-    return plan_newznab_search(
-        provider_kind="direct",
-        host=indexer["api_url"],
+    query = SearchQuery(
         search_type=criteria["search_type"],
         title=criteria["title"],
         year=criteria.get("year", ""),
         imdb=criteria.get("imdb", ""),
         season=criteria.get("season", ""),
         episode=criteria.get("episode", ""),
+        tvdb=criteria.get("tvdb", ""),
+    )
+    return plan_newznab_search(
+        provider_kind="direct",
+        host=indexer["api_url"],
+        query=query,
         caps=indexer.get("caps", {}),
         api_key=indexer["api_key"],
         max_results=max_results,
-        tvdb=criteria.get("tvdb", ""),
     )
 
 
@@ -442,15 +445,9 @@ def _search_one_indexer(indexer, criteria, max_results):
 
 
 def search_direct_indexers(
-    search_type,
-    title,
-    year="",
-    imdb="",
-    season="",
-    episode="",
+    query,
     indexers=None,
     max_results=None,
-    tvdb="",
 ):
     """Search all configured direct Newznab indexers."""
     indexers = get_configured_indexers() if indexers is None else indexers
@@ -463,13 +460,13 @@ def search_direct_indexers(
     all_results = []
     errors = []
     criteria = {
-        "search_type": search_type,
-        "title": title,
-        "year": year,
-        "imdb": imdb,
-        "season": season,
-        "episode": episode,
-        "tvdb": tvdb,
+        "search_type": query.search_type,
+        "title": query.title,
+        "year": query.year,
+        "imdb": query.imdb,
+        "season": query.season,
+        "episode": query.episode,
+        "tvdb": query.tvdb,
     }
 
     def worker(indexer):

--- a/repo/plugin.video.nzbdav/resources/lib/hydra.py
+++ b/repo/plugin.video.nzbdav/resources/lib/hydra.py
@@ -37,7 +37,7 @@ from resources.lib.http_util import (
 )
 from resources.lib.indexer_store import load_provider_caps, save_provider_caps
 from resources.lib.newznab_caps import fetch_caps
-from resources.lib.search_planner import plan_newznab_search
+from resources.lib.search_planner import SearchQuery, plan_newznab_search
 
 NEWZNAB_NS = "http://www.newznab.com/DTD/2010/feeds/attributes/"
 _HYDRA_REQUEST_ERRORS = (
@@ -285,19 +285,22 @@ def _plan_hydra_search(base_url, api_key, search_type, fields):
     """Build the Newznab search plan and caps-availability flag."""
     max_results = _resolve_max_results(fields["settings_getter"])
     caps, has_provider_caps = _get_hydra_caps_for_search(base_url, api_key)
-    plan = plan_newznab_search(
-        provider_kind="nzbhydra2",
-        host=base_url,
+    query = SearchQuery(
         search_type=search_type,
         title=fields["title"],
         year=fields["year"],
         imdb=fields["imdb"],
         season=fields["season"],
         episode=fields["episode"],
+        tvdb=fields["tvdb"],
+    )
+    plan = plan_newznab_search(
+        provider_kind="nzbhydra2",
+        host=base_url,
+        query=query,
         caps=caps,
         api_key=api_key,
         max_results=max_results,
-        tvdb=fields["tvdb"],
     )
     return plan, has_provider_caps
 

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -54,6 +54,7 @@ from resources.lib.nzbdav_api import (  # noqa: F401
     submit_nzb,
 )
 from resources.lib.webdav import (  # noqa: F401
+    TitleHints,
     find_video_file,
     find_video_stream_for_folder,
     get_webdav_stream_url_for_path,

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_completed.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_completed.py
@@ -13,7 +13,19 @@ top-level import cycle; same-module sibling helpers are called directly. Every
 moved name is re-exported from ``resolver``.
 """
 
+from typing import NamedTuple
+
 import resources.lib.resolver as _resolver  # noqa: F401  pylint: disable=unused-import
+
+
+class CompletedVideoProbe(NamedTuple):
+    """Discovered completed-copy video plus the context needed to validate it."""
+
+    video_path: str
+    stream_url: str
+    stream_headers: dict
+    download_size: object
+    webdav_folder: str
 
 
 def _submit_error_is_too_many_requests(submit_error):
@@ -150,7 +162,7 @@ def _find_video_stream_for_folder(
     _resolver._resolve_stage("find_video_file_start folder={}".format(webdav_folder))
     video_path = _resolver.find_video_file(
         webdav_folder,
-        title_hint=title_hint,
+        hints=_resolver.TitleHints(title_hint=title_hint),
         min_video_size=min_video_size,
         **kwargs,
     )
@@ -253,12 +265,14 @@ def _completed_job_stream(
     if _completed_job_video_rejected(
         title,
         completed_job,
-        video_path,
-        stream_url,
-        stream_headers,
-        download_size,
+        CompletedVideoProbe(
+            video_path=video_path,
+            stream_url=stream_url,
+            stream_headers=stream_headers,
+            download_size=download_size,
+            webdav_folder=webdav_folder,
+        ),
         rejected_completed_ids,
-        webdav_folder,
         settings_getter,
     ):
         return None
@@ -268,12 +282,8 @@ def _completed_job_stream(
 def _completed_job_video_rejected(
     title,
     completed_job,
-    video_path,
-    stream_url,
-    stream_headers,
-    download_size,
+    probe,
     rejected_completed_ids,
-    webdav_folder,
     settings_getter=None,
 ):
     """Return True if a discovered completed video is a stub or has no body.
@@ -287,6 +297,11 @@ def _completed_job_video_rejected(
     size, so a stub-only folder is rejected whether the release is a movie or a
     pack. Fails open on unknown size inside ``_discovered_video_is_stub``.
     """
+    video_path = probe.video_path
+    stream_url = probe.stream_url
+    stream_headers = probe.stream_headers
+    download_size = probe.download_size
+    webdav_folder = probe.webdav_folder
     if _resolver._discovered_video_is_stub(
         webdav_folder, video_path, download_size, settings_getter
     ):

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -419,17 +419,7 @@ def _script_completed_job_for_selection(selected):
         return None
 
 
-def _search_all_providers(
-    search_type,
-    title,
-    year="",
-    imdb="",
-    season="",
-    episode="",
-    settings_getter=None,
-    tvdb="",
-    tmdb_id="",
-):
+def _search_all_providers(query, settings_getter=None):
     """
     Search enabled indexer providers and return combined, deduplicated results.
 
@@ -448,6 +438,14 @@ def _search_all_providers(
                 `None`.
     """
     _script_play_stage("providers entry")
+    search_type = query.search_type
+    title = query.title
+    year = query.year
+    imdb = query.imdb
+    season = query.season
+    episode = query.episode
+    tvdb = query.tvdb
+    tmdb_id = query.tmdb_id
     settings_getter = _settings_getter_or_addon_default(settings_getter)
 
     # Provider defaults mirror settings.xml. Runtime setting read failures still
@@ -493,7 +491,17 @@ def _search_all_providers(
     )
 
     provider_outcomes = _run_provider_jobs(provider_jobs)
+    return _collect_provider_outcomes(provider_outcomes)
 
+
+def _collect_provider_outcomes(provider_outcomes):
+    """Merge provider outcomes into deduplicated results plus a first error.
+
+    Logs each provider failure, dedupes surviving results by ``link``, and
+    returns ``(deduped, error_message)`` where ``error_message`` is the first
+    collected provider error only when every provider produced no surviving
+    result; otherwise ``None``.
+    """
     all_results = []
     errors = []
     for provider_label, outcome in provider_outcomes:

--- a/repo/plugin.video.nzbdav/resources/lib/router_play.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_play.py
@@ -57,21 +57,21 @@ def _query_and_cache_providers(search_type, title, cache_kwargs, set_cached):
     (non-error) non-empty query. Extracted verbatim from ``_search_with_cache``.
     """
     import resources.lib.router as _router
+    from resources.lib.search_planner import SearchQuery
 
     addon = xbmcaddon.Addon("plugin.video.nzbdav")
     xbmc.log(
         "NZB-DAV: Search stage: querying providers for '{}'".format(title),
         xbmc.LOGDEBUG,
     )
+    query = SearchQuery(search_type=search_type, title=title, **cache_kwargs)
     results, search_error = _router._search_all_providers(
-        search_type,
-        title,
+        query,
         settings_getter=lambda key, default="": (
             "true"
             if key == "nzbhydra_enabled"
             else _router._get_addon_setting(addon, key, default)
         ),
-        **cache_kwargs,
     )
     if search_error:
         xbmc.log(

--- a/repo/plugin.video.nzbdav/resources/lib/router_scriptplay.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_scriptplay.py
@@ -129,9 +129,11 @@ def _script_play_search_results(search_type, title, search_kwargs, notify):
     ``None`` so the caller stops, exactly as the prior inline block did.
     """
     import resources.lib.router as _router
+    from resources.lib.search_planner import SearchQuery
 
+    query = SearchQuery(search_type=search_type, title=title, **search_kwargs)
     results, search_error = _router._search_all_providers(
-        search_type, title, settings_getter=_router._get_script_setting, **search_kwargs
+        query, settings_getter=_router._get_script_setting
     )
     _router._script_play_stage(
         "provider search done count={}".format(len(results or []))

--- a/repo/plugin.video.nzbdav/resources/lib/router_search.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_search.py
@@ -50,9 +50,19 @@ def _build_provider_jobs(
             get_configured_indexers,
             search_direct_indexers,
         )
+        from resources.lib.search_planner import SearchQuery
 
+        search_type, title = search_args
+        query = SearchQuery(
+            search_type=search_type,
+            title=title,
+            year=common_kwargs.get("year", ""),
+            imdb=common_kwargs.get("imdb", ""),
+            season=common_kwargs.get("season", ""),
+            episode=common_kwargs.get("episode", ""),
+            tvdb=common_kwargs.get("tvdb", ""),
+        )
         kwargs = dict(
-            common_kwargs,
             indexers=get_configured_indexers(),
             max_results=_read_max_results(provider_settings_getter),
         )
@@ -61,7 +71,7 @@ def _build_provider_jobs(
                 "direct indexers",
                 "Direct indexer",
                 search_direct_indexers,
-                search_args,
+                (query,),
                 kwargs,
             )
         )

--- a/repo/plugin.video.nzbdav/resources/lib/search_planner.py
+++ b/repo/plugin.video.nzbdav/resources/lib/search_planner.py
@@ -4,6 +4,7 @@
 """Shared Newznab search query planning."""
 
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from resources.lib.http_util import clean_search_query
 from resources.lib.indexer_presets import (
@@ -11,6 +12,20 @@ from resources.lib.indexer_presets import (
     DOGNZB_TVSEARCH_FALLBACK_HOSTS,
     host_contains,
 )
+
+
+class SearchQuery(NamedTuple):
+    """Identity of one search request. Keep NZBHydra2/Prowlarr symmetric:
+    both providers receive the same SearchQuery."""
+
+    search_type: str
+    title: str
+    year: str = ""
+    imdb: str = ""
+    season: str = ""
+    episode: str = ""
+    tvdb: str = ""
+    tmdb_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -23,17 +38,18 @@ class NewznabSearchPlan:
 def plan_newznab_search(
     provider_kind,
     host,
-    search_type,
-    title,
-    year=None,
-    imdb=None,
-    season=None,
-    episode=None,
+    query,
     caps=None,
     api_key="",
     max_results=25,
-    tvdb=None,
 ):
+    search_type = query.search_type
+    title = query.title
+    year = query.year
+    imdb = query.imdb
+    season = query.season
+    episode = query.episode
+    tvdb = query.tvdb
     base = {"apikey": api_key, "o": "xml", "limit": max_results}
     # Strip query-breaking '&' from the keyword title once, so every q=title
     # branch below (and its title fallback) searches a term the indexer can

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_standby.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_standby.py
@@ -194,7 +194,7 @@ class _FallbackStandbyMixin:  # pylint: disable=too-few-public-methods
     def _resolve_standby_video_path(source, nzo_id):
         """Resolve a completed standby nzo_id to a WebDAV video path, if ready."""
         from resources.lib.nzbdav_api import get_job_history
-        from resources.lib.webdav import find_video_file
+        from resources.lib.webdav import TitleHints, find_video_file
 
         history = get_job_history(nzo_id)
         history_status = history.get("status") if isinstance(history, dict) else ""
@@ -210,7 +210,7 @@ class _FallbackStandbyMixin:  # pylint: disable=too-few-public-methods
             return None
         return find_video_file(
             _sp._storage_to_webdav_path(storage),
-            title_hint=source.get("title") or None,
+            hints=TitleHints(title_hint=source.get("title") or None),
         )
 
     def _standby_length_is_mismatch(self, ctx, content_length):

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -12,6 +12,7 @@ public stream-URL helpers, and re-exports the moved names so existing imports
 """
 
 import base64
+from typing import NamedTuple, Optional
 from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -24,11 +25,26 @@ from resources.lib.webdav_match import (
     _title_hint_match_score,
 )
 
+
+class TitleHints(NamedTuple):
+    """Requested-release name hint (plus its pre-parsed forms) for discovery.
+
+    ``title_hint`` is the optional requested scene title; ``tokens`` and
+    ``episode_tags`` are its pre-parsed forms threaded through recursion so the
+    hint is parsed once per discovery rather than once per folder level.
+    """
+
+    title_hint: Optional[str] = None
+    tokens: Optional[tuple] = None
+    episode_tags: Optional[tuple] = None
+
+
 # Re-exported for callers/tests that resolve these names on ``webdav``.
 __all__ = [
     "_episode_tags",
     "_hint_tokens",
     "_title_hint_match_score",
+    "TitleHints",
     "_get_settings",
     "_http_head",
     "probe_webdav_reachable",
@@ -533,37 +549,30 @@ def folder_video_total_bytes(
 
 def find_video_file(
     folder_path,
-    _depth=0,
-    _visited=None,
-    _already_encoded=False,
-    _settings=None,
-    settings_getter=None,
-    title_hint=None,
-    title_hint_tokens=None,
-    title_hint_episode_tags=None,
+    hints=None,
     min_video_size=0,
+    settings_getter=None,
+    _state=None,
 ):
     """Browse a WebDAV folder and find the requested (or largest) video file.
 
     Args:
         folder_path: WebDAV folder path to scan (may be absolute or relative).
-        _depth: Internal recursion depth counter (used to cap traversal).
-        _visited: Internal set of already-scanned paths; catches a hostile
-            or misconfigured server that returns its parent (or itself) as
-            a child and would otherwise recurse until the depth cap.
-        _already_encoded: Internal flag set by the recursive call when the
-            supplied ``folder_path`` came from a PROPFIND ``<D:href>`` (which
-            the server already URL-encoded for us). Without this, recursive
-            descents double-encode ``%20`` → ``%2520`` and every subdirectory
-            lookup 404s.
-        title_hint: Optional requested release name (e.g. the selected scene
-            title). When supplied and a folder/pack holds several candidate
-            videos, the one whose name matches the hint — especially the
-            requested SxxExx episode — is preferred over the largest video.
+        hints: Optional :class:`TitleHints` carrying the requested release name
+            (``title_hint``) plus its pre-parsed ``tokens``/``episode_tags``.
+            When a ``title_hint`` is supplied and a folder/pack holds several
+            candidate videos, the one whose name matches the hint — especially
+            the requested SxxExx episode — is preferred over the largest video.
             When omitted, the historical largest-video behavior is preserved.
-        title_hint_tokens / title_hint_episode_tags: Internal pre-parsed forms
-            of ``title_hint`` threaded through recursion so the hint is parsed
-            once per discovery rather than once per folder level.
+        _state: Internal ``(depth, visited, already_encoded, settings)`` recursion
+            tuple; external callers never pass it (default
+            ``(0, None, False, None)``). ``depth`` caps traversal; ``visited`` is
+            the set of already-scanned paths that catches a hostile or
+            misconfigured server returning its parent (or itself) as a child;
+            ``already_encoded`` is set by the recursive call when ``folder_path``
+            came from a PROPFIND ``<D:href>`` (already URL-encoded) so recursive
+            descents do not double-encode ``%20`` → ``%2520`` and 404; ``settings``
+            reuses an already-read settings dict.
         min_video_size: Optional minimum plausible size (bytes) for the real
             single-file video, precomputed by the resolver from the advertised
             release size (#282). A current-level candidate whose size is a
@@ -593,11 +602,15 @@ def find_video_file(
     """
     from resources.lib import webdav_discovery
 
+    if hints is None:
+        hints = TitleHints()
+    _depth, _visited, _already_encoded, _settings = _state or (0, None, False, None)
+
     if _depth > 2:
         return None
 
     hint_tokens, hint_episode_tags = webdav_discovery._resolve_hint_sets(
-        title_hint, title_hint_tokens, title_hint_episode_tags
+        hints.title_hint, hints.tokens, hints.episode_tags
     )
 
     _visited = webdav_discovery._mark_visited(folder_path, _visited)
@@ -694,9 +707,9 @@ def find_video_stream_for_folder(
     settings = _read_settings(settings_getter)
     video_path = find_video_file(
         folder_path,
-        _settings=settings,
-        title_hint=title_hint,
+        hints=TitleHints(title_hint=title_hint),
         min_video_size=min_video_size,
+        _state=(0, None, False, settings),
     )
     if not video_path:
         return None, None, None

--- a/repo/plugin.video.nzbdav/resources/lib/webdav_discovery.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav_discovery.py
@@ -153,13 +153,11 @@ def _scan_subdir_worker(
         try:
             result = _webdav.find_video_file(
                 subdir,
-                depth + 1,
-                visited,
-                True,
-                settings,
-                title_hint_tokens=hint_tokens,
-                title_hint_episode_tags=hint_episode_tags,
+                hints=_webdav.TitleHints(
+                    tokens=hint_tokens, episode_tags=hint_episode_tags
+                ),
                 min_video_size=min_video_size,
+                _state=(depth + 1, visited, True, settings),
             )
         except Exception as e:  # pylint: disable=broad-except
             xbmc.log(

--- a/tests/test_combined_search.py
+++ b/tests/test_combined_search.py
@@ -7,6 +7,7 @@ import threading
 from unittest.mock import MagicMock, patch
 
 from resources.lib.router import _search_all_providers
+from resources.lib.search_planner import SearchQuery
 
 
 def _make_result(title, link, indexer="TestIndexer"):
@@ -97,7 +98,7 @@ def test_both_providers_returns_combined_results(mock_addon, mock_prowlarr, mock
         nzbhydra_enabled="true", prowlarr_enabled="true"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None
     assert len(results) == 2
@@ -119,12 +120,14 @@ def test_episode_passes_explicit_tvdb_to_providers(
     )
 
     _search_all_providers(
-        "episode",
-        "Silo",
-        imdb="tt14688458",
-        tvdb="305288",
-        season="2",
-        episode="5",
+        SearchQuery(
+            "episode",
+            "Silo",
+            imdb="tt14688458",
+            tvdb="305288",
+            season="2",
+            episode="5",
+        )
     )
 
     mock_resolve.assert_not_called()
@@ -142,12 +145,14 @@ def test_episode_resolves_tvdb_when_absent(mock_addon, mock_prowlarr, mock_resol
     )
 
     _search_all_providers(
-        "episode",
-        "Silo",
-        imdb="tt14688458",
-        tmdb_id="125988",
-        season="2",
-        episode="5",
+        SearchQuery(
+            "episode",
+            "Silo",
+            imdb="tt14688458",
+            tmdb_id="125988",
+            season="2",
+            episode="5",
+        )
     )
 
     assert mock_resolve.called
@@ -162,7 +167,7 @@ def test_movie_search_does_not_resolve_tvdb(mock_addon, mock_prowlarr, mock_reso
         nzbhydra_enabled="false", prowlarr_enabled="true"
     )
 
-    _search_all_providers("movie", "The Matrix", imdb="tt0133093")
+    _search_all_providers(SearchQuery("movie", "The Matrix", imdb="tt0133093"))
 
     mock_resolve.assert_not_called()
     assert mock_prowlarr.call_args.kwargs["tvdb"] == ""
@@ -180,7 +185,14 @@ def test_episode_unresolved_tvdb_falls_through_empty(
     )
 
     _search_all_providers(
-        "episode", "Silo", imdb="tt14688458", tmdb_id="125988", season="2", episode="5"
+        SearchQuery(
+            "episode",
+            "Silo",
+            imdb="tt14688458",
+            tmdb_id="125988",
+            season="2",
+            episode="5",
+        )
     )
 
     assert mock_prowlarr.call_args.kwargs["tvdb"] == ""
@@ -197,7 +209,7 @@ def test_both_providers_deduplicates_by_link(mock_addon, mock_prowlarr, mock_hyd
         nzbhydra_enabled="true", prowlarr_enabled="true"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None
     assert len(results) == 1, "Duplicate link must be dropped"
@@ -228,7 +240,7 @@ def test_both_top_level_providers_run_concurrently(
     mock_hydra.side_effect = hydra_search
     mock_prowlarr.side_effect = prowlarr_search
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None
     assert len(results) == 2
@@ -273,7 +285,7 @@ def test_concurrent_provider_search_uses_snapshot_settings_getter(
     mock_prowlarr.side_effect = prowlarr_search
 
     results, error = _search_all_providers(
-        "movie", "The Matrix", settings_getter=setting
+        SearchQuery("movie", "The Matrix"), settings_getter=setting
     )
 
     assert error is None
@@ -292,7 +304,7 @@ def test_only_nzbhydra_enabled(mock_addon, mock_hydra):
         nzbhydra_enabled="true", prowlarr_enabled="false"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None
     assert len(results) == 1
@@ -306,7 +318,7 @@ def test_single_provider_exception_returns_provider_error(mock_addon, mock_hydra
         nzbhydra_enabled="true", prowlarr_enabled="false"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert not results
     assert error == "NZBHydra2 search failed: boom"
@@ -319,7 +331,7 @@ def test_only_prowlarr_enabled(mock_addon, mock_prowlarr):
         nzbhydra_enabled="false", prowlarr_enabled="true"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None
     assert len(results) == 1
@@ -335,7 +347,7 @@ def test_neither_provider_enabled_returns_error(mock_addon):
         nzbhydra_enabled="false", prowlarr_enabled="false"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert not results
     assert error is not None
@@ -355,7 +367,7 @@ def test_hydra_fails_prowlarr_succeeds_returns_prowlarr_results(
         nzbhydra_enabled="true", prowlarr_enabled="true"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None, "Should not error when at least one provider succeeded"
     assert len(results) == 1
@@ -374,7 +386,7 @@ def test_prowlarr_fails_hydra_succeeds_returns_hydra_results(
         nzbhydra_enabled="true", prowlarr_enabled="true"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None, "Should not error when at least one provider succeeded"
     assert len(results) == 1
@@ -391,7 +403,7 @@ def test_provider_exception_preserves_other_provider_results(
         nzbhydra_enabled="true", prowlarr_enabled="true"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None, "Should not error when at least one provider succeeded"
     assert len(results) == 1
@@ -408,7 +420,7 @@ def test_all_providers_fail_returns_first_error(mock_addon, mock_prowlarr, mock_
         nzbhydra_enabled="true", prowlarr_enabled="true"
     )
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert not results
     assert error == "NZBHydra unavailable"

--- a/tests/test_direct_indexers.py
+++ b/tests/test_direct_indexers.py
@@ -5,6 +5,8 @@ import time
 from threading import Event, Lock
 from unittest.mock import MagicMock, patch
 
+from resources.lib.search_planner import SearchQuery
+
 
 def _addon_with_settings(values):
     addon = MagicMock()
@@ -379,7 +381,7 @@ def test_search_direct_indexers_movie_uses_imdb_when_present(
     mock_http.return_value = ONE_RESULT_RSS
 
     results, error = search_direct_indexers(
-        "movie", "The Matrix", year="1999", imdb="tt0133093"
+        SearchQuery("movie", "The Matrix", year="1999", imdb="tt0133093")
     )
 
     assert error is None
@@ -412,7 +414,7 @@ def test_search_direct_indexers_episode_uses_tvsearch_params(
     mock_http.return_value = ONE_RESULT_RSS
 
     results, error = search_direct_indexers(
-        "episode", "Breaking Bad", season="5", episode="14"
+        SearchQuery("episode", "Breaking Bad", season="5", episode="14")
     )
 
     assert error is None
@@ -447,12 +449,14 @@ def test_search_direct_indexers_episode_prefers_tvdbid(
     mock_http.return_value = ONE_RESULT_RSS
 
     results, error = search_direct_indexers(
-        "episode",
-        "Breaking Bad",
-        imdb="tt0903747",
-        tvdb="81189",
-        season="5",
-        episode="14",
+        SearchQuery(
+            "episode",
+            "Breaking Bad",
+            imdb="tt0903747",
+            tvdb="81189",
+            season="5",
+            episode="14",
+        )
     )
 
     assert error is None
@@ -482,7 +486,9 @@ def test_search_direct_indexers_imdb_empty_retries_with_title(
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
     mock_http.side_effect = [EMPTY_RSS, ONE_RESULT_RSS]
 
-    results, error = search_direct_indexers("movie", "The Matrix", imdb="tt0133093")
+    results, error = search_direct_indexers(
+        SearchQuery("movie", "The Matrix", imdb="tt0133093")
+    )
 
     assert error is None
     assert len(results) == 1
@@ -515,7 +521,9 @@ def test_search_direct_indexers_uses_planner_for_host_fallback(
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
     mock_http.return_value = ONE_RESULT_RSS
 
-    results, error = search_direct_indexers("movie", "The Matrix", imdb="tt0133093")
+    results, error = search_direct_indexers(
+        SearchQuery("movie", "The Matrix", imdb="tt0133093")
+    )
 
     assert error is None
     assert len(results) == 1
@@ -548,7 +556,9 @@ def test_search_direct_indexers_passes_supported_movie_year_to_planner(
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
     mock_http.return_value = ONE_RESULT_RSS
 
-    results, error = search_direct_indexers("movie", "The Odyssey", year="2026")
+    results, error = search_direct_indexers(
+        SearchQuery("movie", "The Odyssey", year="2026")
+    )
 
     assert error is None
     assert len(results) == 1
@@ -578,7 +588,7 @@ def test_search_direct_indexers_allows_large_result_limit_up_to_ten_thousand(
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "2500"})
     mock_http.return_value = ONE_RESULT_RSS
 
-    results, error = search_direct_indexers("movie", "Terminator 2")
+    results, error = search_direct_indexers(SearchQuery("movie", "Terminator 2"))
 
     assert error is None
     assert len(results) == 1
@@ -606,7 +616,9 @@ def test_search_direct_indexers_normalizes_injected_max_results(
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "999"})
     mock_http.return_value = ONE_RESULT_RSS
 
-    results, error = search_direct_indexers("movie", "Terminator 2", max_results="many")
+    results, error = search_direct_indexers(
+        SearchQuery("movie", "Terminator 2"), max_results="many"
+    )
 
     assert error is None
     assert len(results) == 1
@@ -637,7 +649,7 @@ def test_search_direct_indexers_skips_when_caps_have_no_supported_query(
     ]
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
 
-    results, error = search_direct_indexers("movie", "The Matrix")
+    results, error = search_direct_indexers(SearchQuery("movie", "The Matrix"))
 
     assert not results
     assert error is None
@@ -669,7 +681,7 @@ def test_search_direct_indexers_partial_failure_keeps_successful_results(
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
     mock_http.side_effect = [RuntimeError("down"), ONE_RESULT_RSS]
 
-    results, error = search_direct_indexers("movie", "The Matrix")
+    results, error = search_direct_indexers(SearchQuery("movie", "The Matrix"))
 
     assert error is None
     assert len(results) == 1
@@ -713,7 +725,7 @@ def test_search_direct_indexers_fans_out_concurrently(mock_xbmcaddon, mock_confi
         return ([{"title": indexer["label"], "link": indexer["id"]}], None)
 
     with patch("resources.lib.direct_indexers._search_one_indexer", new=slow_search):
-        results, error = search_direct_indexers("movie", "The Matrix")
+        results, error = search_direct_indexers(SearchQuery("movie", "The Matrix"))
     returned_at = time.monotonic()
 
     assert error is None
@@ -766,7 +778,7 @@ def test_search_direct_indexers_marks_incomplete_futures_timed_out(
         "resources.lib.direct_indexers._DIRECT_FANOUT_TIMEOUT", 0.05, create=True
     ):
         started = time.monotonic()
-        results, error = search_direct_indexers("movie", "The Matrix")
+        results, error = search_direct_indexers(SearchQuery("movie", "The Matrix"))
         elapsed = time.monotonic() - started
 
     assert not results
@@ -794,7 +806,7 @@ def test_search_direct_indexers_all_failures_return_error(
     mock_xbmcaddon.Addon.return_value = _addon_with_settings({"max_results": "25"})
     mock_http.side_effect = RuntimeError("down")
 
-    results, error = search_direct_indexers("movie", "The Matrix")
+    results, error = search_direct_indexers(SearchQuery("movie", "The Matrix"))
 
     assert not results
     assert error == "Direct indexer Bad unavailable: down"

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -28,6 +28,7 @@ from resources.lib.router import (
     parse_route,
     route,
 )
+from resources.lib.search_planner import SearchQuery
 
 
 def test_parse_route_root():
@@ -275,24 +276,28 @@ def test_search_all_providers_calls_direct_indexers_when_enabled(mock_addon):
         },
     ):
         results, error = _search_all_providers(
+            SearchQuery(
+                "episode",
+                "Breaking Bad",
+                year="2008",
+                imdb="tt0903747",
+                season="5",
+                episode="14",
+            )
+        )
+
+    assert error is None
+    assert len(results) == 1
+    direct_search.assert_called_once_with(
+        SearchQuery(
             "episode",
             "Breaking Bad",
             year="2008",
             imdb="tt0903747",
             season="5",
             episode="14",
-        )
-
-    assert error is None
-    assert len(results) == 1
-    direct_search.assert_called_once_with(
-        "episode",
-        "Breaking Bad",
-        year="2008",
-        imdb="tt0903747",
-        season="5",
-        episode="14",
-        tvdb="",
+            tvdb="",
+        ),
         indexers=ANY,
         max_results=ANY,
     )
@@ -310,7 +315,7 @@ def test_search_all_providers_treats_missing_hydra_enabled_as_disabled(mock_addo
         "resources.lib.hydra.search_hydra",
         side_effect=AssertionError("Hydra should default disabled"),
     ):
-        results, error = _search_all_providers("movie", "The Matrix")
+        results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert not results
     assert "No search providers enabled" in error
@@ -330,7 +335,7 @@ def test_search_all_providers_no_provider_error_mentions_direct_indexers(
     }.get(key, "")
     mock_addon.return_value = addon
 
-    results, error = _search_all_providers("movie", "The Matrix")
+    results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert not results
     assert "direct indexers" in error
@@ -363,7 +368,7 @@ def test_search_all_providers_uses_defaults_when_setting_read_raises(mock_addon)
     )
 
     with patch("resources.lib.hydra.search_hydra", hydra_search):
-        results, error = _search_all_providers("movie", "The Matrix")
+        results, error = _search_all_providers(SearchQuery("movie", "The Matrix"))
 
     assert error is None
     assert len(results) == 1
@@ -403,7 +408,7 @@ def test_search_all_providers_uses_default_for_one_snapshot_setting_failure():
 
     with patch("resources.lib.hydra.search_hydra", hydra_search):
         results, error = _search_all_providers(
-            "movie", "The Matrix", settings_getter=setting
+            SearchQuery("movie", "The Matrix"), settings_getter=setting
         )
 
     assert error is None
@@ -444,7 +449,7 @@ def test_search_all_providers_uses_script_settings_getter_without_kodi_addon(
 
     with patch("resources.lib.hydra.search_hydra", hydra_search):
         results, error = _search_all_providers(
-            "movie", "The Odyssey", settings_getter=setting
+            SearchQuery("movie", "The Odyssey"), settings_getter=setting
         )
 
     assert error is None
@@ -509,7 +514,8 @@ def test_search_all_providers_logs_provider_timing(mock_log_timing):
 
         with patch(patch_path, search_mock):
             results, error = _search_all_providers(
-                "movie", "The Matrix", settings_getter=setting(provider_key)
+                SearchQuery("movie", "The Matrix"),
+                settings_getter=setting(provider_key),
             )
 
         assert error is None
@@ -540,7 +546,7 @@ def test_search_all_providers_logs_provider_timing_for_errors(mock_log_timing):
 
     with patch("resources.lib.hydra.search_hydra", hydra_search):
         results, error = _search_all_providers(
-            "movie", "The Matrix", settings_getter=setting
+            SearchQuery("movie", "The Matrix"), settings_getter=setting
         )
 
     assert not results
@@ -571,7 +577,7 @@ def test_search_all_providers_logs_provider_timing_for_exceptions(mock_log_timin
 
     with patch("resources.lib.hydra.search_hydra", hydra_search):
         results, error = _search_all_providers(
-            "movie", "The Matrix", settings_getter=setting
+            SearchQuery("movie", "The Matrix"), settings_getter=setting
         )
 
     assert not results
@@ -2203,9 +2209,9 @@ def test_handle_script_play_recovers_episode_numbers_from_listitem(
     _handle_script_play({"type": "episode", "imdb": "tt9813792", "tmdb_id": "124364"})
 
     mock_search.assert_called_once()
-    kwargs = mock_search.call_args.kwargs
-    assert kwargs["season"] == "3"
-    assert kwargs["episode"] == "5"
+    query = mock_search.call_args.args[0]
+    assert query.season == "3"
+    assert query.episode == "5"
 
 
 @patch("xbmcaddon.Addon")
@@ -2241,9 +2247,9 @@ def test_handle_script_play_recovers_episode_numbers_from_container_listitem(
     _handle_script_play({"type": "episode", "imdb": "tt9813792", "tmdb_id": "124364"})
 
     mock_search.assert_called_once()
-    kwargs = mock_search.call_args.kwargs
-    assert kwargs["season"] == "3"
-    assert kwargs["episode"] == "5"
+    query = mock_search.call_args.args[0]
+    assert query.season == "3"
+    assert query.episode == "5"
 
 
 @patch("xbmcaddon.Addon")
@@ -2280,9 +2286,9 @@ def test_handle_script_play_listitem_labels_are_atomic_per_source(
 
     _handle_script_play({"type": "episode", "imdb": "tt9813792", "tmdb_id": "124364"})
 
-    kwargs = mock_search.call_args.kwargs
-    assert kwargs["season"] == "3"
-    assert kwargs["episode"] == "5"
+    query = mock_search.call_args.args[0]
+    assert query.season == "3"
+    assert query.episode == "5"
 
 
 @patch("xbmcaddon.Addon")
@@ -2321,9 +2327,9 @@ def test_handle_script_play_skips_stale_root_for_title_matching_root(
 
     _handle_script_play({"type": "episode", "imdb": "tt9813792", "tmdb_id": "124364"})
 
-    kwargs = mock_search.call_args.kwargs
-    assert kwargs["season"] == "3"
-    assert kwargs["episode"] == "5"
+    query = mock_search.call_args.args[0]
+    assert query.season == "3"
+    assert query.episode == "5"
 
 
 @patch("xbmcaddon.Addon")
@@ -2357,9 +2363,9 @@ def test_handle_script_play_ignores_listitem_episode_for_different_show(
     _handle_script_play({"type": "episode", "imdb": "tt9813792", "tmdb_id": "124364"})
 
     mock_search.assert_called_once()
-    kwargs = mock_search.call_args.kwargs
-    assert kwargs["season"] == ""
-    assert kwargs["episode"] == ""
+    query = mock_search.call_args.args[0]
+    assert query.season == ""
+    assert query.episode == ""
 
 
 @patch(

--- a/tests/test_search_planner.py
+++ b/tests/test_search_planner.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 nzbdav contributors
 
-from resources.lib.search_planner import plan_newznab_search
+from resources.lib.search_planner import SearchQuery, plan_newznab_search
 
 
 def _supported_caps():
@@ -19,9 +19,7 @@ def test_movie_with_supported_imdb_uses_movie_id():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="movie",
-        title="The Matrix",
-        imdb="tt0133093",
+        query=SearchQuery(search_type="movie", title="The Matrix", imdb="tt0133093"),
         caps=_supported_caps(),
         api_key="secret",
         max_results=42,
@@ -48,8 +46,7 @@ def test_movie_title_on_nzbgeek_falls_back_to_search():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.nzbgeek.info",
-        search_type="movie",
-        title="The Matrix",
+        query=SearchQuery(search_type="movie", title="The Matrix"),
         caps=_supported_caps(),
         api_key="secret",
         max_results=25,
@@ -68,8 +65,7 @@ def test_movie_title_ampersand_stripped_from_query():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="movie",
-        title="Your Friends & Neighbors",
+        query=SearchQuery(search_type="movie", title="Your Friends & Neighbors"),
         caps=_supported_caps(),
         api_key="secret",
         max_results=25,
@@ -84,10 +80,9 @@ def test_episode_title_ampersand_stripped_from_query():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="episode",
-        title="Will & Grace",
-        season="1",
-        episode="1",
+        query=SearchQuery(
+            search_type="episode", title="Will & Grace", season="1", episode="1"
+        ),
         caps=_supported_caps(),
         api_key="secret",
         max_results=25,
@@ -109,12 +104,14 @@ def test_episode_prefers_tvdbid_when_supported_and_present():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="episode",
-        title="Silo",
-        imdb="tt14688458",
-        tvdb="305288",
-        season="2",
-        episode="5",
+        query=SearchQuery(
+            search_type="episode",
+            title="Silo",
+            imdb="tt14688458",
+            tvdb="305288",
+            season="2",
+            episode="5",
+        ),
         caps=_supported_caps_with_tvdbid(),
         api_key="secret",
         max_results=10,
@@ -141,12 +138,14 @@ def test_episode_uses_imdbid_when_tvdbid_not_in_caps():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="episode",
-        title="Silo",
-        imdb="tt14688458",
-        tvdb="305288",
-        season="2",
-        episode="5",
+        query=SearchQuery(
+            search_type="episode",
+            title="Silo",
+            imdb="tt14688458",
+            tvdb="305288",
+            season="2",
+            episode="5",
+        ),
         caps=_supported_caps(),  # tvsearch caps lack "tvdbid"
         api_key="secret",
         max_results=10,
@@ -161,11 +160,13 @@ def test_episode_without_tvdb_is_unchanged():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="episode",
-        title="Silo",
-        imdb="tt14688458",
-        season="2",
-        episode="5",
+        query=SearchQuery(
+            search_type="episode",
+            title="Silo",
+            imdb="tt14688458",
+            season="2",
+            episode="5",
+        ),
         caps=_supported_caps_with_tvdbid(),
         api_key="secret",
         max_results=10,
@@ -180,11 +181,13 @@ def test_episode_tvdb_id_sanitized_to_digits():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="episode",
-        title="Silo",
-        tvdb="tvdb-305288",
-        season="2",
-        episode="5",
+        query=SearchQuery(
+            search_type="episode",
+            title="Silo",
+            tvdb="tvdb-305288",
+            season="2",
+            episode="5",
+        ),
         caps=_supported_caps_with_tvdbid(),
         api_key="secret",
         max_results=10,
@@ -199,12 +202,14 @@ def test_missing_caps_episode_prefers_tvdbid_when_present():
     plan = plan_newznab_search(
         provider_kind="nzbhydra2",
         host="https://hydra.test",
-        search_type="episode",
-        title="Silo",
-        imdb="tt14688458",
-        tvdb="305288",
-        season="2",
-        episode="5",
+        query=SearchQuery(
+            search_type="episode",
+            title="Silo",
+            imdb="tt14688458",
+            tvdb="305288",
+            season="2",
+            episode="5",
+        ),
         caps=None,
         api_key="secret",
         max_results=10,
@@ -222,11 +227,13 @@ def test_episode_uses_tvsearch_when_supported():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="episode",
-        title="Silo",
-        imdb="tt14688458",
-        season="2",
-        episode="5",
+        query=SearchQuery(
+            search_type="episode",
+            title="Silo",
+            imdb="tt14688458",
+            season="2",
+            episode="5",
+        ),
         caps=_supported_caps(),
         api_key="secret",
         max_results=10,
@@ -256,8 +263,7 @@ def test_hydra_uses_provider_caps_without_direct_host_fallback():
     plan = plan_newznab_search(
         provider_kind="nzbhydra2",
         host="https://api.nzbgeek.info",
-        search_type="movie",
-        title="The Matrix",
+        query=SearchQuery(search_type="movie", title="The Matrix"),
         caps=_supported_caps(),
         api_key="secret",
         max_results=25,
@@ -275,9 +281,7 @@ def test_movie_title_includes_year_when_provider_supports_it():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="movie",
-        title="The Odyssey",
-        year="2026",
+        query=SearchQuery(search_type="movie", title="The Odyssey", year="2026"),
         caps=caps,
         api_key="secret",
         max_results=25,
@@ -297,10 +301,12 @@ def test_generic_movie_fallback_includes_year_when_supported():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="movie",
-        title="The Odyssey",
-        year="2026",
-        imdb="tt33764258",
+        query=SearchQuery(
+            search_type="movie",
+            title="The Odyssey",
+            year="2026",
+            imdb="tt33764258",
+        ),
         caps=caps,
         api_key="secret",
         max_results=25,
@@ -317,8 +323,7 @@ def test_missing_caps_keeps_conservative_defaults():
     movie = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="movie",
-        title="The Matrix",
+        query=SearchQuery(search_type="movie", title="The Matrix"),
         caps=None,
         api_key="secret",
         max_results=25,
@@ -326,11 +331,13 @@ def test_missing_caps_keeps_conservative_defaults():
     episode = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="episode",
-        title="Silo",
-        imdb="tt14688458",
-        season="2",
-        episode="5",
+        query=SearchQuery(
+            search_type="episode",
+            title="Silo",
+            imdb="tt14688458",
+            season="2",
+            episode="5",
+        ),
         caps={},
         api_key="secret",
         max_results=25,
@@ -357,8 +364,7 @@ def test_movie_title_without_supported_search_returns_no_query():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="movie",
-        title="The Matrix",
+        query=SearchQuery(search_type="movie", title="The Matrix"),
         caps={
             "search_types": ["movie"],
             "supported_params": {"movie": ["imdbid"]},
@@ -376,8 +382,7 @@ def test_episode_without_tvsearch_or_search_returns_no_query():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.example.test",
-        search_type="episode",
-        title="Silo",
+        query=SearchQuery(search_type="episode", title="Silo"),
         caps={
             "search_types": ["movie"],
             "supported_params": {"movie": ["q", "imdbid"]},
@@ -395,8 +400,7 @@ def test_generic_search_without_q_does_not_include_unsupported_q():
     plan = plan_newznab_search(
         provider_kind="direct",
         host="https://api.nzbgeek.info",
-        search_type="movie",
-        title="The Matrix",
+        query=SearchQuery(search_type="movie", title="The Matrix"),
         caps={
             "search_types": ["search", "movie"],
             "supported_params": {"search": [], "movie": []},

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -14,6 +14,7 @@ from urllib.error import HTTPError
 
 import pytest
 from resources.lib.stream_proxy import _StreamHandler
+from resources.lib.webdav import TitleHints
 
 
 @pytest.fixture(autouse=True)
@@ -11275,7 +11276,9 @@ def test_select_live_fallback_refreshes_completed_standby_job():
     assert source["stream_headers"] == {"Authorization": "Basic fallback"}
     assert source["content_length"] == 10
     history.assert_called_once_with("nzo2")
-    find_video.assert_called_once_with("/content/movies/Fallback/", title_hint=None)
+    find_video.assert_called_once_with(
+        "/content/movies/Fallback/", hints=TitleHints(title_hint=None)
+    )
     stream_url.assert_called_once_with("/content/movies/Fallback/fallback.mkv")
     assert fetch_length.call_args[0] == (
         "http://webdav/fallback.mkv",
@@ -11531,7 +11534,7 @@ def test_standby_refresh_reuses_probe_bases_for_content_length_checks():
             {"Authorization": "Basic fallback"},
         )
 
-    def find_video_path(path, title_hint=None):
+    def find_video_path(path, hints=None):
         return "{}movie.mkv".format(path)
 
     with patch(
@@ -16015,7 +16018,7 @@ def test_standby_refresh_threads_source_title_as_find_video_file_hint():
     ):
         handler._refresh_standby_fallback_source(ctx, source)
 
-    assert find_video.call_args.kwargs["title_hint"] == (
+    assert find_video.call_args.kwargs["hints"].title_hint == (
         "The.Show.S03E07.1080p.WEB-DL.x264-GRP"
     )
 
@@ -16051,7 +16054,7 @@ def test_standby_refresh_passes_none_hint_when_source_title_absent():
     ):
         handler._refresh_standby_fallback_source(ctx, source)
 
-    assert find_video.call_args.kwargs["title_hint"] is None
+    assert find_video.call_args.kwargs["hints"].title_hint is None
 
 
 def test_storage_to_webdav_path_mnt_data_no_category():

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError
 
 from resources.lib.webdav import (
+    TitleHints,
     find_video_file,
     find_video_stream_for_folder,
     folder_video_total_bytes,
@@ -1466,7 +1467,9 @@ def test_find_video_file_prefers_title_hint_over_largest(mock_urlopen, mock_sett
     )
     mock_urlopen.return_value = _webdav_response(listing)
 
-    path = find_video_file("/content/Show/", title_hint="Show.S02E05.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Show/", hints=TitleHints(title_hint="Show.S02E05.1080p.WEB-DL")
+    )
 
     assert path == "/content/Show/Show.S02E05.1080p.mkv"
 
@@ -1548,7 +1551,9 @@ def test_find_video_file_hint_no_match_falls_back_to_largest(
     )
     mock_urlopen.return_value = _webdav_response(listing)
 
-    path = find_video_file("/content/Show/", title_hint="Show.S05E99.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Show/", hints=TitleHints(title_hint="Show.S05E99.1080p.WEB-DL")
+    )
 
     assert path == "/content/Show/Show.S02E06.1080p.mkv"
 
@@ -1593,7 +1598,9 @@ def test_find_video_file_prefers_hint_across_sibling_subfolders(
 
     mock_urlopen.side_effect = propfind
 
-    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Pack/", hints=TitleHints(title_hint="Show.S02E05.1080p.WEB-DL")
+    )
 
     assert path == "/content/Pack/E05/Show.S02E05.1080p.mkv"
 
@@ -1639,7 +1646,9 @@ def test_find_video_file_prefers_dir_tagged_episode_over_larger_sibling(
 
     mock_urlopen.side_effect = propfind
 
-    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Show/", hints=TitleHints(title_hint="Show.S01E02.1080p.WEB-DL")
+    )
 
     assert path == "/content/Show/Show.S01E02.1080p/video.mkv"
 
@@ -1687,7 +1696,8 @@ def test_find_video_file_nearest_dir_tag_not_masked_by_ancestor_pack(
     mock_urlopen.side_effect = propfind
 
     path = find_video_file(
-        "/content/Show.S01E02.Pack/", title_hint="Show.S01E02.1080p.WEB-DL"
+        "/content/Show.S01E02.Pack/",
+        hints=TitleHints(title_hint="Show.S01E02.1080p.WEB-DL"),
     )
 
     # NOT the larger S01E03: the nearest dir's own tag rules it out even
@@ -1727,7 +1737,9 @@ def test_find_video_file_grandparent_tag_matches_when_nearest_dir_generic(
 
     mock_urlopen.side_effect = propfind
 
-    path = find_video_file("/content/Show.S01E02/", title_hint="Show.S01E02.1080p")
+    path = find_video_file(
+        "/content/Show.S01E02/", hints=TitleHints(title_hint="Show.S01E02.1080p")
+    )
 
     assert path == "/content/Show.S01E02/1080p/video.mkv"
 
@@ -1759,7 +1771,8 @@ def test_find_video_file_basename_episode_overrides_parent_range_dir(
     mock_urlopen.return_value = _webdav_response(listing)
 
     path = find_video_file(
-        "/content/Show.S02E01-E10.Pack/", title_hint="Show.S02E05.1080p.WEB-DL"
+        "/content/Show.S02E01-E10.Pack/",
+        hints=TitleHints(title_hint="Show.S02E05.1080p.WEB-DL"),
     )
 
     # NOT the larger E07: its own basename tag rules it out even though the
@@ -1784,7 +1797,9 @@ def test_find_video_file_season_complete_parent_does_not_falsely_match(
     )
     mock_urlopen.return_value = _webdav_response(listing)
 
-    path = find_video_file("/content/Show.S01.Complete/", title_hint="Show.S01E02")
+    path = find_video_file(
+        "/content/Show.S01.Complete/", hints=TitleHints(title_hint="Show.S01E02")
+    )
 
     assert path == "/content/Show.S01.Complete/part2.mkv"
 
@@ -1824,7 +1839,9 @@ def test_find_video_file_recurses_past_wrong_episode_at_current_level(
 
     mock_urlopen.side_effect = propfind
 
-    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Pack/", hints=TitleHints(title_hint="Show.S02E05.1080p.WEB-DL")
+    )
 
     assert path == "/content/Pack/Extras/Show.S02E05.1080p.mkv"
 
@@ -1856,7 +1873,9 @@ def test_find_video_file_keeps_wrong_episode_when_siblings_have_no_match(
 
     mock_urlopen.side_effect = propfind
 
-    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Pack/", hints=TitleHints(title_hint="Show.S02E05.1080p.WEB-DL")
+    )
 
     assert path == "/content/Pack/Show.S02E06.1080p.mkv"
 
@@ -1878,7 +1897,9 @@ def test_find_video_file_matches_middle_episode_of_multi_ep_tag(
     )
     mock_urlopen.return_value = _webdav_response(listing)
 
-    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Show/", hints=TitleHints(title_hint="Show.S01E02.1080p.WEB-DL")
+    )
 
     assert path == "/content/Show/Show.S01E01E02E03.1080p.mkv"
 
@@ -1963,7 +1984,7 @@ def test_find_video_file_matches_nxn_episode_in_range_pack(mock_urlopen, mock_se
         ]
     )
     mock_urlopen.return_value = _webdav_response(listing)
-    path = find_video_file("/content/Show/", title_hint="Show 1x02")
+    path = find_video_file("/content/Show/", hints=TitleHints(title_hint="Show 1x02"))
     assert path == "/content/Show/Show.1x01-03.mkv"
 
 
@@ -1981,7 +2002,9 @@ def test_find_video_file_matches_episode_in_range_pack(mock_urlopen, mock_settin
         ]
     )
     mock_urlopen.return_value = _webdav_response(listing)
-    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Show/", hints=TitleHints(title_hint="Show.S01E02.1080p.WEB-DL")
+    )
     assert path == "/content/Show/Show.S01E01-E03.1080p.mkv"
 
 
@@ -2000,7 +2023,7 @@ def test_find_video_file_matches_nxnn_episode_notation(mock_urlopen, mock_settin
     )
     mock_urlopen.return_value = _webdav_response(listing)
 
-    path = find_video_file("/content/Show/", title_hint="Show 2x05")
+    path = find_video_file("/content/Show/", hints=TitleHints(title_hint="Show 2x05"))
 
     assert path == "/content/Show/Show.2x05.1080p.mkv"
 
@@ -2020,7 +2043,9 @@ def test_find_video_file_matches_nxnn_multi_episode_pack(mock_urlopen, mock_sett
     )
     mock_urlopen.return_value = _webdav_response(listing)
 
-    path = find_video_file("/content/Show/", title_hint="Doctor Who 2x06")
+    path = find_video_file(
+        "/content/Show/", hints=TitleHints(title_hint="Doctor Who 2x06")
+    )
 
     assert path == "/content/Show/Doctor.Who.2x05.2x06.mkv"
 
@@ -2057,7 +2082,9 @@ def test_find_video_file_keeps_larger_current_level_over_smaller_equalscore_sibl
 
     mock_urlopen.side_effect = propfind
 
-    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Pack/", hints=TitleHints(title_hint="Show.S02E05.1080p.WEB-DL")
+    )
 
     assert path == "/content/Pack/Show.Complete.1080p.BIG.mkv"
 
@@ -2122,7 +2149,9 @@ def test_find_video_file_recurses_past_generic_nonepisode_at_current_level(
 
     mock_urlopen.side_effect = propfind
 
-    path = find_video_file("/content/Pack/", title_hint="Show.S02E05.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Pack/", hints=TitleHints(title_hint="Show.S02E05.1080p.WEB-DL")
+    )
 
     assert path == "/content/Pack/E05/Show.S02E05.1080p.WEB-DL.mkv"
 
@@ -2152,7 +2181,9 @@ def test_find_video_file_movie_hint_keeps_largest_over_token_heavy_extra(
 
     path = find_video_file(
         "/content/Dune/",
-        title_hint="Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX-FraMeSToR",
+        hints=TitleHints(
+            title_hint="Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX-FraMeSToR"
+        ),
     )
 
     assert path == "/content/Dune/Dune.mkv"
@@ -2205,7 +2236,9 @@ def test_find_video_file_movie_hint_keeps_largest_across_sibling_subfolders(
 
     path = find_video_file(
         "/content/Dune/",
-        title_hint="Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX-FraMeSToR",
+        hints=TitleHints(
+            title_hint="Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX-FraMeSToR"
+        ),
     )
 
     assert path == "/content/Dune/Movie/Dune.mkv"
@@ -2274,7 +2307,9 @@ def test_find_video_file_aspect_ratio_file_does_not_beat_real_episode(
 
     mock_urlopen.side_effect = propfind
 
-    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Show/", hints=TitleHints(title_hint="Show.S01E02.1080p.WEB-DL")
+    )
 
     assert path == "/content/Show/Show.S01E02/video.16x9.mkv"
 
@@ -2313,7 +2348,7 @@ def test_find_video_file_movie_hint_recurses_past_zero_size_token_file(
     mock_urlopen.side_effect = propfind
 
     path = find_video_file(
-        "/content/Dune/", title_hint="Dune.Part.Two.2024.2160p.BluRay"
+        "/content/Dune/", hints=TitleHints(title_hint="Dune.Part.Two.2024.2160p.BluRay")
     )
 
     assert path == "/content/Dune/Feature/Dune.Part.Two.2024.mkv"
@@ -2355,7 +2390,9 @@ def test_find_video_file_repeated_season_pack_covers_middle_episode(
     )
     mock_urlopen.return_value = _webdav_response(listing)
 
-    path = find_video_file("/content/Show/", title_hint="Show.S01E02.1080p.WEB-DL")
+    path = find_video_file(
+        "/content/Show/", hints=TitleHints(title_hint="Show.S01E02.1080p.WEB-DL")
+    )
 
     assert path == "/content/Show/Show.S01E01-S01E03.1080p.mkv"
 
@@ -2549,7 +2586,7 @@ def test_find_video_file_floor_prefers_real_episode_over_root_episode_stub(
 
     path = find_video_file(
         "/content/Show/",
-        title_hint="Show.S01E05.1080p.WEB-DL",
+        hints=TitleHints(title_hint="Show.S01E05.1080p.WEB-DL"),
         min_video_size=2_000_000_000,
     )
 
@@ -2595,7 +2632,7 @@ def test_find_video_file_floor_prefers_real_file_over_episode_tagged_stub(
 
     path = find_video_file(
         "/content/Show/",
-        title_hint="Show.S01E05.1080p.WEB-DL",
+        hints=TitleHints(title_hint="Show.S01E05.1080p.WEB-DL"),
         min_video_size=2_000_000_000,
     )
 
@@ -2631,7 +2668,7 @@ def test_find_video_file_floor_demotes_same_level_episode_stub(
 
     path = find_video_file(
         "/content/Show/",
-        title_hint="Show.S01E05.1080p.WEB-DL",
+        hints=TitleHints(title_hint="Show.S01E05.1080p.WEB-DL"),
         min_video_size=2_000_000_000,
     )
 
@@ -2675,7 +2712,7 @@ def test_find_video_file_floor_adopts_size_unknown_exact_episode_child(
 
     path = find_video_file(
         "/content/Show/",
-        title_hint="Show.S01E05.1080p.WEB-DL",
+        hints=TitleHints(title_hint="Show.S01E05.1080p.WEB-DL"),
         min_video_size=2_000_000_000,
     )
 
@@ -2712,7 +2749,7 @@ def test_find_video_file_floor_keeps_requested_stub_over_same_level_wrong_episod
 
     path = find_video_file(
         "/content/Show/",
-        title_hint="Show.S01E05.1080p.WEB-DL",
+        hints=TitleHints(title_hint="Show.S01E05.1080p.WEB-DL"),
         min_video_size=2_000_000_000,
     )
 
@@ -2764,7 +2801,7 @@ def test_find_video_file_floor_keeps_requested_stub_over_sibling_wrong_episode(
 
     path = find_video_file(
         "/content/Show/",
-        title_hint="Show.S01E05.1080p.WEB-DL",
+        hints=TitleHints(title_hint="Show.S01E05.1080p.WEB-DL"),
         min_video_size=2_000_000_000,
     )
 
@@ -2815,7 +2852,7 @@ def test_find_video_file_floor_prefers_generic_real_over_sibling_episode_stub(
 
     path = find_video_file(
         "/content/Show/",
-        title_hint="Show.S01E05.1080p.WEB-DL",
+        hints=TitleHints(title_hint="Show.S01E05.1080p.WEB-DL"),
         min_video_size=2_000_000_000,
     )
 


### PR DESCRIPTION
Bundles search-request identity into a \`SearchQuery\` NamedTuple consumed symmetrically by NZBHydra2, Prowlarr, and direct indexers, plus \`TitleHints\` for WebDAV video discovery and \`CompletedVideoProbe\` for completed-job rejection. Part 3 of the complexity-reduction campaign (Phase A cluster A3). Independent of #378/#379.

## What changed
- \`search_planner.py\`: \`SearchQuery\` (8 identity fields); \`plan_newznab_search\` 12 params → 6.
- \`router.py\`: \`_search_all_providers(query, settings_getter=None)\` (9 params → 2, 66 nloc → <50 via pure-move \`_collect_provider_outcomes\` extraction); callers in \`router_play.py\`/\`router_scriptplay.py\` updated.
- \`direct_indexers.py\`: \`search_direct_indexers(query, indexers=None, max_results=None)\`.
- \`webdav.py\`: \`find_video_file(folder_path, hints=None, min_video_size=0, settings_getter=None, _state=None)\` — \`TitleHints\` bundle + recursion state folded into \`_state\`; depth cap, visited-set cycle guard, and encoding behavior byte-identical.
- \`resolver_completed.py\`: \`CompletedVideoProbe\` bundle for \`_completed_job_video_rejected\`.

## Complexity delta (codacy-cli lizard)
- shipped-lib parameter-count findings: **17 → 12**; \`_search_all_providers\` also off the nloc list. No findings added.

## Safety (fable contract review passed)
- All \`clean_search_query\` ampersand-stripping sites unmoved (keyword-search layer only; identity/submit paths untouched).
- Hydra/Prowlarr receive the same \`SearchQuery\`; provider request composition unreachable by this diff.
- \`just lint\` clean; \`just test\` 2234 passed / 2 skipped; no assertion weakened (direct-indexer assertion now pins all 8 fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)