### PR TITLE
refactor: split fallback job bookkeeping under the 500 file-nloc gate

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -304,18 +304,11 @@ from resources.lib.resolver_entry import (  # noqa: E402,F401
 )
 from resources.lib.resolver_fallback import (  # noqa: E402,F401
     _adopt_existing_fallback_job,
-    _await_fallback_worker_finish,
     _await_playback_start,
-    _cancel_fallback_job,
-    _cancel_fallback_submitted_jobs,
     _collect_fallback_candidate_jobs,
     _fallback_candidate_row,
-    _fallback_job_pending,
-    _fallback_job_value,
     _fallback_streams_enabled,
-    _fallback_submit_jobs_snapshot,
     _get_fallback_submit_delay_seconds,
-    _invoke_fallback_job_cancel,
     _load_and_submit_fallback_candidates,
     _lookup_existing_fallback_jobs,
     _notify_no_fallback_candidates,
@@ -328,10 +321,19 @@ from resources.lib.resolver_fallback import (  # noqa: E402,F401
     _run_fallback_on_append_hook,
     _signal_fallback_playback_started,
     _start_fallback_submit_worker,
-    _stop_fallback_submit_worker,
     _submit_fallback_candidates,
     _submit_one_fallback_candidate,
     _wait_prewarm_or_inactive,
+)
+from resources.lib.resolver_fallback_jobs import (  # noqa: E402,F401
+    _await_fallback_worker_finish,
+    _cancel_fallback_job,
+    _cancel_fallback_submitted_jobs,
+    _fallback_job_pending,
+    _fallback_job_value,
+    _fallback_submit_jobs_snapshot,
+    _invoke_fallback_job_cancel,
+    _stop_fallback_submit_worker,
 )
 from resources.lib.resolver_flow import (  # noqa: E402,F401
     _invoke_poll_until_ready,

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_fallback.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_fallback.py
@@ -547,7 +547,7 @@ def _start_fallback_submit_worker(
             else:
                 state["jobs"].append(job)
         if should_cancel:
-            _cancel_fallback_job(state, job)
+            _resolver._cancel_fallback_job(state, job)
             return
         _run_fallback_on_append_hook(state)
 
@@ -582,7 +582,7 @@ def _start_fallback_submit_worker(
                 ),
                 _resolver.xbmc.LOGWARNING,
             )
-            _cancel_fallback_submitted_jobs(state)
+            _resolver._cancel_fallback_submitted_jobs(state)
         finally:
             state["finished"].set()
 
@@ -603,113 +603,3 @@ def _start_fallback_submit_worker(
             _resolver.xbmc.LOGWARNING,
         )
     return state
-
-
-def _fallback_job_value(job, key, default=None):
-    if isinstance(job, dict):
-        return job.get(key, default)
-    return getattr(job, key, default)
-
-
-def _fallback_job_pending(job):
-    status = _fallback_job_value(job, "status")
-    if status is None:
-        status = _fallback_job_value(job, "state")
-    if status is None:
-        return True
-    return str(status).strip().lower() not in _resolver._FALLBACK_TERMINAL_STATUSES
-
-
-def _invoke_fallback_job_cancel(job, nzo_id, cancel_callable):
-    """Run the first applicable cancel strategy; True if one fired."""
-    if nzo_id and cancel_callable:
-        cancel_callable(nzo_id)
-        return True
-    if hasattr(job, "cancel"):
-        job.cancel()
-        return True
-    if hasattr(job, "abort"):
-        job.abort()
-        return True
-    return False
-
-
-def _cancel_fallback_job(state, job):
-    cancel_callable = state.get("cancel_job") or _resolver.cancel_job
-    if not _fallback_job_pending(job):
-        return False
-    nzo_id = _fallback_job_value(job, "nzo_id")
-    try:
-        return _invoke_fallback_job_cancel(job, nzo_id, cancel_callable)
-    except Exception as error:  # pylint: disable=broad-except
-        _resolver.xbmc.log(
-            "NZB-DAV: Failed to cancel fallback submit job {}: {}".format(
-                _resolver._redact_log(nzo_id or job), _resolver._redact_log(error)
-            ),
-            _resolver.xbmc.LOGWARNING,
-        )
-    return False
-
-
-def _cancel_fallback_submitted_jobs(state):
-    """Cancel submitted fallback jobs that are still pending or running."""
-    if not state:
-        return []
-    with state["lock"]:
-        jobs_to_cancel = list(state["jobs"])
-
-    cancelled = []
-    for job in jobs_to_cancel:
-        if _cancel_fallback_job(state, job):
-            cancelled.append(job)
-    return cancelled
-
-
-def _await_fallback_worker_finish(thread, finished, wait_seconds):
-    """Briefly wait for the fallback worker to finish, bounded by wait_seconds."""
-    if not thread or wait_seconds <= 0:
-        return
-    deadline = _resolver.time.monotonic() + max(0, wait_seconds)
-    while thread.is_alive():
-        remaining = deadline - _resolver.time.monotonic()
-        if remaining <= 0:
-            break
-        if finished and finished.wait(min(0.05, remaining)):
-            break
-
-
-def _fallback_submit_jobs_snapshot(state, wait_seconds=0.5):
-    """Return fallback jobs submitted so far, waiting briefly for completion."""
-    if not state:
-        return []
-    _await_fallback_worker_finish(
-        state.get("thread"), state.get("finished"), wait_seconds
-    )
-    with state["lock"]:
-        return [dict(job) if isinstance(job, dict) else job for job in state["jobs"]]
-
-
-def _stop_fallback_submit_worker(
-    state,
-    cancel_submitted=False,
-    join_timeout=_resolver._FALLBACK_SHUTDOWN_JOIN_TIMEOUT,
-):
-    """Signal the fallback worker to stop and optionally cancel known jobs."""
-    if not state:
-        return []
-    state["stop"].set()
-    thread = state.get("thread")
-    if thread:
-        timeout = max(0, join_timeout)
-        thread.join(timeout=timeout)
-        if thread.is_alive():
-            _resolver.xbmc.log(
-                "NZB-DAV: Fallback submit worker still running after {:.2f}s; "
-                "resolve shutdown is continuing".format(timeout),
-                _resolver.xbmc.LOGWARNING,
-            )
-        else:
-            state["thread"] = None
-    if cancel_submitted:
-        _cancel_fallback_submitted_jobs(state)
-    return _resolver._fallback_submit_jobs_snapshot(state, wait_seconds=0)

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_fallback_jobs.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_fallback_jobs.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+# pylint: disable=cyclic-import
+
+"""Fallback submit-job bookkeeping: pending checks, cancel, snapshot, stop.
+
+Cohesive helper group split out of ``resolver_fallback`` to keep every module
+under Codacy's 500-NLOC file gate. References to names that live in (or are
+patched via) ``resolver`` are resolved at call time through
+``import resources.lib.resolver as _resolver`` so the suite's
+``@patch("resources.lib.resolver.<name>")`` decorators keep working with no
+top-level import cycle; same-module sibling helpers are called directly. Every
+moved name is re-exported from ``resolver``.
+"""
+
+import resources.lib.resolver as _resolver  # noqa: F401  pylint: disable=unused-import
+
+
+def _fallback_job_value(job, key, default=None):
+    if isinstance(job, dict):
+        return job.get(key, default)
+    return getattr(job, key, default)
+
+
+def _fallback_job_pending(job):
+    status = _fallback_job_value(job, "status")
+    if status is None:
+        status = _fallback_job_value(job, "state")
+    if status is None:
+        return True
+    return str(status).strip().lower() not in _resolver._FALLBACK_TERMINAL_STATUSES
+
+
+def _invoke_fallback_job_cancel(job, nzo_id, cancel_callable):
+    """Run the first applicable cancel strategy; True if one fired."""
+    if nzo_id and cancel_callable:
+        cancel_callable(nzo_id)
+        return True
+    if hasattr(job, "cancel"):
+        job.cancel()
+        return True
+    if hasattr(job, "abort"):
+        job.abort()
+        return True
+    return False
+
+
+def _cancel_fallback_job(state, job):
+    cancel_callable = state.get("cancel_job") or _resolver.cancel_job
+    if not _fallback_job_pending(job):
+        return False
+    nzo_id = _fallback_job_value(job, "nzo_id")
+    try:
+        return _invoke_fallback_job_cancel(job, nzo_id, cancel_callable)
+    except Exception as error:  # pylint: disable=broad-except
+        _resolver.xbmc.log(
+            "NZB-DAV: Failed to cancel fallback submit job {}: {}".format(
+                _resolver._redact_log(nzo_id or job), _resolver._redact_log(error)
+            ),
+            _resolver.xbmc.LOGWARNING,
+        )
+    return False
+
+
+def _cancel_fallback_submitted_jobs(state):
+    """Cancel submitted fallback jobs that are still pending or running."""
+    if not state:
+        return []
+    with state["lock"]:
+        jobs_to_cancel = list(state["jobs"])
+
+    cancelled = []
+    for job in jobs_to_cancel:
+        if _cancel_fallback_job(state, job):
+            cancelled.append(job)
+    return cancelled
+
+
+def _await_fallback_worker_finish(thread, finished, wait_seconds):
+    """Briefly wait for the fallback worker to finish, bounded by wait_seconds."""
+    if not thread or wait_seconds <= 0:
+        return
+    deadline = _resolver.time.monotonic() + max(0, wait_seconds)
+    while thread.is_alive():
+        remaining = deadline - _resolver.time.monotonic()
+        if remaining <= 0:
+            break
+        if finished and finished.wait(min(0.05, remaining)):
+            break
+
+
+def _fallback_submit_jobs_snapshot(state, wait_seconds=0.5):
+    """Return fallback jobs submitted so far, waiting briefly for completion."""
+    if not state:
+        return []
+    _await_fallback_worker_finish(
+        state.get("thread"), state.get("finished"), wait_seconds
+    )
+    with state["lock"]:
+        return [dict(job) if isinstance(job, dict) else job for job in state["jobs"]]
+
+
+def _stop_fallback_submit_worker(
+    state,
+    cancel_submitted=False,
+    join_timeout=_resolver._FALLBACK_SHUTDOWN_JOIN_TIMEOUT,
+):
+    """Signal the fallback worker to stop and optionally cancel known jobs."""
+    if not state:
+        return []
+    state["stop"].set()
+    thread = state.get("thread")
+    if thread:
+        timeout = max(0, join_timeout)
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            _resolver.xbmc.log(
+                "NZB-DAV: Fallback submit worker still running after {:.2f}s; "
+                "resolve shutdown is continuing".format(timeout),
+                _resolver.xbmc.LOGWARNING,
+            )
+        else:
+            state["thread"] = None
+    if cancel_submitted:
+        _cancel_fallback_submitted_jobs(state)
+    return _resolver._fallback_submit_jobs_snapshot(state, wait_seconds=0)


### PR DESCRIPTION
Brings `resolver_fallback.py` back under Codacy Lizard's 500 file-nloc limit (507 → ~420) ahead of the cloud-gate re-enable in #386. The finding is pre-existing on `main` (surfaced by a freshly-initialized codacy-cli lizard config that counts NLOC slightly differently than the run #382 documented); fixing it in its own PR keeps #386 focused.

## What changed (pure code motion)

The 8-function job cancel/snapshot/stop tail group (`_fallback_job_value`, `_fallback_job_pending`, `_invoke_fallback_job_cancel`, `_cancel_fallback_job`, `_cancel_fallback_submitted_jobs`, `_await_fallback_worker_finish`, `_fallback_submit_jobs_snapshot`, `_stop_fallback_submit_worker`) moves **verbatim** into new `resolver_fallback_jobs.py`, following the established sibling idiom (call-time name resolution via `import resources.lib.resolver as _resolver`; all 8 names re-exported from `resolver.py`). The group was chosen because its call graph is closed: internal calls stay direct, and every outward reference already went through `_resolver.`.

Only two lines outside the move changed: the `_append_job`/`_worker` closures in `_start_fallback_submit_worker` now call `_resolver._cancel_fallback_job` / `_resolver._cancel_fallback_submitted_jobs` — the same function objects via the surface (a patchability widening, not a behavior change; no test patches those names).

## Verification

- Moved block proven **byte-identical** to `origin/main` lines 608–715; remaining file proven identical minus the group plus the two prefix edits.
- Adversarial review (all clean): load-order safety of the import-time default arg (`_FALLBACK_SHUTDOWN_JOIN_TIMEOUT` bound at `resolver.py:77`, new import at `:328`; live-import proof `__defaults__ == (False, 10)`); patch-surface completeness (all `@patch("resources.lib.resolver.*")` targets and test from-imports still resolve; no module imports `resolver_fallback` directly); function-object identity across the surface; sibling-idiom parity with `resolver_queueclear.py`; vermin 3.8-clean.
- `just lint`: pylint 10.00/10, ruff/black clean. `just test`: **2171 passed, 2 skipped, 0 failed**.
- codacy-cli lizard SARIF: `resolver_fallback.py` no longer flagged; `resolver_fallback_jobs.py` clean. The one remaining shipped-lib file-nloc finding on `main` (`fallback_streams_select.py` 548) is fixed by #386's A4 split, so shipped-lib file-nloc is fully clean once both merge.

Independent of #386 (bases `main`; merges cleanly either order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
