### PR TITLE
🎨 Palette: Add auto-scroll to variable-length text labels in focused layout

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -195,11 +195,13 @@
           <left>1470</left><top>4</top><width>200</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(indexer)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>1680</left><top>4</top><width>220</width><height>30</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(group)]</label><aligny>center</aligny><align>right</align>
+          <scroll>true</scroll>
         </control>
 
         <!-- LINE 2: Res + HDR + Codec + Audio + Source -->
@@ -217,11 +219,13 @@
           <left>320</left><top>34</top><width>150</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(codec)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>470</left><top>34</top><width>250</width><height>26</height>
           <font>font12</font><textcolor>FFFFFFFF</textcolor>
           <label>$INFO[ListItem.Property(audio)]</label><aligny>center</aligny>
+          <scroll>true</scroll>
         </control>
         <control type="label">
           <left>720</left><top>34</top><width>150</width><height>26</height>


### PR DESCRIPTION
### 💡 What
Added `<scroll>true</scroll>` to variable-length metadata labels (`indexer`, `group`, `codec`, `audio`) inside the `<focusedlayout>` block of the `results-dialog.xml` skin file.

### 🎯 Why
In a 10-foot UI, horizontal screen space is limited. Some metadata strings, particularly release group names and complex audio codec descriptions, frequently exceed their allocated label width and get permanently truncated. This prevents the user from reading the full details.

### 📸 Before/After
**Before:** Long labels (e.g., `DTS-HD MA 7.1`, or long P2P release group names) would abruptly cut off with no way for the user to see the rest of the string.
**After:** When a user navigates to and focuses on a specific result row, any truncated labels within that row will smoothly scroll horizontally, revealing the full text. 

### ♿ Accessibility
Improves readability for users by ensuring all text is accessible without needing a larger screen or smaller, harder-to-read font size. The animation correctly only applies when the row is explicitly focused, avoiding overwhelming the user with a screen full of moving text on unfocused rows.

---
*PR created automatically by Jules for task [5946215299944546931](https://jules.google.com/task/5946215299944546931) started by @xbmc4lyfe*