### PR TITLE
🛡️ Sentinel: [HIGH] Fix XXE Vulnerability in hydra.py

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/hydra.py
+++ b/repo/plugin.video.nzbdav/resources/lib/hydra.py
@@ -7,16 +7,6 @@ from datetime import datetime, timezone
 from urllib.error import URLError
 from urllib.parse import urlencode, urlparse
 
-try:
-    from defusedxml import ElementTree as element_tree
-    from defusedxml.common import DefusedXmlException as _UnsafeXmlError
-except ImportError:  # pragma: no cover - Kodi installs may not bundle defusedxml
-    from xml.etree import ElementTree as element_tree
-
-    class _UnsafeXmlError(ValueError):
-        """Raised when stdlib fallback rejects DTD/entity declarations."""
-
-
 import xbmc
 import xbmcaddon
 
@@ -38,6 +28,9 @@ from resources.lib.http_util import (
 from resources.lib.indexer_store import load_provider_caps, save_provider_caps
 from resources.lib.newznab_caps import fetch_caps
 from resources.lib.search_planner import SearchQuery, plan_newznab_search
+from resources.lib.xml_safety import ParseError as _XmlParseError
+from resources.lib.xml_safety import UnsafeXmlError as _UnsafeXmlError
+from resources.lib.xml_safety import safe_fromstring as _safe_fromstring
 
 NEWZNAB_NS = "http://www.newznab.com/DTD/2010/feeds/attributes/"
 
@@ -559,51 +552,11 @@ def _build_result(item):
     }
 
 
-def _build_xxe_safe_parser():
-    """Return an ElementTree XMLParser with external entities disabled.
-
-    ``xml.etree.ElementTree`` doesn't expose a ``resolve_entities=False``
-    knob directly, but the underlying expat parser can be told to
-    ignore DefaultHandler output and reject ExternalEntityRef callbacks.
-    A hostile NZBHydra2 instance (compromised, MITM'd, or simply
-    misbehaving) could otherwise coerce us into reading arbitrary
-    local files via an XXE payload. Mirrors webdav.py's WebDAV
-    PROPFIND parser for defense in depth.
-    """
-    parser = element_tree.XMLParser()  # nosec B314 — entities disabled below
-    try:
-        parser.parser.DefaultHandler = lambda _d: None
-        parser.parser.ExternalEntityRefHandler = lambda *_: False
-    except AttributeError:  # pragma: no cover — non-expat parser backend
-        pass
-    return parser
-
-
-def _contains_xml_declaration_markup(xml_text):
-    """Return true when XML text declares a DTD/entity block."""
-    if isinstance(xml_text, bytes):
-        probe = xml_text.lower()
-        return b"<!doctype" in probe or b"<!entity" in probe
-    probe = str(xml_text).lower()
-    return "<!doctype" in probe or "<!entity" in probe
-
-
-def _parse_hydra_xml(xml_text):
-    """Parse Hydra XML with DTD/entity expansion disabled."""
-    if getattr(element_tree, "__name__", "").startswith("defusedxml."):
-        return element_tree.fromstring(xml_text)
-    if _contains_xml_declaration_markup(xml_text):
-        raise _UnsafeXmlError("DTD and entity declarations are not allowed")
-    return element_tree.fromstring(
-        xml_text, parser=_build_xxe_safe_parser()
-    )  # nosec B314 — declarations rejected above and entities disabled when possible
-
-
 def _parse_results_checked(xml_text):
     """Parse Newznab XML and return (results, error_message)."""
     try:
-        root = _parse_hydra_xml(xml_text)
-    except (element_tree.ParseError, _UnsafeXmlError) as error:
+        root = _safe_fromstring(xml_text)
+    except (_XmlParseError, _UnsafeXmlError) as error:
         xbmc.log(
             "NZB-DAV: Failed to parse Hydra XML response: {}".format(error),
             xbmc.LOGERROR,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Custom fallback in `hydra.py` failed to protect against XML External Entity (XXE) attacks when `defusedxml` is not installed.
🎯 Impact: Local file disclosure / Billion laughs DoS by a hostile indexer.
🔧 Fix: Removed manual `XMLParser` fallbacks and migrated `hydra.py` to use `xml_safety.py`'s robust `safe_fromstring` method.
✅ Verification: Ran unit tests via `pytest` and linting via `ruff`/`black` to ensure compliance and correctness. Tests passed.

---
*PR created automatically by Jules for task [12167892422401430108](https://jules.google.com/task/12167892422401430108) started by @xbmc4lyfe*