### PR TITLE
Roll up PRs 401-409

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/hydra.py
+++ b/repo/plugin.video.nzbdav/resources/lib/hydra.py
@@ -7,16 +7,6 @@ from datetime import datetime, timezone
 from urllib.error import URLError
 from urllib.parse import urlencode, urlparse
 
-try:
-    from defusedxml import ElementTree as element_tree
-    from defusedxml.common import DefusedXmlException as _UnsafeXmlError
-except ImportError:  # pragma: no cover - Kodi installs may not bundle defusedxml
-    from xml.etree import ElementTree as element_tree
-
-    class _UnsafeXmlError(ValueError):
-        """Raised when stdlib fallback rejects DTD/entity declarations."""
-
-
 import xbmc
 import xbmcaddon
 
@@ -559,51 +549,13 @@ def _build_result(item):
     }
 
 
-def _build_xxe_safe_parser():
-    """Return an ElementTree XMLParser with external entities disabled.
-
-    ``xml.etree.ElementTree`` doesn't expose a ``resolve_entities=False``
-    knob directly, but the underlying expat parser can be told to
-    ignore DefaultHandler output and reject ExternalEntityRef callbacks.
-    A hostile NZBHydra2 instance (compromised, MITM'd, or simply
-    misbehaving) could otherwise coerce us into reading arbitrary
-    local files via an XXE payload. Mirrors webdav.py's WebDAV
-    PROPFIND parser for defense in depth.
-    """
-    parser = element_tree.XMLParser()  # nosec B314 — entities disabled below
-    try:
-        parser.parser.DefaultHandler = lambda _d: None
-        parser.parser.ExternalEntityRefHandler = lambda *_: False
-    except AttributeError:  # pragma: no cover — non-expat parser backend
-        pass
-    return parser
-
-
-def _contains_xml_declaration_markup(xml_text):
-    """Return true when XML text declares a DTD/entity block."""
-    if isinstance(xml_text, bytes):
-        probe = xml_text.lower()
-        return b"<!doctype" in probe or b"<!entity" in probe
-    probe = str(xml_text).lower()
-    return "<!doctype" in probe or "<!entity" in probe
-
-
-def _parse_hydra_xml(xml_text):
-    """Parse Hydra XML with DTD/entity expansion disabled."""
-    if getattr(element_tree, "__name__", "").startswith("defusedxml."):
-        return element_tree.fromstring(xml_text)
-    if _contains_xml_declaration_markup(xml_text):
-        raise _UnsafeXmlError("DTD and entity declarations are not allowed")
-    return element_tree.fromstring(
-        xml_text, parser=_build_xxe_safe_parser()
-    )  # nosec B314 — declarations rejected above and entities disabled when possible
-
-
 def _parse_results_checked(xml_text):
     """Parse Newznab XML and return (results, error_message)."""
+    from resources.lib.xml_safety import ParseError, UnsafeXmlError, safe_fromstring
+
     try:
-        root = _parse_hydra_xml(xml_text)
-    except (element_tree.ParseError, _UnsafeXmlError) as error:
+        root = safe_fromstring(xml_text)
+    except (ParseError, UnsafeXmlError) as error:
         xbmc.log(
             "NZB-DAV: Failed to parse Hydra XML response: {}".format(error),
             xbmc.LOGERROR,

--- a/repo/plugin.video.nzbdav/resources/lib/router_play.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_play.py
@@ -328,15 +328,19 @@ def _normalize_release_name(title):
     return " ".join(str(title or "").split()).casefold()
 
 
+_IMDB_DIGITS_RE = re.compile(r"(\d+)")
+_TITLE_SLUG_NON_WORD_RE = re.compile(r"[^\w]+")
+
+
 def _imdb_digits(value):
     """Bare IMDb digits from a possibly ``tt``-prefixed id (docs: ``imdb=123456``)."""
-    match = re.search(r"(\d+)", str(value or ""))
+    match = _IMDB_DIGITS_RE.search(str(value or ""))
     return match.group(1) if match else ""
 
 
 def _key_title_slug(title):
     """Lowercased hyphen slug of a title for the fallback (title-based) DupeKey."""
-    return re.sub(r"[^\w]+", "-", str(title or "").strip().lower()).strip("-")
+    return _TITLE_SLUG_NON_WORD_RE.sub("-", str(title or "").strip().lower()).strip("-")
 
 
 def _int_or_none(value):

--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -78,7 +78,7 @@
         <control type="image">
           <left>0</left><top>0</top><width>1910</width><height>66</height>
           <texture>white.png</texture>
-          <colordiffuse>FF0C0C10</colordiffuse>
+          <colordiffuse>$INFO[ListItem.Property(row_bg)]</colordiffuse>
         </control>
 
         <!-- LINE 1: Available indicator + Filename + Size + Age + Indexer + Group -->

--- a/tests/test_results_dialog.py
+++ b/tests/test_results_dialog.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 
 from resources.lib.results_dialog import (
     _AVAILABLE_LABEL,
+    _BG_A,
+    _BG_B,
     _available_text,
+    _build_result_item,
     _format_date,
     _format_size,
     _lang_short,
@@ -40,6 +43,24 @@ def test_available_label_is_ascii_for_skin_compatibility():
 
 def test_available_label_renders_green():
     assert _available_text() == "[COLOR FF22C55E]DL[/COLOR]"
+
+
+def test_build_result_item_sets_alternating_row_backgrounds():
+    first_item = MagicMock()
+    second_item = MagicMock()
+    third_item = MagicMock()
+
+    with patch(
+        "resources.lib.results_dialog.xbmcgui.ListItem",
+        side_effect=[first_item, second_item, third_item],
+    ):
+        _build_result_item(_make_result(), 0)
+        _build_result_item(_make_result(), 1)
+        _build_result_item(_make_result(), 2)
+
+    first_item.setProperty.assert_any_call("row_bg", _BG_A)
+    second_item.setProperty.assert_any_call("row_bg", _BG_B)
+    third_item.setProperty.assert_any_call("row_bg", _BG_A)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_results_dialog_skin.py
+++ b/tests/test_results_dialog_skin.py
@@ -6,6 +6,8 @@
 import os
 import xml.etree.ElementTree as ET
 
+from resources.lib.results_dialog import _BG_A, _BG_B
+
 _DIALOG_XML_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "repo",
@@ -39,6 +41,7 @@ def test_results_dialog_scrollbar_is_linked_to_results_list():
 
 
 _FOCUS_ACCENT_COLOR = "FF4A9EFF"
+_ROW_BG_INFO = "$INFO[ListItem.Property(row_bg)]"
 
 
 def _accent_bars(layout):
@@ -72,7 +75,9 @@ def test_results_dialog_focused_row_has_high_contrast_focus_indicator():
 
 
 def _perceived_luminance(argb):
-    """Rec.601 luma (0–255) of an 8-char ``AARRGGBB`` Kodi colour."""
+    """Rec.601 luma (0-255) of an 8-char ``AARRGGBB`` Kodi colour."""
+    if argb.startswith("$INFO["):
+        raise ValueError("dynamic skin info labels must be resolved first")
     r, g, b = int(argb[2:4], 16), int(argb[4:6], 16), int(argb[6:8], 16)
     return 0.299 * r + 0.587 * g + 0.114 * b
 
@@ -83,6 +88,27 @@ def _row_background_color(layout, layout_width="1910"):
         if image.findtext("width") == layout_width:
             return image.findtext("colordiffuse")
     return None
+
+
+def _row_background_colors(colordiffuse):
+    """Resolve a skin row background into the actual palette colors tested."""
+    if colordiffuse == _ROW_BG_INFO:
+        return (_BG_A, _BG_B)
+    if colordiffuse and colordiffuse.startswith("$INFO["):
+        raise ValueError("unhandled dynamic row background: {}".format(colordiffuse))
+    return (colordiffuse,)
+
+
+def test_results_dialog_unfocused_row_uses_controller_zebra_palette():
+    root = ET.parse(_DIALOG_XML_PATH).getroot()
+    results_list = _control(root, "list", "50")
+    assert results_list is not None, "results list control id=50 missing"
+    unfocused = results_list.find("./itemlayout")
+    assert unfocused is not None
+
+    unfocused_bg = _row_background_color(unfocused)
+    assert unfocused_bg == _ROW_BG_INFO
+    assert _row_background_colors(unfocused_bg) == (_BG_A, _BG_B)
 
 
 def test_focus_indicator_appearance_is_high_contrast_and_correctly_placed():
@@ -111,10 +137,12 @@ def test_focus_indicator_appearance_is_high_contrast_and_correctly_placed():
     # brighter than the focused fill it sits on (so focus is unmistakable).
     focused_bg = _row_background_color(focused)
     unfocused_bg = _row_background_color(unfocused)
-    assert _FOCUS_ACCENT_COLOR not in (focused_bg, unfocused_bg)
     accent_lum = _perceived_luminance(_FOCUS_ACCENT_COLOR)
+    assert _FOCUS_ACCENT_COLOR != focused_bg
     assert accent_lum - _perceived_luminance(focused_bg) > 80
-    assert accent_lum - _perceived_luminance(unfocused_bg) > 80
+    for row_bg in _row_background_colors(unfocused_bg):
+        assert _FOCUS_ACCENT_COLOR != row_bg
+        assert accent_lum - _perceived_luminance(row_bg) > 80
 
     # Render order: the bar must come AFTER the focused background image so it
     # paints on top of it (Kodi draws controls in document order).


### PR DESCRIPTION
## Summary
- Rolls up PRs #401-#409 into one clean integration branch.
- Enables result-dialog zebra striping once, with stronger tests for controller row background properties and both stripe colors.
- Routes Hydra XML parsing through shared XML safety helpers to preserve XXE hardening.
- Applies the cleaner router_play regex precompile variant from #408, superseding #404.
- Keeps #406 as the already-merged main baseline.

## PR validation
- One gpt-5.5 xhigh validator was run per PR #401-#409.
- PR #401 and #405 had test fixes pushed to their PR branches under xbmc4lyfe.
- PR #403/#409 were duplicate Hydra safety variants; the roll-up uses the lazy shared-helper form from #409.
- PR #404/#408 were duplicate regex variants; the roll-up uses #408.

## QA
- Focused results dialog, XML safety/Hydra, and router duplicate-key tests passed.
- `just test` passed: 2282 passed, 2 skipped.
- `just lint` passed.
- `just ci` passed, including Python 3.8 compileall.