### PR TITLE
⚡ Bolt: [performance improvement] Pre-compile regex in episode inventory

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/episode_inventory.py
+++ b/repo/plugin.video.nzbdav/resources/lib/episode_inventory.py
@@ -9,6 +9,9 @@ from typing import NamedTuple, Optional
 
 from resources.lib.webdav_match import _resolve_file_episode_tags
 
+_PATH_SEP_RE = re.compile(r"[/\\]+")
+_WORD_SEP_RE = re.compile(r"[. _-]+")
+
 _AUXILIARY_RE = re.compile(
     r"(?:^|[. _-])(samples?|trailers?|featurettes?|extras?)(?:[. _-]|$)",
     re.IGNORECASE,
@@ -48,13 +51,13 @@ def _coerce_size(value):
 def _auxiliary_parent_markers(parent):
     return tuple(
         item
-        for item in re.split(r"[/\\]+", parent)
+        for item in _PATH_SEP_RE.split(parent)
         if item and _AUXILIARY_TOKEN_RE.fullmatch(item)
     )
 
 
 def _has_different_auxiliary_parent(name, auxiliary_parents):
-    leading_name = re.split(r"[. _-]+", name, maxsplit=1)[0]
+    leading_name = _WORD_SEP_RE.split(name, 1)[0]
     return any(leading_name.casefold() != item.casefold() for item in auxiliary_parents)
 
 
@@ -124,7 +127,7 @@ def _leading_auxiliary_context(path):
     if not match:
         return None
     remainder = name[match.end() :].lstrip(". _-")
-    parts = tuple(item for item in re.split(r"[. _-]+", remainder) if item)
+    parts = tuple(item for item in _WORD_SEP_RE.split(remainder) if item)
     for count in range(1, len(parts) + 1):
         probe = ".".join(parts[:count])
         if _resolve_file_episode_tags(probe, ""):
@@ -134,8 +137,8 @@ def _leading_auxiliary_context(path):
 
 def _release_folder_matches_marker(path, marker):
     parent = path.rsplit("/", 1)[0] if "/" in path else ""
-    for segment in (item for item in re.split(r"[/\\]+", parent) if item):
-        leading_segment = re.split(r"[. _-]+", segment, maxsplit=1)[0]
+    for segment in (item for item in _PATH_SEP_RE.split(parent) if item):
+        leading_segment = _WORD_SEP_RE.split(segment, 1)[0]
         if leading_segment.casefold() == marker:
             return True
     return False


### PR DESCRIPTION
💡 **What:**
Pre-compiled the `[/\\]+` and `[. _-]+` regular expressions in `episode_inventory.py` at the module level instead of repeatedly parsing them inline using `re.split()` during loops and generator expressions.

🎯 **Why:**
While the `re` module caches recent strings, fetching from this cache still incurs dictionary lookup and evaluation overhead. The `episode_inventory` module parses and categorizes directory and file trees for episodes, making these splits highly frequent operations that benefit from pre-compilation.

📊 **Impact:**
Small measurable improvement in execution time for bulk WebDAV episode parsing, particularly when scanning large multi-season directory structures with deep nesting.

🔬 **Measurement:**
Run the existing test suite (`just test` or `uv run pytest`) to verify functionality remains unchanged. Benchmark `build_video_inventory` on a large mock directory tree to measure the parsing speedup.

---
*PR created automatically by Jules for task [15514529023412550955](https://jules.google.com/task/15514529023412550955) started by @xbmc4lyfe*