### PR TITLE
Roll up PRs 412, 413, 414: results-dialog scroll + XML-safety rewiring

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/fallback_streams_probe.py
+++ b/repo/plugin.video.nzbdav/resources/lib/fallback_streams_probe.py
@@ -17,12 +17,6 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urlsplit, urlunsplit
 from urllib.request import Request
 
-try:
-    from defusedxml import ElementTree as ET
-except ImportError:  # pragma: no cover - Kodi installs may not bundle defusedxml
-    # nosemgrep
-    from xml.etree import ElementTree as ET
-
 import resources.lib.fallback_streams as _fs
 
 _CONTENT_RANGE_RE = re.compile(r"^bytes\s+(\d+)-(\d+)/(\d+|\*)$")
@@ -272,13 +266,17 @@ def _schema_setting_default(setting_id):
     candidate_paths.append(
         os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "settings.xml"))
     )
+
+    from resources.lib.xml_safety import ParseError, safe_fromstring
+
     for path in candidate_paths:
         try:
-            # nosemgrep
-            root = ET.parse(path).getroot()
-        except (OSError, ET.ParseError):
+            with open(path, "rb") as fh:
+                xml_bytes = fh.read()
+            root = safe_fromstring(xml_bytes)
+        except (OSError, ParseError, ValueError):
             continue
-        default = _fs._setting_default_from_root(root, setting_id)
+        default = _setting_default_from_root(root, setting_id)
         if default is not None:
             return default
     return ""

--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -364,15 +364,14 @@ def _attach_selected_result_metadata(resolver_params, selected):
 
 def _get_script_setting(key, default=""):
     """Read this addon's setting from settings.xml without Kodi settings APIs."""
-    try:
-        from defusedxml import ElementTree as element_tree
-    except ImportError:  # pragma: no cover - Kodi installs may not bundle defusedxml
-        from xml.etree import ElementTree as element_tree
+    from resources.lib.xml_safety import ParseError, safe_fromstring
 
     for settings_path in _script_settings_paths():
         try:
-            root = element_tree.parse(settings_path).getroot()
-        except (OSError, element_tree.ParseError):
+            with open(settings_path, "rb") as fh:
+                xml_bytes = fh.read()
+            root = safe_fromstring(xml_bytes)
+        except (OSError, ParseError, ValueError):
             continue
 
         for setting in root.findall(".//setting"):

--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -179,6 +179,7 @@
           <left>40</left><top>4</top><width>1140</width><height>30</height>
           <font>font13</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Label]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1190</left><top>4</top><width>120</width><height>30</height>

--- a/tests/test_fallback_streams.py
+++ b/tests/test_fallback_streams.py
@@ -146,6 +146,34 @@ def test_schema_default_reader_supports_old_and_new_settings_format():
     )
 
 
+def test_schema_setting_default_parses_real_file_via_safe_fromstring(tmp_path):
+    from resources.lib import fallback_streams
+
+    schema_file = tmp_path / "settings.xml"
+    schema_file.write_text(
+        """
+        <settings version="1">
+          <section id="plugin.video.nzbdav">
+            <category id="connection">
+              <group id="webdav">
+                <setting id="webdav_url" type="string">
+                  <default>http://example-schema:9999</default>
+                </setting>
+              </group>
+            </category>
+          </section>
+        </settings>
+        """,
+        encoding="utf-8",
+    )
+
+    with patch("xbmcvfs.translatePath", return_value=str(schema_file)):
+        assert (
+            fallback_streams._schema_setting_default("webdav_url")
+            == "http://example-schema:9999"
+        )
+
+
 def test_configured_stream_bases_tolerates_trailing_space_in_url():
     """A stray trailing space in nzbdav_url must not empty the probe-base
     allow-list. _split_http_url rejects whitespace in the netloc (an SSRF/


### PR DESCRIPTION
## Summary
Rolls up three Jules/Sentinel bot PRs into one, with the actual duplicate collapsed and the security fix QA'd:

- **#412** — adds `<scroll>true</scroll>` to the focused filename label in `results-dialog.xml` so long release names marquee-scroll instead of truncating.
- **#413** — **byte-identical diff to #412** (same file, same line, different Jules task ID). Not reapplied separately; superseded by #412's change.
- **#414** — removes the last two ad-hoc `defusedxml`-or-`xml.etree` try/except parsers (`fallback_streams_probe._schema_setting_default`, `router._get_script_setting`) in favor of the shared `resources.lib.xml_safety.safe_fromstring`, closing an XXE/billion-laughs gap that the earlier XML-safety rewiring (#370) had missed at these two call sites.

## QA performed
- Verified the `_fs` module alias and `ET`/`element_tree` imports have no other call sites left dangling in either changed file.
- Confirmed `safe_fromstring`'s bytes-input usage in #414 matches the 8 other established call sites in this codebase (`hydra.py`, `nzb_manifest.py`, `kodi_advancedsettings.py`, `webdav.py`, etc.).
- Added a direct regression test (`test_schema_setting_default_parses_real_file_via_safe_fromstring`) for `_schema_setting_default`'s file-read + `safe_fromstring` path — previously only the inner `_setting_default_from_root` helper had coverage.
- `just lint`: ruff, black, pylint (10.00/10), vermin (3.8-compatible) all clean.
- `just test`: 2287 passed, 2 skipped, 0 failed (full suite, run uncontended to rule out the repo's known wall-clock timing flakes under machine load).

## Test plan
- [x] `just lint`
- [x] `just test` (full suite, clean run)
- [x] Manual trace of both changed files for dangling imports/references