### PR TITLE
🎨 Palette: Add scrollable text for long metadata fields in results list

### DIFF
--- a/repo/.jules/palette.md
+++ b/repo/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-27 - [Add scroll to variable-length controls]
+**Learning:** In Kodi XML skins (10-foot UIs), variable-length text fields (such as codec, audio, indexer, and release group) within `<focusedlayout>` and `<itemlayout>` will permanently truncate and hide important information if they exceed their `<width>`.
+**Action:** Always add `<scroll>true</scroll>` to variable-length text `<label>` controls to ensure all metadata is accessible to the user when focused.

--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -195,11 +195,13 @@
           <left>1470</left><top>4</top><width>200</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(indexer)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1680</left><top>4</top><width>220</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(group)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
 
         <!-- LINE 2: Res + HDR + Codec + Audio + Source -->
@@ -212,16 +214,19 @@
           <left>120</left><top>34</top><width>200</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(hdr)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>320</left><top>34</top><width>150</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(codec)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>470</left><top>34</top><width>250</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(audio)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>720</left><top>34</top><width>150</width><height>26</height>


### PR DESCRIPTION
💡 **What**: Added `<scroll>true</scroll>` to variable-length metadata `<label>` controls (such as Indexer, Release Group, HDR format, Codec, and Audio) within the `<focusedlayout>` of the results dialog.

🎯 **Why**: In a 10-foot Kodi UI, real estate is strictly defined by the control widths. When complex releases have long metadata fields (e.g., long indexer names or extended audio strings like "DTS-HD MA 7.1"), they silently overflow and get permanently truncated. This prevents the user from seeing crucial information needed to select the correct release. Adding `<scroll>true</scroll>` allows the active/focused row to animate text horizontally so all information is readable.

📸 **Before/After**: 
- **Before**: "DTS-HD MA 7..." or "MySuperLongInd..."
- **After**: The text smoothly scrolls horizontally when the row is selected to reveal "...7.1" or "...IndexerName".

♿ **Accessibility**: Improves accessibility for users relying on the 10-foot UI from a distance by ensuring all critical metadata points can be fully read without requiring a separate "info" screen or smaller, unreadable font sizes.

---
*PR created automatically by Jules for task [8466283760928599044](https://jules.google.com/task/8466283760928599044) started by @xbmc4lyfe*