### PR TITLE
feat(justfile): add deploy-addon, ci, version, and changelog recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,15 @@ These must stay true or Kodi playback, shutdown, or updates can break:
 just test          # Run all tests
 just lint          # ruff + black + pylint + vermin
 just lint-fix      # Auto-fix lint/format issues, then re-run just lint
+just ci            # Same checks as GitHub CI: lint + test + Python 3.8 compileall gate
 just release       # Build plugin.video.nzbdav.zip
 just ship          # test + release
+just deploy-addon  # Push the addon tree to the CoreELEC box and restart Kodi
+just version       # Print the current addon version from addon.xml
+just changelog     # Show the Kodi-visible addon changelog
 just docs          # Build the MkDocs docs site into ./site (strict)
 just docs-serve    # Serve the docs site locally with live reload
+just extreme-tests # Run the extreme end-to-end fault-recovery test
 just clean         # Remove __pycache__, .pytest_cache, zip
 just dist-clean    # clean + remove the generated docs site
 ```

--- a/justfile
+++ b/justfile
@@ -10,6 +10,9 @@ uvdev := "uv run --with-requirements requirements-dev.txt --no-project --python 
 # is not part of the addon runtime, so it uses requirements-docs.txt, not -dev.
 docs_run := "uv run --with-requirements requirements-docs.txt --no-project --python 3.12"
 
+# CoreELEC/Kodi box that receives `just deploy-addon` (override: COREELEC_HOST=user@host)
+coreelec_host := env_var_or_default("COREELEC_HOST", "root@coreelec.local")
+
 # Install local development dependencies needed by the other recipes
 make-dev:
     #!/usr/bin/env bash
@@ -256,6 +259,8 @@ setup-extreme-functional-test:
     echo "  1. Verify the file: cat $target"
     echo "  2. Run the test:    just extreme-functional-test"
 
+alias extreme-tests := extreme-functional-test
+
 # Run the extreme end-to-end fault-recovery test (20+ minutes, real Eweka, real Hydra).
 # Brings up a self-contained docker-compose stack, installs TMDBHelper from the
 # jurialmunkey repository and the nzbdav addon from `just repo-zip`, picks a random
@@ -292,12 +297,56 @@ lint-fix:
     {{uvdev}} ruff check repo/plugin.video.nzbdav/ tests/ tests-extensive/ scripts/ --fix
     {{uvdev}} black repo/plugin.video.nzbdav/ tests/ tests-extensive/ scripts/
 
+# Run the same checks as GitHub CI: lint + test + the Python 3.8 compat gate
+ci: lint test compat-3-8
+
+# Verify the addon runtime parses on the Python 3.8 floor (mirrors CI's compat-3-8 job)
+compat-3-8:
+    uv run --python 3.8 --no-project python -m compileall repo/plugin.video.nzbdav/
+
 # Build the addon zip for Kodi installation
 release:
     python3 scripts/build_zip.py
 
 # Run tests then build release
 ship: test release
+
+# Print the current addon version from addon.xml
+version:
+    @python3 -c "import xml.etree.ElementTree as ET; print(ET.parse('repo/plugin.video.nzbdav/addon.xml').getroot().get('version'))"
+
+# Show the Kodi-visible addon changelog (full version notes live in CHANGELOG.md)
+changelog:
+    @cat repo/plugin.video.nzbdav/changelog.txt
+
+# Backs up the installed addon to /tmp on the box first; addon settings under
+# userdata/addon_data are untouched. Restarts Kodi by default because plugin
+# code reloads per invocation but service/stream-proxy changes only apply
+# after a restart — pass `norestart` to skip that.
+# Deploy the addon tree to the Kodi box (override with COREELEC_HOST=user@host)
+deploy-addon restart="restart":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    host="{{coreelec_host}}"
+    addon="plugin.video.nzbdav"
+    dest="/storage/.kodi/addons/$addon"
+    stage="$dest.deploy-staging"
+
+    echo "Staging $addon on $host..."
+    tar -C repo -cf - --exclude='*__pycache__*' --exclude='*.pyc' --exclude='.DS_Store' "$addon" \
+        | ssh -o ConnectTimeout=10 "$host" "rm -rf '$stage' && mkdir -p '$stage' && tar -C '$stage' -xf -"
+
+    echo "Swapping in the new addon (backup kept in /tmp on the box)..."
+    ssh "$host" "if [ -d '$dest' ]; then mv '$dest' \"/tmp/$addon.\$(date +%Y%m%d-%H%M%S).bak\"; fi && mv '$stage/$addon' '$dest' && rmdir '$stage'"
+
+    if [ "{{restart}}" = "norestart" ]; then
+        echo "Deployed without restarting Kodi. Plugin code reloads per invocation;"
+        echo "service/proxy changes need: ssh $host 'systemctl restart kodi'"
+    else
+        echo "Restarting Kodi..."
+        ssh "$host" 'systemctl restart kodi'
+    fi
+    echo "Deployed $addon to $host."
 
 # Build the documentation site into ./site (mirrors the Docs GitHub Pages build)
 docs:

--- a/tests/test_justfile.py
+++ b/tests/test_justfile.py
@@ -149,3 +149,47 @@ def test_extreme_functional_test_recipe_preserves_exported_env_overrides():
     assert "env_snapshot" in body
     assert 'source "$env_file"' in body
     assert 'source "$env_snapshot"' in body
+
+
+def test_justfile_ci_recipe_mirrors_github_ci_jobs():
+    contents = Path(__file__).resolve().parents[1].joinpath("justfile").read_text()
+
+    # ci = lint + test + the 3.8 compileall gate, the same trio ci.yml runs.
+    assert re.search(r"^ci: lint test compat-3-8$", contents, re.M)
+    body = _recipe_body(contents, "compat-3-8")
+    assert "--python 3.8" in body
+    assert "compileall" in body
+    assert "repo/plugin.video.nzbdav/" in body
+
+
+def test_justfile_deploy_addon_backs_up_then_syncs_and_restarts():
+    contents = Path(__file__).resolve().parents[1].joinpath("justfile").read_text()
+    body = _recipe_body(contents, "deploy-addon")
+
+    # Backup-first, no __pycache__ shipped, and a Kodi restart by default so
+    # service.py changes actually take effect (skippable via `norestart`).
+    assert "/storage/.kodi/addons" in body
+    assert "__pycache__" in body
+    assert ".bak" in body
+    assert "systemctl restart kodi" in body
+    assert "norestart" in body
+
+
+def test_justfile_docs_recipe_builds_strictly_and_serve_serves():
+    contents = Path(__file__).resolve().parents[1].joinpath("justfile").read_text()
+
+    assert "mkdocs build --strict" in _recipe_body(contents, "docs")
+    assert "mkdocs serve" in _recipe_body(contents, "docs-serve")
+
+
+def test_justfile_version_and_changelog_read_addon_sources():
+    contents = Path(__file__).resolve().parents[1].joinpath("justfile").read_text()
+
+    assert "addon.xml" in _recipe_body(contents, "version")
+    assert "changelog.txt" in _recipe_body(contents, "changelog")
+
+
+def test_justfile_extreme_tests_alias_points_at_full_recipe():
+    contents = Path(__file__).resolve().parents[1].joinpath("justfile").read_text()
+
+    assert "alias extreme-tests := extreme-functional-test" in contents


### PR DESCRIPTION
## Summary

Rounds out the justfile to cover the full local dev loop:

- **`just deploy-addon`** — pushes `repo/plugin.video.nzbdav/` to the CoreELEC box (`root@coreelec.local`, override with `COREELEC_HOST=user@host`). Tar-over-ssh (no rsync needed on the box), stages into a `.deploy-staging` dir and `mv`-swaps so the installed addon is never half-copied, backs the old tree up to `/tmp` on the box first. Restarts Kodi by default so `service.py`/stream-proxy changes take effect; `just deploy-addon norestart` skips that (plugin code reloads per invocation). Addon settings under `userdata/addon_data` are untouched.
- **`just ci`** — the same trio GitHub CI runs: `lint` + `test` + a new `compat-3-8` recipe (Python 3.8 `compileall` of the addon runtime via uv).
- **`just version`** — prints the addon version from `addon.xml` (same ElementTree one-liner `release.yml` uses for its tag check).
- **`just changelog`** — shows the Kodi-visible `changelog.txt`.
- **`just extreme-tests`** — alias for `extreme-functional-test`.
- AGENTS.md Fast Commands updated; five meta-tests added in `tests/test_justfile.py` guarding the `ci` chain, deploy backup/restart behavior, docs recipes, and the version/changelog sources.

No workflow changes: `pages.yml` calls `mkdocs` directly and `ci.yml`/`release.yml` still invoke `just lint` / `just test`.

## Verification

- `just lint` — ruff, black, pylint 10.00/10, vermin 3.8 floor clean
- `just test` — 2182 passed, 2 skipped (includes the new meta-tests)
- `just compat-3-8` — compileall green on Python 3.8
- `just --list`, `just version` (1.2.5), `just changelog`, `just -n deploy-addon` all sane
- `deploy-addon` not yet smoke-run live: the CoreELEC box was offline during development

🤖 Generated with [Claude Code](https://claude.com/claude-code)