### PR TITLE
🎨 Palette: [UX improvement] Add scrolling to long filenames in focused layout

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -179,6 +179,7 @@
           <left>40</left><top>4</top><width>1140</width><height>30</height>
           <font>font13</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Label]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1190</left><top>4</top><width>120</width><height>30</height>


### PR DESCRIPTION
### 💡 What
Added `<scroll>true</scroll>` to the main filename label within the `<focusedlayout>` of the results dialog.

### 🎯 Why
In 10-foot UIs (TV interfaces), fixed-width list items frequently truncate long release names or filenames. This hides critical information (like quality, group, or tags at the end of the filename) when browsing search results. Adding scrolling allows the full text to be read smoothly as a marquee when the item is focused.

### 📸 Before/After
* **Before:** `Avatar.The.Way.of.Water.2022.2160p.WEB-DL.DDP5...` (permanently truncated)
* **After:** `Avatar.The.Way.of.Water.2022.2160p.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-FLUX` (scrolls horizontally when focused)

### ♿ Accessibility
Improves readability for users who rely on full release names to make selections, and prevents critical information loss on devices with lower resolutions or larger display scaling where less text fits on screen initially.

---
*PR created automatically by Jules for task [6504280172056909071](https://jules.google.com/task/6504280172056909071) started by @xbmc4lyfe*