### PR TITLE
🎨 Palette: [UX improvement] Enable zebra striping in results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -78,7 +78,7 @@
         <control type="image">
           <left>0</left><top>0</top><width>1910</width><height>66</height>
           <texture>white.png</texture>
-          <colordiffuse>FF0C0C10</colordiffuse>
+          <colordiffuse>$INFO[ListItem.Property(row_bg)]</colordiffuse>
         </control>
 
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->

--- a/tests/test_results_dialog_skin.py
+++ b/tests/test_results_dialog_skin.py
@@ -111,6 +111,14 @@ def test_focus_indicator_appearance_is_high_contrast_and_correctly_placed():
     # brighter than the focused fill it sits on (so focus is unmistakable).
     focused_bg = _row_background_color(focused)
     unfocused_bg = _row_background_color(unfocused)
+
+    # If the skin delegates unfocused_bg to a Python property (e.g., zebra striping),
+    # verify contrast against the primary python background constant.
+    if unfocused_bg == "$INFO[ListItem.Property(row_bg)]":
+        from resources.lib.results_dialog import _BG_A
+
+        unfocused_bg = _BG_A
+
     assert _FOCUS_ACCENT_COLOR not in (focused_bg, unfocused_bg)
     accent_lum = _perceived_luminance(_FOCUS_ACCENT_COLOR)
     assert accent_lum - _perceived_luminance(focused_bg) > 80

--- a/tests/test_results_dialog_skin.py
+++ b/tests/test_results_dialog_skin.py
@@ -112,17 +112,20 @@ def test_focus_indicator_appearance_is_high_contrast_and_correctly_placed():
     focused_bg = _row_background_color(focused)
     unfocused_bg = _row_background_color(unfocused)
 
+    unfocused_bgs = (unfocused_bg,)
+
     # If the skin delegates unfocused_bg to a Python property (e.g., zebra striping),
-    # verify contrast against the primary python background constant.
+    # verify contrast against both Python background constants.
     if unfocused_bg == "$INFO[ListItem.Property(row_bg)]":
-        from resources.lib.results_dialog import _BG_A
+        from resources.lib.results_dialog import _BG_A, _BG_B
 
-        unfocused_bg = _BG_A
+        unfocused_bgs = (_BG_A, _BG_B)
 
-    assert _FOCUS_ACCENT_COLOR not in (focused_bg, unfocused_bg)
+    assert _FOCUS_ACCENT_COLOR not in (focused_bg,) + unfocused_bgs
     accent_lum = _perceived_luminance(_FOCUS_ACCENT_COLOR)
     assert accent_lum - _perceived_luminance(focused_bg) > 80
-    assert accent_lum - _perceived_luminance(unfocused_bg) > 80
+    for bg in unfocused_bgs:
+        assert accent_lum - _perceived_luminance(bg) > 80
 
     # Render order: the bar must come AFTER the focused background image so it
     # paints on top of it (Kodi draws controls in document order).


### PR DESCRIPTION
### 💡 What
Replaced the hardcoded unfocused background color (`FF0C0C10`) in the `results-dialog.xml` skin with the dynamic `$INFO[ListItem.Property(row_bg)]` property to enable zebra striping.

### 🎯 Why
Long lists of results with similar dark backgrounds are hard to scan. By delegating the row color to the backend logic (which alternates between `_BG_A` and `_BG_B`), we get a subtle zebra striping effect. This significantly improves the readability and scannability of the search results, making the interface more pleasant to use.

### 📸 Before/After
**Before:** All unfocused rows shared the exact same flat, dark color, making it hard to track your eyes across a single row's metadata (size, age, etc.).
**After:** Every alternating row uses a slightly varied background shade, creating a clear visual track for each result.

### ♿ Accessibility
Zebra striping helps users with tracking difficulties maintain their place while reading horizontally across wide lists containing multiple columns of information.

---
*PR created automatically by Jules for task [3871729625319372305](https://jules.google.com/task/3871729625319372305) started by @xbmc4lyfe*