### PR TITLE
chore: fix actionable Codacy code-scanning findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.0.0-beta.1] — 2026-07-09
+## [2.0.0-beta.1][] — 2026-07-09
 
 > **The big one.** Two months of accumulated work since 1.2.3, released together
 > as a beta: a new NZBGet backend with automatic duplicate-fleet failover, a
@@ -262,7 +262,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vendored PTT parser), so defended-but-flagged patterns and test-only code
   stop generating false-positive CI noise.
 
-## [1.2.3] — 2026-05-08
+## [1.2.3][] — 2026-05-08
 
 > **Proxy fallback and repository-install hardening.** This release keeps
 > fallback rescue paths active for MKV playback, avoids unsafe service-thread
@@ -296,7 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   RunScript settings paths, WebDAV path encoding, and Docker/VNC functional
   playback scaffolding.
 
-## [1.2.2] — 2026-05-07
+## [1.2.2][] — 2026-05-07
 
 > **Hotfix for Kodi/CoreELEC freezes when opening the NZB-DAV add-on info
 > dialog.** The published `v1.2.1` release asset still carried the full
@@ -308,7 +308,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shipped package, matching the repository-side metadata guard and preventing
   the oversized add-on info dialog path from being republished.
 
-## [1.2.1] — 2026-05-07
+## [1.2.1][] — 2026-05-07
 
 > **Fallback selection handles more real-world NZBs and avoids more wasted
 > manifest fetches.** Parser-unsupported candidates can now use conservative
@@ -345,7 +345,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   synthesis, cached prefetch proof size-gate enforcement, raw NZB fetch caching
   with fresh health-check parsing, and failed-history polling precedence.
 
-## [1.2.0] — 2026-05-07
+## [1.2.0][] — 2026-05-07
 
 > **RunScript playback now gets the same fallback discovery as plugin-handle
 > playback.** TMDBHelper script-mode picks were previously skipping standby
@@ -382,7 +382,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `settings_getter` plumbing through fallback discovery and submission, and
   probe-thread starvation during submit.
 
-## [1.1.0] — 2026-05-07
+## [1.1.0][] — 2026-05-07
 
 > **Playback starts sooner and avoids the post-picker freeze.** TMDBHelper now
 > enters the addon through a script-mode player path, and already-ready MKV
@@ -421,7 +421,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   faster provider/search handoff, nonblocking submit and poll loops, direct MKV
   playback handoff, 99% completed-history races, and rate-limit submit errors.
 
-## [1.0.9] — 2026-05-06
+## [1.0.9][] — 2026-05-06
 
 > **Fallback discovery and failover are faster.** This batch keeps the same
 > conservative fallback safety chain while moving expensive work out of the
@@ -474,7 +474,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.8] — 2026-05-05
+## [1.0.8][] — 2026-05-05
 
 > **Fallback manifest hardening.** This release tightens the v1.0.7 manifest
 > grouping path so malformed metadata fails closed and NZB downloads use the
@@ -496,7 +496,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.7] — 2026-05-04
+## [1.0.7][] — 2026-05-04
 
 > **Fallback streams are on by default.** Standby fallback submits now default
 > to 5 per primary result, stay on the pass-through proxy path, and replace
@@ -525,7 +525,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.6] — 2026-05-04
+## [1.0.6][] — 2026-05-04
 
 > **Live fallback streams on a pass-through-first proxy.** Duplicate releases
 > can now be attached as standby sources for the same playback session, while
@@ -568,7 +568,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.5] — 2026-05-04
+## [1.0.5][] — 2026-05-04
 
 > **Direct Newznab indexers and repository update hardening.** Users who do
 > not run NZBHydra2 or Prowlarr can now configure Newznab-compatible
@@ -617,7 +617,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.4] — 2026-04-25
+## [1.0.4][] — 2026-04-25
 
 > **Pass-through stall watchdog closes the playback wedge.** Live triage on
 > the CoreELEC test box on 2026-04-25 produced a complete repro: a 4K HDR
@@ -747,7 +747,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.3] — 2026-04-23
+## [1.0.3][] — 2026-04-23
 
 > **Hotfix for "Refusing to start unsafe ffmpeg command" HTTP 500 on every
 > auth'd force-remux stream.** `_is_safe_ffmpeg_cmd` (PR #83 security
@@ -775,7 +775,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.2] — 2026-04-23
+## [1.0.2][] — 2026-04-23
 
 > **Hotfix for `Completed but no video found` on reverse-proxied nzbdav
 > setups.** `v1.0.0-pre-alpha` added a cross-origin host check on every
@@ -802,7 +802,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.1] — 2026-04-23
+## [1.0.1][] — 2026-04-23
 
 > **Source-data Dolby Vision classifier.** The ffmpeg-stderr DV probe shipped
 > with `1.0.0-pre-alpha` is retired in favour of a pure-Python RPU parser
@@ -871,7 +871,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.0-pre-alpha] — 2026-04-15
+## [1.0.0-pre-alpha][] — 2026-04-15
 
 > **First major rewrite milestone — tagged on the spike/hls-fmp4 branch as a pre-release before merging to main.** Big-file force-remux on by default, the fmp4 HLS spike landed and self-heals on failure, the submit pipeline stops freezing on slow nzbdav, the resolver hardens against typo'd settings, and `PROXY.md` documents the proxy subsystem end-to-end. 100 GB DV REMUXes now force-remux through ffmpeg instead of crashing 32-bit Kodi on pass-through, and the experimental fragmented-MP4 HLS branch (opt-in via Advanced settings) automatically falls back to the known-good piped-Matroska path before Kodi ever sees a broken URL when ffmpeg can't produce output. Verified on a CoreELEC ARM64 test box against multiple UHD remuxes — fmp4 HLS gives full random seek for non-DV-Profile-7 sources, matroska fallback covers the DV P7 case.
 
@@ -920,7 +920,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.21] — 2026-04-13
+## [0.6.21][] — 2026-04-13
 
 > **Two `submit_nzb` lifecycle fixes.** The addon now tells nzbdav to cancel an in-flight job when it gives up on a download, so re-submitting the same NZB doesn't get blocked by stale duplicates. And when nzbdav rejects a submit, the dialog now shows the actual server message instead of a generic "check your settings" string.
 
@@ -930,7 +930,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.20] — 2026-04-13
+## [0.6.20][] — 2026-04-13
 
 > **Two resolve-loop fixes.** Kodi's UI no longer briefly freezes during resolve polling when nzbdav is momentarily unreachable, and an invalid WebDAV password now surfaces as the "Authentication failed" dialog within a poll iteration instead of being silently masked until the download timeout fires.
 
@@ -940,7 +940,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.19] — 2026-04-12
+## [0.6.19][] — 2026-04-12
 
 > **Documentation refresh.** Nothing user-visible. The README finally catches up with how the stream proxy has actually worked since v0.6.14.
 
@@ -952,7 +952,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.18] — 2026-04-12
+## [0.6.18][] — 2026-04-12
 
 > **Big MKVs now play, seek, and recover from bad Usenet articles — without ffmpeg in the loop.** Pass-through is finally the default on 32-bit Kodi, which gives you native scrubbing through the source file's real Cues plus v0.6.15's zero-fill recovery on missing articles. If huge remuxes ever felt fragile, this is the release you want.
 
@@ -966,7 +966,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.17] — 2026-04-12
+## [0.6.17][] — 2026-04-12
 
 > **Kill the zombie.** Fixes a nasty bug where a stalled playback would leave an ffmpeg remux process behind, so the next time you hit Play the addon hung with "Playback never started after 70 s". Restarts just work again.
 
@@ -977,7 +977,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.16] — 2026-04-12
+## [0.6.16][] — 2026-04-12
 
 > **First attempt at fixing huge MKVs on 32-bit Kodi.** Force-remuxes anything over 4 GB through ffmpeg so Kodi never sees an overflowing Content-Length. **Superseded by v0.6.18** — the real root cause turned out to be elsewhere (already fixed in v0.6.14). The setting is still available if your platform needs it.
 
@@ -990,7 +990,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.15] — 2026-04-12
+## [0.6.15][] — 2026-04-12
 
 > **Your stream no longer dies on a single bad Usenet article.** The proxy probes forward to find a readable offset, fills the gap with zeros, and keeps playing. Retries for up to 30 seconds in case the backend is just briefly unhappy.
 
@@ -1000,7 +1000,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.14] — 2026-04-12
+## [0.6.14][] — 2026-04-12
 
 > **Fixes "Playback failed to start" on MKV files** by routing every format through the local stream proxy. Kodi no longer pokes the WebDAV server directly, which was triggering a PROPFIND cascade that broke playback on some setups.
 
@@ -1010,7 +1010,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.13] — 2026-04-12
+## [0.6.13][] — 2026-04-12
 
 > **NZB submit timeout is now configurable.** Large NZBs can take longer than 15 seconds for nzbdav to parse; the default is now 30 seconds and you can tune it in settings.
 
@@ -1019,7 +1019,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.12] — 2026-04-12
+## [0.6.12][] — 2026-04-12
 
 > **Fixes "Playback failed to start" when you replay the same NZB.** Kodi was auto-resuming from stale bookmarks on plugin URLs; those are now wiped before each play.
 
@@ -1028,7 +1028,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.11] — 2026-04-12
+## [0.6.11][] — 2026-04-12
 
 > **Error messages stop getting truncated.** NZBHydra failures and invalid responses pop up in proper modal dialogs with the full text, and duplicate results across indexers stay visible instead of being merged.
 
@@ -1041,7 +1041,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.10] — 2026-04-12
+## [0.6.10][] — 2026-04-12
 
 > **Every playback failure gets a real dialog now.** Toast notifications were too easy to miss, especially for late failures like missing articles or auth rejection mid-stream.
 
@@ -1054,7 +1054,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.9] — 2026-04-12
+## [0.6.9][] — 2026-04-12
 
 > **Duplicate results from multiple indexers collapse into one row.** Also, the **Max results** setting actually limits NZBHydra2 queries now — it was previously hardcoded to 100.
 
@@ -1066,7 +1066,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.8] — 2026-04-12
+## [0.6.8][] — 2026-04-12
 
 > **Fixes playback failing because Kodi was mangling the auth header.** URL-encoded `=` characters in pipe-syntax auth were being eaten. Download failures also get a modal dialog instead of a toast now.
 
@@ -1079,7 +1079,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.7] — 2026-04-10
+## [0.6.7][] — 2026-04-10
 
 > **Internal cleanup.** No user-visible changes.
 
@@ -1088,7 +1088,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.6] — 2026-04-10
+## [0.6.6][] — 2026-04-10
 
 > **Security hardening.** API keys and auth credentials are now redacted from debug logs, and the stream proxy rejects non-HTTP URLs. Includes several internal cleanups to clear code-scanning alerts.
 
@@ -1107,7 +1107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.5] — 2026-04-10
+## [0.6.5][] — 2026-04-10
 
 > **The addon actually tells you when something goes wrong.** Download failures, missing video files, stream errors — all surfaced to the user instead of silently eaten. Also fixes a playback freeze when ffmpeg's stderr buffer filled up.
 
@@ -1121,7 +1121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.2] — 2026-04-10
+## [0.6.2][] — 2026-04-10
 
 > **Flaky test fix.** No user-visible changes.
 
@@ -1130,7 +1130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.1] — 2026-04-10
+## [0.6.1][] — 2026-04-10
 
 > **Internal cleanup.** No user-visible changes.
 
@@ -1140,7 +1140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.6.0] — 2026-04-07
+## [0.6.0][] — 2026-04-07
 
 > **A huge one.** MP4 files now get native Kodi seeking, pause, and Dolby Vision support via a **pure-Python proxy that rewrites the MP4's internal chunk offsets on the fly** — no ffmpeg re-encode. Files over 4 GB work too. There's a three-tier fallback if the fast path fails, and a new "container" column in the results list makes MP4 vs MKV obvious at a glance.
 
@@ -1165,7 +1165,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.5.0] — 2026-04-06
+## [0.5.0][] — 2026-04-06
 
 > **Settings are simpler.** The WebDAV URL field is gone (it defaults to the nzbdav URL automatically), and release-group fields became proper multi-select dialogs with 93 known groups pre-loaded. The TMDBHelper installer no longer prompts — it just installs.
 
@@ -1187,7 +1187,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.4.3] — 2026-04-06
+## [0.4.3][] — 2026-04-06
 
 > **First cut of the stream proxy.** MP4 files get remuxed to MKV on the fly via ffmpeg to work around a 32-bit Kodi `CFileCache` bug, subtitles are converted from `mov_text` to SRT, and seeking works with a real progress bar. The proxy now lives in the background service, so it survives script exit and can auto-recover on playback failure.
 
@@ -1207,7 +1207,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.4.1] — 2026-04-06
+## [0.4.1][] — 2026-04-06
 
 > **Security review fixes.** Addressed HIGH/MEDIUM findings from code review. No user-visible behaviour changes.
 
@@ -1216,7 +1216,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.4.0] — 2026-04-06
+## [0.4.0][] — 2026-04-06
 
 > **Spot instant plays at a glance.** NZBs that are already downloaded in nzbdav now get a lightning-bolt indicator in the results list. Also silences some noisy log spam when you stop playback.
 
@@ -1228,7 +1228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.3.0] — 2026-04-05
+## [0.3.0][] — 2026-04-05
 
 > **WebDAV streaming works reliably on CoreELEC** via an MP4 faststart proxy. Adds Test Connection buttons for NZBHydra2 and nzbdav in settings, skips re-downloading NZBs that are already complete, and TV show search finally uses IMDb ID so it finds the right show every time.
 
@@ -1254,7 +1254,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.2.0] — 2026-04-05
+## [0.2.0][] — 2026-04-05
 
 > **Kodi localization support.** The addon UI and settings labels are now driven through Kodi's standard string system, so translations are possible.
 
@@ -1268,7 +1268,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.1.0] — 2026-04-05
+## [0.1.0][] — 2026-04-05
 
 > **Initial release.** Search NZBHydra2, submit to nzbdav, stream via WebDAV — all wrapped in a TMDBHelper player.
 
@@ -1286,6 +1286,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[2.0.0-beta.1]: https://github.com/Appz4Fun/nzbdavkodi/compare/v1.2.3...v2.0.0-beta.1
+[1.2.3]: https://github.com/Appz4Fun/nzbdavkodi/compare/v1.2.2...v1.2.3
+[1.2.2]: https://github.com/Appz4Fun/nzbdavkodi/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Appz4Fun/nzbdavkodi/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Appz4Fun/nzbdavkodi/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Appz4Fun/nzbdavkodi/compare/v1.0.9...v1.1.0

--- a/repo/plugin.video.nzbdav/addon.py
+++ b/repo/plugin.video.nzbdav/addon.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 nzbdav contributors
 
+"""Plugin entry point: dispatch plugin:// invocations to the router."""
+
 import faulthandler
 import os
 import sys

--- a/repo/plugin.video.nzbdav/resources/lib/dead_candidates.py
+++ b/repo/plugin.video.nzbdav/resources/lib/dead_candidates.py
@@ -34,9 +34,11 @@ class DeadCandidates:
             self._nzo_ids.add(nzo_id)
 
     def has_url(self, nzb_url):
+        """Return True when ``nzb_url`` is a recorded dead candidate."""
         return bool(nzb_url) and nzb_url in self._urls
 
     def has_nzo(self, nzo_id):
+        """Return True when ``nzo_id`` is a recorded dead candidate."""
         return bool(nzo_id) and nzo_id in self._nzo_ids
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/direct_indexers.py
+++ b/repo/plugin.video.nzbdav/resources/lib/direct_indexers.py
@@ -136,6 +136,7 @@ def _configured_json_indexer(item):
 
 
 def get_legacy_configured_indexers(addon=None):
+    """Return the legacy settings.xml preset and custom-slot direct indexers."""
     addon = addon or xbmcaddon.Addon("plugin.video.nzbdav")
     configured = []
     for indexer_id, label, default_url in PRESET_INDEXERS:

--- a/repo/plugin.video.nzbdav/resources/lib/dv_rpu.py
+++ b/repo/plugin.video.nzbdav/resources/lib/dv_rpu.py
@@ -35,6 +35,8 @@ _NLQ_NUM_PIVOTS = 2
 
 @dataclass
 class DolbyVisionRpuInfo:
+    """Structured DV classification: detected profile and optional EL type."""
+
     profile: int
     el_type: Optional[str] = None
 
@@ -52,6 +54,7 @@ class _BitReader:
         self.bit_pos = 0
 
     def read_bit(self):
+        """Read and return the next bit MSB-first; raise ValueError if truncated."""
         byte_index = self.bit_pos // 8
         if byte_index >= len(self.data):
             # Truncated payload — caller (`parse_unspec62_nalu`) wraps
@@ -67,12 +70,14 @@ class _BitReader:
         return (self.data[byte_index] >> bit_index) & 1
 
     def read_bits(self, count):
+        """Read ``count`` bits MSB-first and return them as an unsigned integer."""
         value = 0
         for _ in range(count):
             value = (value << 1) | self.read_bit()
         return value
 
     def read_ue(self):
+        """Read and return an unsigned Exp-Golomb ``ue(v)`` value."""
         zeros = 0
         while self.read_bit() == 0:
             zeros += 1
@@ -86,12 +91,14 @@ class _BitReader:
         return (1 << zeros) - 1 + self.read_bits(zeros)
 
     def read_se(self):
+        """Read and return a signed Exp-Golomb ``se(v)`` value."""
         value = self.read_ue()
         if value % 2 == 0:
             return -(value // 2)
         return (value + 1) // 2
 
     def read_var(self, bit_count):
+        """Read ``bit_count`` bits; alias for read_bits kept for dovi_tool parity."""
         # Alias for read_bits, preserved for grep parity with dovi_tool's
         # `read_var` naming in rpu_data_mapping.rs / rpu_data_nlq.rs.
         return self.read_bits(bit_count)
@@ -113,6 +120,7 @@ class _RpuHeader:
     use_prev_vdr_rpu_flag: bool
 
     def get_dovi_profile(self):
+        """Return the Dolby Vision profile derived from the header fields."""
         if self.vdr_rpu_profile == 0:
             return 5 if self.bl_video_full_range_flag else 0
         if self.vdr_rpu_profile == 1:
@@ -137,6 +145,7 @@ class _RpuNlq:
     linear_deadzone_threshold: list
 
     def is_mel(self):
+        """Return True when the NLQ fields match the MEL pattern (not FEL)."""
         # MEL has every NLQ field zeroed except vdr_in_max_int, which is all
         # ones. Each (values, expected) pair must hold across all components.
         checks = (
@@ -151,6 +160,7 @@ class _RpuNlq:
         return all(all(v == expected for v in values) for values, expected in checks)
 
     def el_type(self):
+        """Return ``"MEL"`` or ``"FEL"`` from the NLQ classification."""
         return "MEL" if self.is_mel() else "FEL"
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/dv_source.py
+++ b/repo/plugin.video.nzbdav/resources/lib/dv_source.py
@@ -45,6 +45,8 @@ _EBML_ID_BLOCK = 0xA1
 
 @dataclass
 class DolbyVisionSourceResult:
+    """Structured DV source probe result driving fMP4 vs Matroska routing."""
+
     classification: str
     reason: str
     profile: Optional[int] = None

--- a/repo/plugin.video.nzbdav/resources/lib/episode_inventory.py
+++ b/repo/plugin.video.nzbdav/resources/lib/episode_inventory.py
@@ -26,6 +26,8 @@ _AMBIGUOUS_LEADING_MARKERS = frozenset(("extra", "extras", "trailer", "trailers"
 
 
 class VideoFile(NamedTuple):
+    """One candidate video file with its episode tags and auxiliary flag."""
+
     path: str
     size: int
     episode_tags: frozenset
@@ -33,6 +35,8 @@ class VideoFile(NamedTuple):
 
 
 class VideoInventory(NamedTuple):
+    """Result of episode-aware selection over a set of video files."""
+
     selected_path: Optional[str]
     selected_size: int
     files: tuple

--- a/repo/plugin.video.nzbdav/resources/lib/exact_job.py
+++ b/repo/plugin.video.nzbdav/resources/lib/exact_job.py
@@ -19,18 +19,22 @@ class ExactJobLookup(NamedTuple):
 
     @property
     def state(self):
+        """Return the tri-state name: "transient", "valid", or "stale"."""
         if not self.lookup_done:
             return "transient"
         return "valid" if self.job is not None else "stale"
 
     @classmethod
     def valid(cls, job):
+        """Return a lookup holding the exact completed ``job``."""
         return cls(job, True)
 
     @classmethod
     def stale(cls):
+        """Return a lookup proving the exact job is absent or no longer completed."""
         return cls(None, True)
 
     @classmethod
     def transient(cls):
+        """Return a lookup marking the backend as inconclusive."""
         return cls(None, False)

--- a/repo/plugin.video.nzbdav/resources/lib/hydra.py
+++ b/repo/plugin.video.nzbdav/resources/lib/hydra.py
@@ -4,7 +4,6 @@
 """NZBHydra2 Newznab API client."""
 
 from datetime import datetime, timezone
-from urllib.error import URLError
 from urllib.parse import urlencode, urlparse
 
 import xbmc
@@ -144,7 +143,8 @@ def _fetch_hydra_xml(request_url, error_prefix):
     """Fetch XML from Hydra and normalize network/runtime failures."""
     try:
         return _http_get(request_url, timeout=300), None
-    except (URLError,) + _HYDRA_REQUEST_ERRORS as error:
+    except _HYDRA_REQUEST_ERRORS as error:
+        # URLError falls under OSError in _HYDRA_REQUEST_ERRORS.
         # HTTPError/URLError str() can echo the failing URL (which embeds
         # the indexer's apikey query param) back into the log. Redact
         # before logging — same defense as the prowlarr fallback path.

--- a/repo/plugin.video.nzbdav/resources/lib/indexer_presets.py
+++ b/repo/plugin.video.nzbdav/resources/lib/indexer_presets.py
@@ -39,6 +39,7 @@ _MULTIPLE_UNDERSCORES_RE = re.compile(r"_+")
 
 
 def slugify_preset_id(name):
+    """Return a slug: ``name`` lowercased with non-alphanumerics as underscores."""
     value = _NON_ALPHANUMERIC_RE.sub("_", name).strip("_").lower()
     return _MULTIPLE_UNDERSCORES_RE.sub("_", value)
 
@@ -48,6 +49,7 @@ def _preset(indexer_id, name, api_url):
 
 
 def list_newznab_presets():
+    """Return all Newznab presets as dicts, sorted by display name."""
     return [
         _preset(indexer_id, name, api_url)
         for indexer_id, name, api_url in sorted(
@@ -58,6 +60,7 @@ def list_newznab_presets():
 
 
 def get_preset(indexer_id):
+    """Return the preset dict for ``indexer_id``, or None if unknown."""
     for preset in list_newznab_presets():
         if preset["id"] == indexer_id:
             return preset
@@ -65,5 +68,6 @@ def get_preset(indexer_id):
 
 
 def host_contains(host, needles):
+    """Return True when ``host`` contains any of ``needles`` (case-insensitive)."""
     lowered = str(host or "").lower()
     return any(str(needle).lower() in lowered for needle in needles)

--- a/repo/plugin.video.nzbdav/resources/lib/indexer_store.py
+++ b/repo/plugin.video.nzbdav/resources/lib/indexer_store.py
@@ -26,10 +26,12 @@ def _profile_path():
 
 
 def default_indexers_path():
+    """Return the default filesystem path to the indexers JSON file."""
     return os.path.join(_profile_path(), INDEXERS_FILENAME)
 
 
 def default_provider_caps_path():
+    """Return the default filesystem path to the provider caps JSON file."""
     return os.path.join(_profile_path(), PROVIDER_CAPS_FILENAME)
 
 
@@ -54,6 +56,7 @@ def _bool_setting(value, default=False):
 
 
 def normalize_caps(caps):
+    """Return a normalized copy of a caps dict, coercing known field types."""
     if not isinstance(caps, dict):
         return {}
 
@@ -72,6 +75,7 @@ def normalize_caps(caps):
 
 
 def normalize_indexer(item):
+    """Return a normalized indexer dict with defaulted fields and enabled flag."""
     item = item if isinstance(item, dict) else {}
     deleted = bool(item.get("deleted"))
     if deleted:
@@ -110,6 +114,7 @@ def _ensure_parent_dir(path):
 
 
 def load_indexers(path=None):
+    """Load and normalize the stored indexers from ``path`` (default profile path)."""
     path = path or default_indexers_path()
     data = _read_json(path, {}, "NZB-DAV: Failed to read indexers JSON")
     indexers = data.get("indexers", []) if isinstance(data, dict) else []
@@ -119,6 +124,7 @@ def load_indexers(path=None):
 
 
 def save_indexers(indexers, path=None):
+    """Write ``indexers`` as normalized JSON to ``path`` (default profile path)."""
     path = path or default_indexers_path()
     _ensure_parent_dir(path)
     payload = {
@@ -145,6 +151,7 @@ def _normalize_provider_caps(data):
 
 
 def load_provider_caps(path=None):
+    """Load and normalize the stored provider caps from ``path``."""
     path = path or default_provider_caps_path()
     data = _read_json(path, {}, "NZB-DAV: Failed to read provider caps JSON")
     if not isinstance(data, dict):
@@ -153,6 +160,7 @@ def load_provider_caps(path=None):
 
 
 def save_provider_caps(providers, path=None):
+    """Write ``providers`` caps as normalized JSON to ``path``."""
     path = path or default_provider_caps_path()
     _ensure_parent_dir(path)
     payload = {

--- a/repo/plugin.video.nzbdav/resources/lib/kodi_advancedsettings.py
+++ b/repo/plugin.video.nzbdav/resources/lib/kodi_advancedsettings.py
@@ -13,7 +13,7 @@ See TODO.md §D.2.3 (advancedsettings bypass) and §D.5.1 (Phase 1 plan).
 """
 
 import os
-from xml.etree import ElementTree as ET
+from xml.etree import ElementTree
 
 import xbmcvfs
 
@@ -53,7 +53,7 @@ def has_cache_memorysize_zero():
         return False
     try:
         root = _parse_local_xml_root(path)
-    except (ET.ParseError, OSError, ValueError):
+    except (ElementTree.ParseError, OSError, ValueError):
         return False
     cache = root.find("cache")
     if cache is None:

--- a/repo/plugin.video.nzbdav/resources/lib/newznab_caps.py
+++ b/repo/plugin.video.nzbdav/resources/lib/newznab_caps.py
@@ -43,6 +43,7 @@ def normalize_api_endpoint(api_url):
 
 
 def build_caps_url(api_url, api_key):
+    """Build the Newznab ``t=caps`` URL for ``api_url`` with ``api_key``."""
     parts = urlsplit(normalize_api_endpoint(api_url))
     query = [
         (key, value)
@@ -78,6 +79,7 @@ def _params(value):
 
 
 def parse_caps(xml_text):
+    """Parse Newznab caps XML into search types, supported params, and categories."""
     try:
         root = _safe_fromstring(xml_text)
     except (_XmlParseError, _UnsafeXmlError, TypeError):
@@ -108,6 +110,7 @@ def parse_caps(xml_text):
 
 
 def fetch_caps(api_url, api_key, timeout=15):
+    """Fetch and parse Newznab caps, returning ``(caps, error)``."""
     url = build_caps_url(api_url, api_key)
     try:
         response = _http_get(url, timeout=timeout, max_bytes=CAPS_MAX_BYTES)

--- a/repo/plugin.video.nzbdav/resources/lib/nzb_manifest.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzb_manifest.py
@@ -561,6 +561,8 @@ def _valid_nzb_url(url):
         parts = urlsplit(url)
         if not _safe_nzb_url_parts(parts):
             return False
+        # parts.port raises ValueError for out-of-range/non-numeric ports;
+        # the value itself is unused.
         _port = parts.port
     except ValueError:
         return False

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_entry.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_entry.py
@@ -45,6 +45,7 @@ class _ResolveSideEffects:
         self.fallback_state = None
 
     def start_cleanup_once(self):
+        """Start the playback-state cleanup once, memoizing ``cleanup_state``."""
         if self.cleanup_state is None:
             self.cleanup_state = _resolver._start_playback_state_cleanup(self._params)
 
@@ -61,6 +62,7 @@ class _ResolveSideEffects:
         )
 
     def start_fallback_after_primary(self, _nzo_id):
+        """Start cleanup, then the fallback submit worker once after primary submit."""
         self.start_cleanup_once()
         if self.fallback_state is None:
             kwargs = {

--- a/repo/plugin.video.nzbdav/resources/lib/search_planner.py
+++ b/repo/plugin.video.nzbdav/resources/lib/search_planner.py
@@ -30,6 +30,8 @@ class SearchQuery(NamedTuple):
 
 @dataclass(frozen=True)
 class NewznabSearchPlan:
+    """A planned Newznab search: primary params, fallback params, and reason."""
+
     primary: dict
     fallback: dict
     reason: str
@@ -43,6 +45,7 @@ def plan_newznab_search(
     api_key="",
     max_results=25,
 ):
+    """Return a NewznabSearchPlan for one search request, honoring advertised caps."""
     search_type = query.search_type
     title = query.title
     year = query.year

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_buffer.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_buffer.py
@@ -155,20 +155,25 @@ class ReadAheadBuffer:
             self.served_high_water = max(self.served_high_water, new_start)
 
     def space_remaining(self):
+        """Return the free bytes left before the window reaches ``cap_bytes`` (>= 0)."""
         with self._lock:
             remaining = self.cap_bytes - len(self.data)
         return remaining if remaining > 0 else 0
 
     def next_fetch_offset(self):
+        """Return the offset just past the buffered window (where prefetch resumes)."""
         with self._lock:
             return self.base_offset + len(self.data)
 
     def is_full(self):
+        """Return True when the buffered window has reached ``cap_bytes``."""
         with self._lock:
             return len(self.data) >= self.cap_bytes
 
     def stop(self):
+        """Signal the prefetch thread to stop."""
         self._stop.set()
 
     def should_stop(self):
+        """Return True once ``stop`` has been called."""
         return self._stop.is_set()

--- a/repo/plugin.video.nzbdav/service.py
+++ b/repo/plugin.video.nzbdav/service.py
@@ -343,7 +343,8 @@ class NzbdavPlayer(xbmc.Player):
         except _PLAYER_RUNTIME_ERRORS:
             pass
 
-    def _clear_stable_resume(self, resume_key):
+    @staticmethod
+    def _clear_stable_resume(resume_key):
         if not resume_key:
             return
         try:

--- a/tests-extensive/extreme/_fixtures.py
+++ b/tests-extensive/extreme/_fixtures.py
@@ -127,6 +127,7 @@ def compose_up(env_loaded, run_dir):
 
 @pytest.fixture(scope="session")
 def nzbdav_seeded(compose_up):
+    """Seed nzbdav by running the seed_nzbdav.sh script."""
     seed = EXTREME_DIR / "scripts" / "seed_nzbdav.sh"
     env = os.environ.copy()
     env["NZBDAV_URL"] = f"http://localhost:{NZBDAV_HOST_PORT}"
@@ -163,18 +164,21 @@ def kodi_ready(compose_up, nzbdav_seeded):
 
 @pytest.fixture(scope="session")
 def jurialmunkey_repo_added(kodi_ready):
+    """Install the jurialmunkey Kodi repo into the running container."""
     script = EXTREME_DIR / "scripts" / "install_jurialmunkey_repo.sh"
     _run(["bash", str(script), "nzbdav-extreme-kodi"])
 
 
 @pytest.fixture(scope="session")
 def tmdbhelper_installed(jurialmunkey_repo_added):
+    """Install TMDBHelper from the jurialmunkey repo."""
     script = EXTREME_DIR / "scripts" / "install_tmdbhelper.sh"
     _run(["bash", str(script), f"http://localhost:{KODI_HOST_PORT}", "kodi:kodi"])
 
 
 @pytest.fixture(scope="session")
 def nzbdav_addon_installed(tmdbhelper_installed):
+    """Install the nzbdav addon using the settings template."""
     script = EXTREME_DIR / "scripts" / "install_nzbdav_addon.sh"
     template = EXTREME_DIR / "fixtures" / "addon-settings-template.xml"
     _run(
@@ -191,6 +195,7 @@ def nzbdav_addon_installed(tmdbhelper_installed):
 
 @pytest.fixture(scope="session")
 def tmdbhelper_player_added(nzbdav_addon_installed):
+    """Copy the nzbdav player file into TMDBHelper's players directory."""
     src = EXTREME_DIR / "fixtures" / "nzbdav-player.json"
     _run(
         [

--- a/tests-extensive/extreme/scripts/bulk_submit_dups.py
+++ b/tests-extensive/extreme/scripts/bulk_submit_dups.py
@@ -230,6 +230,7 @@ def process_movie(movie: dict) -> dict:
 
 
 def main():
+    """Process every IMDB Top 50 movie in parallel and write a summary."""
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     started = time.time()
     summary = []

--- a/tests-extensive/extreme/scripts/cinefile_fallback_loop.py
+++ b/tests-extensive/extreme/scripts/cinefile_fallback_loop.py
@@ -47,6 +47,7 @@ OUT_DIR = Path(os.environ.get("CINEFILE_OUT_DIR", "/tmp/cinefile_loop")).resolve
 
 
 def redact_url(url: str) -> str:
+    """Strip userinfo/query/fragment from a URL, leaving host and path."""
     parts = urllib.parse.urlsplit(url)
     if not parts.netloc:
         return url
@@ -78,6 +79,7 @@ def _kodi_rpc(method: str, params: dict | None = None, timeout: int = 10):
 
 
 def list_completed_cinefile_storages() -> list[str]:
+    """Return storage paths for completed CiNEFiLE history slots."""
     qs = urllib.parse.urlencode(
         {
             "mode": "history",
@@ -161,6 +163,7 @@ def storage_to_stream_url(storage: str) -> str:
 
 
 def schedule_fault(at_seconds: float, fault_type: str = "connection_reset"):
+    """Schedule a fault-proxy fault event at the given offset."""
     body = json.dumps(
         {"events": [{"at_seconds": at_seconds, "fault_type": fault_type}]}
     ).encode("utf-8")
@@ -191,6 +194,7 @@ def clear_fault_schedule():
 
 
 def stop_player():
+    """Stop any active Kodi player, ignoring errors."""
     try:
         resp = _kodi_rpc("Player.GetActivePlayers")
         for p in resp.get("result", []) or []:
@@ -224,6 +228,7 @@ def play_via_direct_play(primary_url: str, fallback_urls: list[str]):
 
 
 def player_status() -> dict:
+    """Return the active Kodi player's id and playback properties."""
     try:
         active = _kodi_rpc("Player.GetActivePlayers").get("result", []) or []
         if not active:
@@ -242,6 +247,7 @@ def player_status() -> dict:
 
 
 def time_to_seconds(time_obj) -> float:
+    """Convert a Kodi Player.GetProperties time dict to total seconds."""
     if not isinstance(time_obj, dict):
         return 0.0
     return (
@@ -253,6 +259,7 @@ def time_to_seconds(time_obj) -> float:
 
 
 def run_iteration(iteration: int, urls: list[str], log: Path) -> dict:
+    """Play one primary/fallback cutover iteration and log its timeline."""
     primary = urls[iteration % len(urls)]
     fallback_pool = [u for u in urls if u != primary]
     summary = {
@@ -264,6 +271,7 @@ def run_iteration(iteration: int, urls: list[str], log: Path) -> dict:
     }
 
     def record(event_type: str, **kw):
+        """Append a timestamped event to the summary and the JSONL log."""
         rec = {"t": time.time(), "type": event_type, **kw}
         summary["events"].append(rec)
         with log.open("a") as fh:
@@ -332,6 +340,7 @@ def run_iteration(iteration: int, urls: list[str], log: Path) -> dict:
 
 
 def main():
+    """Discover CiNEFiLE storages and run all fallback-cutover iterations."""
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     log = OUT_DIR / "cinefile_loop.jsonl"
     if log.exists():

--- a/tests-extensive/extreme/scripts/cinefile_proxy_swap_loop.py
+++ b/tests-extensive/extreme/scripts/cinefile_proxy_swap_loop.py
@@ -80,6 +80,7 @@ def _kodi_rpc(method: str, params: dict | None = None, timeout: int = 10):
 
 
 def url_with_auth(host: str, path: str) -> str:
+    """Build a WebDAV URL with basic-auth credentials embedded."""
     return "http://{}:{}@{}{}".format(
         urllib.parse.quote(WEBDAV_USERNAME, safe=""),
         urllib.parse.quote(WEBDAV_PASSWORD, safe=""),
@@ -89,6 +90,7 @@ def url_with_auth(host: str, path: str) -> str:
 
 
 def redact_url(url: str) -> str:
+    """Strip userinfo/query/fragment from a URL, leaving host and path."""
     parts = urllib.parse.urlsplit(url)
     if not parts.netloc:
         return url
@@ -101,6 +103,7 @@ def redact_url(url: str) -> str:
 
 
 def schedule_fault(at_seconds: float, fault_type: str = "connection_reset"):
+    """Schedule a fault-proxy fault event at the given offset."""
     body = json.dumps(
         {"events": [{"at_seconds": at_seconds, "fault_type": fault_type}]}
     ).encode("utf-8")
@@ -115,6 +118,7 @@ def schedule_fault(at_seconds: float, fault_type: str = "connection_reset"):
 
 
 def clear_fault_schedule():
+    """POST an empty schedule so prior iterations' faults don't fire."""
     body = json.dumps({"events": []}).encode("utf-8")
     req = urllib.request.Request(
         "{}/control/schedule".format(FAULT_PROXY_CONTROL),
@@ -130,6 +134,7 @@ def clear_fault_schedule():
 
 
 def stop_player():
+    """Stop any active Kodi player, ignoring errors."""
     try:
         for p in _kodi_rpc("Player.GetActivePlayers").get("result", []) or []:
             _kodi_rpc("Player.Stop", {"playerid": p.get("playerid", 1)})
@@ -155,6 +160,7 @@ def trigger_direct_play(primary_url: str, fallback_urls: list[str]):
 
 
 def player_status() -> dict:
+    """Return the active Kodi player's type and playback properties."""
     try:
         active = _kodi_rpc("Player.GetActivePlayers").get("result", []) or []
         if not active:
@@ -176,6 +182,7 @@ def player_status() -> dict:
 
 
 def time_to_seconds(time_obj) -> float:
+    """Convert a Kodi Player.GetProperties time dict to total seconds."""
     if not isinstance(time_obj, dict):
         return 0.0
     return (
@@ -187,6 +194,7 @@ def time_to_seconds(time_obj) -> float:
 
 
 def run_iteration(iteration: int, path_a: str, path_b: str, log: Path) -> dict:
+    """Play one alternating primary/fallback iteration and log its timeline."""
     primary_path = path_a if iteration % 2 == 0 else path_b
     fallback_path = path_b if iteration % 2 == 0 else path_a
     primary_url = url_with_auth(HOST_FAULTPROXY, primary_path)  # via fault-proxy
@@ -269,6 +277,7 @@ def _discover_paths() -> tuple[str, str]:
 
 
 def main():
+    """Discover storages and run all proxy-swap iterations."""
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     log = OUT_DIR / "proxy_swap.jsonl"
     if log.exists():

--- a/tests-extensive/extreme/scripts/cinefile_two_stream_loop.py
+++ b/tests-extensive/extreme/scripts/cinefile_two_stream_loop.py
@@ -79,6 +79,7 @@ WEBDAV_BASE_WITH_AUTH = _build_base_with_auth()
 
 
 def redact_url(url: str) -> str:
+    """Strip userinfo/query/fragment from a URL, leaving host and path."""
     parts = urllib.parse.urlsplit(url)
     if not parts.netloc:
         return url
@@ -169,6 +170,7 @@ def _stream_url_with_auth(mkv_path: str) -> str:
 
 
 def find_two_streamable_urls() -> list[str]:
+    """Find and verify two byte-distinct streamable CiNEFiLE upload URLs."""
     qs = urllib.parse.urlencode(
         {
             "mode": "history",
@@ -219,6 +221,7 @@ def find_two_streamable_urls() -> list[str]:
 
 
 def player_status() -> dict:
+    """Return the active Kodi player's id and playback properties."""
     try:
         active = _kodi_rpc("Player.GetActivePlayers").get("result", []) or []
         if not active:
@@ -237,6 +240,7 @@ def player_status() -> dict:
 
 
 def time_to_seconds(time_obj) -> float:
+    """Convert a Kodi Player.GetProperties time dict to total seconds."""
     if not isinstance(time_obj, dict):
         return 0.0
     return (
@@ -248,6 +252,7 @@ def time_to_seconds(time_obj) -> float:
 
 
 def stop_player():
+    """Stop any active Kodi player, ignoring errors."""
     try:
         for p in _kodi_rpc("Player.GetActivePlayers").get("result", []) or []:
             _kodi_rpc("Player.Stop", {"playerid": p.get("playerid", 1)})
@@ -256,10 +261,12 @@ def stop_player():
 
 
 def play(url: str):
+    """Tell Kodi to open and play the given URL."""
     return _kodi_rpc("Player.Open", {"item": {"file": url}})
 
 
 def play_window(url: str, label: str, log: Path, iteration: int) -> dict:
+    """Play url for PER_STREAM_PLAY_SECONDS and return its progress metrics."""
     play_resp = play(url)
     started_at = time.time()
     deadline = started_at + PER_STREAM_PLAY_SECONDS
@@ -308,6 +315,7 @@ def play_window(url: str, label: str, log: Path, iteration: int) -> dict:
 
 
 def main():
+    """Find two streamable CiNEFiLE URLs and alternate playing them."""
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     log = OUT_DIR / "two_stream.jsonl"
     if log.exists():

--- a/tests-extensive/extreme/scripts/cinefile_user_two.py
+++ b/tests-extensive/extreme/scripts/cinefile_user_two.py
@@ -40,6 +40,7 @@ OUT_DIR = Path(os.environ.get("CINEFILE_OUT_DIR", "/tmp/cinefile_user_two")).res
 
 
 def redact_url(url: str) -> str:
+    """Strip userinfo/query/fragment from a URL, leaving host and path."""
     parts = urllib.parse.urlsplit(url)
     if not parts.netloc:
         return url
@@ -83,6 +84,7 @@ def _build_kodi_url(mkv_path: str) -> str:
 
 
 def player_status() -> dict:
+    """Return the active Kodi player's id, type, and playback properties."""
     try:
         active = _kodi_rpc("Player.GetActivePlayers").get("result", []) or []
         if not active:
@@ -104,6 +106,7 @@ def player_status() -> dict:
 
 
 def time_to_seconds(time_obj) -> float:
+    """Convert a Kodi Player.GetProperties time dict to total seconds."""
     if not isinstance(time_obj, dict):
         return 0.0
     return (
@@ -115,6 +118,7 @@ def time_to_seconds(time_obj) -> float:
 
 
 def stop_player():
+    """Stop any active Kodi player, ignoring errors."""
     try:
         for p in _kodi_rpc("Player.GetActivePlayers").get("result", []) or []:
             _kodi_rpc("Player.Stop", {"playerid": p.get("playerid", 1)})
@@ -123,10 +127,12 @@ def stop_player():
 
 
 def play(url: str):
+    """Tell Kodi to open and play the given URL."""
     return _kodi_rpc("Player.Open", {"item": {"file": url}})
 
 
 def play_window(url: str, label: str, log: Path, iteration: int) -> dict:
+    """Play url for PER_STREAM_PLAY_SECONDS and return its progress metrics."""
     play_resp = play(url)
     started_at = time.time()
     deadline = started_at + PER_STREAM_PLAY_SECONDS
@@ -176,6 +182,7 @@ def play_window(url: str, label: str, log: Path, iteration: int) -> dict:
 
 
 def main():
+    """Discover two CiNEFiLE storages and alternate playing them."""
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     log = OUT_DIR / "user_two.jsonl"
     if log.exists():

--- a/tests-extensive/extreme/scripts/install_nzbdav_addon.sh
+++ b/tests-extensive/extreme/scripts/install_nzbdav_addon.sh
@@ -40,8 +40,15 @@ kodi_version_supported() {
 echo "[nzbdav-addon] just release"
 ( cd "$REPO_ROOT" && just release )
 
-# `just release` writes the addon zip to the repository root; find the latest.
-ZIP="$(ls -t "$REPO_ROOT"/plugin.video.nzbdav-*.zip 2>/dev/null | head -n1)"
+# `just release` writes the addon zip to the repository root; find the latest
+# by mtime with a glob + `-nt` so odd filenames can't break word splitting.
+ZIP=""
+for zip_candidate in "$REPO_ROOT"/plugin.video.nzbdav-*.zip; do
+    [[ -e "$zip_candidate" ]] || continue
+    if [[ -z "$ZIP" || "$zip_candidate" -nt "$ZIP" ]]; then
+        ZIP="$zip_candidate"
+    fi
+done
 if [[ -z "$ZIP" ]]; then
     echo "[nzbdav-addon] FATAL: no zip found in $REPO_ROOT/"
     exit 1
@@ -74,6 +81,7 @@ RENDERED="$WORKDIR/settings.xml"
 # bypasses OrbStack's transparent proxy for RFC1918 destinations via
 # NO_PROXY (set on the kodi-desktop service in docker-compose.yml), so
 # LAN-hosted Hydra URLs work without rewriting.
+# shellcheck disable=SC2016  # envsubst needs the ${VAR} tokens literal
 SUBST_VARS='${HYDRA_URL} ${HYDRA_API_KEY} ${NZBDAV_API_KEY} ${WEBDAV_USERNAME} ${WEBDAV_PASSWORD}'
 for var_name in HYDRA_URL HYDRA_API_KEY NZBDAV_API_KEY WEBDAV_USERNAME WEBDAV_PASSWORD; do
     if [[ -z "${!var_name:-}" ]]; then

--- a/tests-extensive/extreme/scripts/install_tmdbhelper.sh
+++ b/tests-extensive/extreme/scripts/install_tmdbhelper.sh
@@ -142,9 +142,9 @@ if [[ $fail -ne 0 ]]; then
     docker exec "$CONTAINER" ls -la /root/.kodi/addons || true
     echo "[tmdbhelper] tail of kodi.log (broken/install/dependency):"
     docker exec "$CONTAINER" sh -c \
-      'log=$(ls /root/.kodi/temp/kodi*.log 2>/dev/null | head -1); \
-       if [ -n "$log" ]; then \
-         grep -iE "broken|missing|depend|install|themoviedb|tmdbhelper" "$log" | tail -80; \
+      'log=$(ls /root/.kodi/temp/kodi*.log 2>/dev/null | head -1)
+       if [ -n "$log" ]; then
+         grep -iE "broken|missing|depend|install|themoviedb|tmdbhelper" "$log" | tail -80
        else echo "(no kodi.log)"; fi' || true
     exit 1
 fi
@@ -164,6 +164,6 @@ echo "[tmdbhelper] FATAL: $ADDON_ID not in installed+enabled state within 60s"
 echo "$state"
 echo "[tmdbhelper] --- diagnostics ---"
 docker exec "$CONTAINER" sh -c \
-  'log=$(ls /root/.kodi/temp/kodi*.log 2>/dev/null | head -1); \
+  'log=$(ls /root/.kodi/temp/kodi*.log 2>/dev/null | head -1)
    [ -n "$log" ] && grep -iE "broken|missing|depend|themoviedb|tmdbhelper" "$log" | tail -80'
 exit 1

--- a/tests-extensive/test_extreme_functional.py
+++ b/tests-extensive/test_extreme_functional.py
@@ -291,6 +291,7 @@ def _wait_for_player(timeout=30):
 
 
 def test_extreme_fallback_run(stack_ready, run_dir):
+    """Play a movie through TMDBHelper while faults trigger fallback cutover."""
     seed_value = _seed()
     rng = random.Random(seed_value)
 

--- a/tests-extensive/test_functional_fallback_playback.py
+++ b/tests-extensive/test_functional_fallback_playback.py
@@ -392,6 +392,7 @@ def _movie_search_pool(settings, movie, query_title=None, use_imdb=True):
 
 
 def test_movie_search_pool_passes_live_settings_to_hydra_search():
+    """Assert _movie_search_pool forwards live settings into search_hydra."""
     settings = {
         "hydra_url": "http://live-hydra:5076",
         "hydra_api_key": "live-key",
@@ -405,6 +406,7 @@ def test_movie_search_pool_passes_live_settings_to_hydra_search():
     captured = {}
 
     def fake_search(search_type, title, year="", imdb="", settings_getter=None, **_kw):
+        """Record the search args and settings passed by _movie_search_pool."""
         captured.update(
             {
                 "search_type": search_type,
@@ -900,9 +902,11 @@ class _FailingPrimaryWebdavHandler(BaseHTTPRequestHandler):
         return
 
     def do_HEAD(self):
+        """Serve a HEAD request for the primary stream, without a body."""
         self._send_primary(include_body=False)
 
     def do_GET(self):
+        """Serve a GET request for the primary stream, with a body."""
         self._send_primary(include_body=True)
 
     def _send_primary(self, include_body):
@@ -1157,6 +1161,7 @@ def _looks_like_availability_failure(error):
 
 
 def test_functional_matrix_fallback_playback_submits_to_nzbdav_and_switches():
+    """Exercise live fallback playback for The Matrix against real services."""
     env = _live_env()
     settings = _addon_settings(env)
     runtime = _functional_runtime_config()
@@ -1174,6 +1179,7 @@ def test_functional_matrix_fallback_playback_submits_to_nzbdav_and_switches():
 
 
 def test_functional_imdb_top50_random_sample_fallback_playback():
+    """Exercise live fallback playback across a random IMDb Top 50 sample."""
     env = _live_env()
     settings = _addon_settings(env)
     runtime = _functional_runtime_config()

--- a/tests-extensive/test_functional_playback.py
+++ b/tests-extensive/test_functional_playback.py
@@ -44,7 +44,8 @@ class KodiJSONRPC:
             {"window": "addonbrowser", "parameters": [f"addonid={addon_id}"]},
         )
 
-    def wait_for_property(self, check_fn, timeout=30, interval=0.5):
+    @staticmethod
+    def wait_for_property(check_fn, timeout=30, interval=0.5):
         """Wait for a property condition to be true."""
         start = time.time()
         while time.time() - start < timeout:

--- a/tests-extensive/test_live_services.py
+++ b/tests-extensive/test_live_services.py
@@ -105,6 +105,7 @@ def _candidate_pool(results, title, pool_limit):
 
 
 def test_live_hydra_matrix_search_produces_fallback_candidates():
+    """Confirm a live Hydra search yields linked fallback candidates."""
     env = _live_env()
     search = _live_search_config()
     settings = _addon_settings(env)
@@ -142,6 +143,7 @@ def test_live_hydra_matrix_search_produces_fallback_candidates():
 
 
 def test_live_nzbdav_api_and_webdav_are_reachable():
+    """Confirm the live nzbdav queue API and WebDAV endpoint respond."""
     env = _live_env()
     settings = _addon_settings(env)
     params = {


### PR DESCRIPTION
## What

Works through the [1,979 open code-scanning alerts](https://github.com/Appz4Fun/nzbdavkodi/security/code-scanning) left behind by the Codacy Security Scan workflow that was retired in #433, and fixes everything that is still live in the current tree and genuinely worth fixing:

| Category | Alerts | Action |
|---|---|---|
| Missing docstrings (PyLint C0111) | ~99 non-vendored | **Fixed** — 92 docstrings added (runtime libs, `addon.py`, tests-extensive); the rest had already been resolved by refactors since the last Codacy scan |
| CHANGELOG reference links (remark-lint) | 48 | **Fixed** — 43 headings converted to collapsed reference form, 3 missing version link definitions added (`2.0.0-beta.1`, `1.2.3`, `1.2.2` were rendering as broken plain text) |
| Shellcheck SC1004/SC2012/SC2016 | 6 | **Fixed** — both extreme-test install scripts are now shellcheck-clean |
| `ET` acronym import (pep8-naming N817) | 10 | **Fixed** — last remaining site (`kodi_advancedsettings.py`); others already renamed on main |
| No-self-use methods (R0201) | 14 | **Fixed** — 2 remaining sites converted to `@staticmethod`; 5 sites already gone |
| Invalid exception operation (W0716) | 1 | **Fixed** — dropped redundant `(URLError,) +` concat in `hydra.py` (`URLError` ⊂ `OSError`, already in `_HYDRA_REQUEST_ERRORS`) |
| `_port` unused (pyflakes F841) | 2 | 1 already gone; 1 annotated — it deliberately triggers `ValueError` on invalid URL ports |
| Duplicate defs (E0102), `urlopen` redef (F811) | 4 | Already fixed on main / intentional documented pattern |

## Not fixed (and why)

- **`bad-continuation` / `bad-whitespace` (~1,367)** — pylint 1.x indentation rules that directly conflict with the repo's enforced black formatting; false positives under current tooling.
- **`locally-disabled` meta-warnings (134)** — Prospector complaining that `# pylint: disable` comments exist.
- **`broad-except` (92)** — intentional playback-resilience pattern, documented in `.pylintrc`.
- **mccabe complexity (43), E1101 stdlib false positives (26), fixme (12), misc old-pylint option errors (~10)** — stale-toolchain false positives or intentional.

## Note on alert closure

These alerts can never auto-close: the analysis category `.github/workflows/codacy.yml:codacy-security-scan` no longer receives uploads since #433 removed the workflow. Closing out the security tab requires deleting the stale Codacy analyses via the code-scanning API (or bulk-dismissing) as a separate follow-up.

## Verification

- `just ci` passes: ruff + black + pylint + vermin, **2567 tests passed** (2 skipped), and the Python 3.8 `compileall` gate.
- Both edited shell scripts verified clean with shellcheck 0.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)