### PR TITLE
🎨 Palette: Add auto-scroll to metadata labels

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -106,11 +106,13 @@
           <left>1470</left><top>4</top><width>200</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(indexer)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1680</left><top>4</top><width>220</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(group)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
 
         <!-- LINE 2: Res + HDR + Codec + Audio + Source -->
@@ -118,31 +120,37 @@
           <left>20</left><top>34</top><width>100</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(resolution)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>120</left><top>34</top><width>200</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(hdr)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>320</left><top>34</top><width>150</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(codec)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>470</left><top>34</top><width>250</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(audio)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>720</left><top>34</top><width>150</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(quality)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>870</left><top>34</top><width>80</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(container)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
 
         <!-- Row separator -->


### PR DESCRIPTION
💡 What: Added `<scroll>true</scroll>` to variable-length text labels for metadata (e.g., codec, audio, container, group) within the `<focusedlayout>` of the results list in `repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml`.
🎯 Why: Prevents truncating important file details on 10-foot UIs, ensuring metadata is fully readable when focused.
📸 Before/After: Visual scrolling animation on focused row metadata items.
♿ Accessibility: Improved readability for text that exceeds narrow label widths.

---
*PR created automatically by Jules for task [16816643705002066840](https://jules.google.com/task/16816643705002066840) started by @xbmc4lyfe*