### PR TITLE
🎨 Palette: [UX improvement] Add boundary focus trap to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -67,7 +67,10 @@
       <left>0</left><top>60</top><width>1910</width><height>975</height>
       <orientation>vertical</orientation>
       <pagecontrol>60</pagecontrol>
+      <onleft>50</onleft>
       <onright>60</onright>
+      <onup>50</onup>
+      <ondown>50</ondown>
       <scrolltime>200</scrolltime>
 
       <!-- ==================== UNFOCUSED ROW ==================== -->
@@ -243,6 +246,9 @@
       <left>1910</left><top>60</top><width>10</width><height>975</height>
       <orientation>vertical</orientation>
       <onleft>50</onleft>
+      <onright>60</onright>
+      <onup>60</onup>
+      <ondown>60</ondown>
       <showonepage>false</showonepage>
       <texturesliderbackground colordiffuse="00FFFFFF">white.png</texturesliderbackground>
       <texturesliderbar colordiffuse="FF4A5568">white.png</texturesliderbar>


### PR DESCRIPTION
Added self-referencing explicit directional navigation tags to the boundary edges of the custom UI list and scrollbar components in `results-dialog.xml` to prevent keyboard/remote focus from unpredictably escaping.

---
*PR created automatically by Jules for task [2501106363004957713](https://jules.google.com/task/2501106363004957713) started by @xbmc4lyfe*