### PR TITLE
⚡ Bolt: [performance improvement] Pre-compile regexes in episode_inventory

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/episode_inventory.py
+++ b/repo/plugin.video.nzbdav/resources/lib/episode_inventory.py
@@ -21,6 +21,9 @@ _UNAMBIGUOUS_AUXILIARY_MARKERS = frozenset(
 )
 _AMBIGUOUS_LEADING_MARKERS = frozenset(("extra", "extras", "trailer", "trailers"))
 
+_PATH_SEP_RE = re.compile(r"[/\\]+")
+_TITLE_SEP_RE = re.compile(r"[. _-]+")
+
 
 class VideoFile(NamedTuple):
     path: str
@@ -48,13 +51,13 @@ def _coerce_size(value):
 def _auxiliary_parent_markers(parent):
     return tuple(
         item
-        for item in re.split(r"[/\\]+", parent)
+        for item in _PATH_SEP_RE.split(parent)
         if item and _AUXILIARY_TOKEN_RE.fullmatch(item)
     )
 
 
 def _has_different_auxiliary_parent(name, auxiliary_parents):
-    leading_name = re.split(r"[. _-]+", name, maxsplit=1)[0]
+    leading_name = _TITLE_SEP_RE.split(name, 1)[0]
     return any(leading_name.casefold() != item.casefold() for item in auxiliary_parents)
 
 
@@ -124,7 +127,7 @@ def _leading_auxiliary_context(path):
     if not match:
         return None
     remainder = name[match.end() :].lstrip(". _-")
-    parts = tuple(item for item in re.split(r"[. _-]+", remainder) if item)
+    parts = tuple(item for item in _TITLE_SEP_RE.split(remainder) if item)
     for count in range(1, len(parts) + 1):
         probe = ".".join(parts[:count])
         if _resolve_file_episode_tags(probe, ""):
@@ -134,8 +137,8 @@ def _leading_auxiliary_context(path):
 
 def _release_folder_matches_marker(path, marker):
     parent = path.rsplit("/", 1)[0] if "/" in path else ""
-    for segment in (item for item in re.split(r"[/\\]+", parent) if item):
-        leading_segment = re.split(r"[. _-]+", segment, maxsplit=1)[0]
+    for segment in (item for item in _PATH_SEP_RE.split(parent) if item):
+        leading_segment = _TITLE_SEP_RE.split(segment, 1)[0]
         if leading_segment.casefold() == marker:
             return True
     return False


### PR DESCRIPTION
**💡 What:** Pre-compiled the repeated inline `re.split(r"[/\\]+", ...)` and `re.split(r"[. _-]+", ...)` calls into module-level regex constants (`_PATH_SEP_RE` and `_TITLE_SEP_RE`) in `resources/lib/episode_inventory.py`.

**🎯 Why:** `episode_inventory.py` iterates over parsed directories and filenames to determine pack inventory. Re-compiling string patterns (even when CPython relies on its LRU cache) introduces a dictionary lookup overhead that is bypassed by using the native C methods (`pattern.split()`) directly on module-level `re.Pattern` objects. 

**📊 Impact:** Reduces parsing overhead when building video inventory, specifically the repetitive splits applied across long file paths during WebDAV discovery scanning and fallback matching.

**🔬 Measurement:** Verified by passing all 37 unit tests in `tests/test_episode_inventory.py` and the complete test suite.

---
*PR created automatically by Jules for task [4120877580593868316](https://jules.google.com/task/4120877580593868316) started by @xbmc4lyfe*