### PR TITLE
🎨 Palette: [UX improvement] Add scrolling to long metadata text in focused rows

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -185,21 +185,25 @@
           <left>1190</left><top>4</top><width>120</width><height>30</height>
           <font>font13</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(size)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1320</left><top>4</top><width>140</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(age)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1470</left><top>4</top><width>200</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(indexer)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1680</left><top>4</top><width>220</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(group)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
 
         <!-- LINE 2: Res + HDR + Codec + Audio + Source -->
@@ -207,31 +211,37 @@
           <left>20</left><top>34</top><width>100</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(resolution)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>120</left><top>34</top><width>200</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(hdr)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>320</left><top>34</top><width>150</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(codec)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>470</left><top>34</top><width>250</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(audio)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>720</left><top>34</top><width>150</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(quality)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>870</left><top>34</top><width>80</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(container)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
 
         <!-- Row separator -->


### PR DESCRIPTION
💡 **What:** Added `<scroll>true</scroll>` to all metadata labels (`size`, `age`, `indexer`, `group`, `resolution`, `hdr`, `codec`, `audio`, `quality`, `container`) in the focused layout of the results dialog.

🎯 **Why:** In 10-foot TV interfaces, long variable-length text fields can easily exceed the static width of a layout column. Without a scroll parameter, critical technical information (such as complex codec or audio strings, or long indexer names) is permanently truncated, presenting a significant usability issue for technical content. Enabling scroll allows the user to read the full string when they focus the row.

📸 **Before/After:** (No UI screenshot needed; behavioral change where focused long strings will animate and scroll instead of remaining statically cropped).

♿ **Accessibility:** Improves readability for visually constrained or cognitively diverse users by ensuring full text is accessible and not unexpectedly hidden.

---
*PR created automatically by Jules for task [2722203820515618026](https://jules.google.com/task/2722203820515618026) started by @xbmc4lyfe*