### PR TITLE
🎨 Palette: Improve readability of variable-length metadata with auto-scrolling labels

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -106,11 +106,13 @@
           <left>1470</left><top>4</top><width>200</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(indexer)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1680</left><top>4</top><width>220</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(group)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
 
         <!-- LINE 2: Res + HDR + Codec + Audio + Source -->
@@ -118,31 +120,37 @@
           <left>20</left><top>34</top><width>100</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(resolution)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>120</left><top>34</top><width>200</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(hdr)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>320</left><top>34</top><width>150</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(codec)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>470</left><top>34</top><width>250</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(audio)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>720</left><top>34</top><width>150</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(quality)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>870</left><top>34</top><width>80</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(container)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
 
         <!-- Row separator -->


### PR DESCRIPTION
💡 What: Added `<scroll>true</scroll>` to variable-length metadata `<label>` controls (such as indexer, group, codec, and audio) within the `<focusedlayout>` of the results dialog.
🎯 Why: In Kodi skins (10-foot UIs), long dynamic text strings are often permanently truncated when they exceed their fixed width. Adding the scroll tag allows the text to automatically scroll horizontally when a user focuses the row, ensuring critical information is readable.
📸 Before/After: Long release groups or complicated audio codecs would be cut off with an ellipsis `...`. Now, they smoothly scroll horizontally when the list item is focused.
♿ Accessibility: Improves readability for users relying on larger text sizes or those sitting further back, ensuring all descriptive text is fully accessible without needing to manually inspect properties.

---
*PR created automatically by Jules for task [3579370331143781140](https://jules.google.com/task/3579370331143781140) started by @xbmc4lyfe*