### PR TITLE
🎨 Palette: [UX improvement] Add scrolling to focused filenames in results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -179,6 +179,7 @@
           <left>40</left><top>4</top><width>1140</width><height>30</height>
           <font>font13</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Label]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1190</left><top>4</top><width>120</width><height>30</height>


### PR DESCRIPTION
💡 What: Added `<scroll>true</scroll>` to the `$INFO[ListItem.Label]` control in the `<focusedlayout>` of the results dialog.
🎯 Why: In Kodi's 10-foot UI, search results often have very long filenames, with critical release tags (like resolution, codec, release group) at the very end. Before this change, long names would be permanently truncated, making it difficult for users to fully read what they are selecting. With this change, when a user focuses on a row, the full title will gracefully scroll horizontally.
📸 Before/After: Visual change in the Kodi client. When an item is focused, long filenames will now auto-scroll.
♿ Accessibility: Ensures that screen real estate limits do not prevent users from accessing the complete text of a list item.

---
*PR created automatically by Jules for task [1439295237280963439](https://jules.google.com/task/1439295237280963439) started by @xbmc4lyfe*