### PR TITLE
🎨 Palette: Add focus boundaries to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -67,7 +67,10 @@
       <left>0</left><top>60</top><width>1910</width><height>975</height>
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
+      <onleft>50</onleft>
       <onright>60</onright>
+      <onup>50</onup>
+      <ondown>50</ondown>
       <scrolltime>200</scrolltime>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
@@ -243,6 +246,9 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <onleft>50</onleft>
+      <onright>60</onright>
+      <onup>60</onup>
+      <ondown>60</ondown>
       <showonepage>false</showonepage>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>


### PR DESCRIPTION
💡 **What:** Added self-referencing `<onleft>`, `<onup>`, and `<ondown>` navigation tags to the main list control (ID 50) and `<onright>`, `<onup>`, `<ondown>` to the scrollbar control (ID 60) in `results-dialog.xml`.

🎯 **Why:** In Kodi XML skins, when explicit directional navigation bounds aren't defined at the edges of interactive controls, pressing the D-pad or arrow keys can cause the UI focus to escape into a dead zone or behave erratically.

📸 **Before/After:**
*   **Before:** Pressing 'Up' on the top item of the list, or 'Left' on the list, could send focus to an unpredictable location, making keyboard/remote navigation frustrating.
*   **After:** Navigation bounds are "trapped" within the intended interactive elements. Focus safely stays on the current control if there is no adjacent control in that direction.

♿ **Accessibility:** This directly fixes keyboard and remote-control accessibility by ensuring deterministic and predictable focus movement.

---
*PR created automatically by Jules for task [12981866957818181563](https://jules.google.com/task/12981866957818181563) started by @xbmc4lyfe*