### PR TITLE
🎨 Palette: [UX improvement] Add empty state for missing results

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -268,6 +268,17 @@
       <textureslidernibfocus></textureslidernibfocus>
     </control>
 
+    <!-- Empty state label -->
+    <control type="label" id="7">
+      <left>0</left><top>400</top><width>1920</width><height>60</height>
+      <label>No results found matching your filters.</label>
+      <font>font14</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Footer background -->
     <control type="image">
       <left>0</left><top>1035</top><width>1920</width><height>45</height>


### PR DESCRIPTION
💡 What: Added an empty state label in `results-dialog.xml` that appears when the search results list is empty.
🎯 Why: Without an empty state, users are met with a completely blank dark screen, which is confusing and lacks feedback. The new label immediately confirms that their search/filter produced no results.
📸 Before/After: Before: Blank screen. After: "No results found matching your filters." label centered on screen.
♿ Accessibility: Improved usability by providing clear text feedback when lists are unpopulated, rather than relying on the user to guess why the screen is empty.

---
*PR created automatically by Jules for task [14395053759294277997](https://jules.google.com/task/14395053759294277997) started by @xbmc4lyfe*