### PR TITLE
test: recover PTT and newznab_caps unit tests from closed-PR snapshots

### DIFF
--- a/tests/test_newznab_caps.py
+++ b/tests/test_newznab_caps.py
@@ -9,6 +9,7 @@ from resources.lib.newznab_caps import (
     CAPS_MAX_BYTES,
     build_caps_url,
     fetch_caps,
+    normalize_api_endpoint,
     parse_caps,
 )
 
@@ -29,6 +30,35 @@ CAPS_XML = """<?xml version="1.0" encoding="UTF-8"?>
   </categories>
 </caps>
 """
+
+
+def test_normalize_api_endpoint():
+    assert (
+        normalize_api_endpoint("https://api.nzbgeek.info")
+        == "https://api.nzbgeek.info/api"
+    )
+    assert (
+        normalize_api_endpoint("https://api.nzbgeek.info/")
+        == "https://api.nzbgeek.info/api"
+    )
+    assert (
+        normalize_api_endpoint("https://api.nzbgeek.info/api")
+        == "https://api.nzbgeek.info/api"
+    )
+    assert (
+        normalize_api_endpoint("https://api.nzbgeek.info/api/")
+        == "https://api.nzbgeek.info/api"
+    )
+    # An explicit non-standard API path is preserved, only trailing slash trimmed.
+    assert (
+        normalize_api_endpoint("https://tabula-rasa.pw/api/v1/")
+        == "https://tabula-rasa.pw/api/v1"
+    )
+    assert (
+        normalize_api_endpoint("http://localhost:5076") == "http://localhost:5076/api"
+    )
+    assert normalize_api_endpoint("") == "/api"
+    assert normalize_api_endpoint(None) == "/api"
 
 
 def test_build_caps_url_appends_api_and_redacts_nothing():

--- a/tests/test_ptt_parse.py
+++ b/tests/test_ptt_parse.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 nzbdav contributors
 
-from resources.lib.ptt.parse import extend_options
+import pytest
+from resources.lib.ptt.parse import (
+    LANGUAGES_TRANSLATION_TABLE,
+    clean_title,
+    extend_options,
+    translate_langs,
+)
 
 DEFAULT_OPTIONS = {
     "skipIfAlreadyFound": True,
@@ -62,3 +68,85 @@ def test_extend_options_extra_keys():
     options = {"extra_key": "value"}
     result = extend_options(options)
     assert result == expected_options(extra_key="value")
+
+
+@pytest.mark.parametrize(
+    "raw_title, expected_title",
+    [
+        # Underscores become spaces
+        ("Movie_Title", "Movie Title"),
+        ("A_Very_Long_Movie_Title_2023", "A Very Long Movie Title 2023"),
+        # MOVIE_REGEX removals ([movie], (movie)), case insensitive
+        ("The Matrix [movie]", "The Matrix"),
+        ("The Matrix (Movie)", "The Matrix"),
+        # NOT_ALLOWED_SYMBOLS_AT_START_AND_END removal
+        ("-Movie Title-", "Movie Title"),
+        ("[Movie Title]", "Movie Title"),
+        ("...Movie Title...", "Movie Title"),
+        # STAR_REGEX_1 strips a leading ★/【】 tag block
+        ("★ Tag ★ The Dark Knight", "The Dark Knight"),
+        ("【 Tag 】 The Dark Knight", "The Dark Knight"),
+        ("★Tag★ The Dark Knight", "The Dark Knight"),
+        ("【Tag】 The Dark Knight", "The Dark Knight"),
+        # STAR_REGEX_2 strips a trailing tag block
+        ("The Dark Knight ★ Tag ★", "The Dark Knight"),
+        ("The Dark Knight 【 Tag 】", "The Dark Knight"),
+        # EMPTY_BRACKETS_REGEX removals
+        ("Movie Title []", "Movie Title"),
+        ("Movie Title ()", "Movie Title"),
+        ("Movie Title {}", "Movie Title"),
+        ("Movie Title [  ]", "Movie Title"),
+        # PARANTHESES_WITHOUT_CONTENT removals
+        ("Movie Title (-)", "Movie Title"),
+        ("Movie Title [.]", "Movie Title"),
+        # SPECIAL_CHAR_SPACING removals
+        ("Movie -- Title", "Movie Title"),
+        ("Movie  ++  Title", "Movie Title"),
+        # Unbalanced single bracket removal
+        ("Movie Title (2020", "Movie Title 2020"),
+        ("Movie Title [2020", "Movie Title 2020"),
+        # Dots become spaces only when the title has no spaces already
+        ("The.Matrix.1999", "The Matrix 1999"),
+        ("The.Matrix 1999", "The.Matrix 1999"),
+        # REDUNDANT_SYMBOLS_AT_END removals
+        ("Movie Title -", "Movie Title"),
+        ("Movie Title :", "Movie Title"),
+        ("Movie Title .", "Movie Title"),
+        ("Movie Title /", "Movie Title"),
+        ("Movie Title \\", "Movie Title"),
+        # Whitespace collapse and trim
+        ("Movie    Title", "Movie Title"),
+        ("   Movie Title   ", "Movie Title"),
+        # MP3 suffix removal
+        ("Movie Soundtrack mp3", "Movie Soundtrack"),
+        # Combination of cleanups
+        ("★ Tag ★ The.Matrix.1999[movie]( ) -", "The Matrix 1999"),
+    ],
+)
+def test_clean_title(raw_title, expected_title):
+    assert clean_title(raw_title) == expected_title
+
+
+def test_translate_langs_basic():
+    assert translate_langs(["en", "fr"]) == ["English", "French"]
+    assert translate_langs(["de", "it"]) == ["German", "Italian"]
+    assert translate_langs(["ru"]) == ["Russian"]
+
+
+def test_translate_langs_empty():
+    assert translate_langs([]) == []
+
+
+def test_translate_langs_unknown_codes_omitted():
+    assert translate_langs(["xx", "yy"]) == []
+    assert translate_langs(["en", "xx", "fr"]) == ["English", "French"]
+
+
+def test_translate_langs_preserves_duplicates():
+    assert translate_langs(["en", "en", "xx", "fr"]) == ["English", "English", "French"]
+
+
+def test_translate_langs_covers_full_table():
+    keys = list(LANGUAGES_TRANSLATION_TABLE.keys())
+    values = list(LANGUAGES_TRANSLATION_TABLE.values())
+    assert translate_langs(keys) == values

--- a/tests/test_ptt_transformers.py
+++ b/tests/test_ptt_transformers.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+from resources.lib.ptt.transformers import convert_months, transform_resolution
+
+
+def test_transform_resolution():
+    assert transform_resolution("2160") == "2160p"
+    assert transform_resolution("4k") == "2160p"
+    assert transform_resolution("4K") == "2160p"
+    assert transform_resolution("2160p") == "2160p"
+
+    assert transform_resolution("1440") == "1440p"
+    assert transform_resolution("2k") == "1440p"
+    assert transform_resolution("2K") == "1440p"
+
+    assert transform_resolution("1080") == "1080p"
+    assert transform_resolution("1080p") == "1080p"
+    assert transform_resolution("1080i") == "1080p"
+    assert transform_resolution("1080P") == "1080p"
+
+    assert transform_resolution("720") == "720p"
+    assert transform_resolution("720p") == "720p"
+
+    assert transform_resolution("480") == "480p"
+    assert transform_resolution("480p") == "480p"
+
+    assert transform_resolution("360") == "360p"
+    assert transform_resolution("360p") == "360p"
+
+    assert transform_resolution("240") == "240p"
+    assert transform_resolution("240p") == "240p"
+
+    assert transform_resolution("unknown") == "unknown"
+    assert transform_resolution("") == ""
+    assert transform_resolution("SD") == "sd"
+
+
+def test_convert_months_basic():
+    assert convert_months("20 Janu 2020") == "20 Jan 2020"
+    assert convert_months("15 Febr 2021") == "15 Feb 2021"
+
+
+def test_convert_months_case_insensitive():
+    assert convert_months("20 jAnU 2020") == "20 Jan 2020"
+    assert convert_months("15 fEbR 2021") == "15 Feb 2021"
+
+
+def test_convert_months_all_months():
+    months = [
+        ("Janu", "Jan"),
+        ("Febr", "Feb"),
+        ("Marc", "Mar"),
+        ("Apri", "Apr"),
+        ("May", "May"),
+        ("June", "Jun"),
+        ("July", "Jul"),
+        ("Augu", "Aug"),
+        ("Sept", "Sep"),
+        ("Octo", "Oct"),
+        ("Nove", "Nov"),
+        ("Dece", "Dec"),
+    ]
+    for long_month, short_month in months:
+        assert convert_months("01 {} 2020".format(long_month)) == "01 {} 2020".format(
+            short_month
+        )
+
+
+def test_convert_months_no_match():
+    # Full month names and already-short names pass through unchanged.
+    assert convert_months("01 January 2020") == "01 January 2020"
+    assert convert_months("01 Jan 2020") == "01 Jan 2020"
+    assert convert_months("random string") == "random string"
+    assert convert_months("") == ""


### PR DESCRIPTION
## Summary

Salvages the still-applicable unit tests from the `recovery/original/pr-{112,113,115,116,119}` snapshot branches before the recovery snapshots are deleted. These bot PRs were closed without merging, and main had no direct unit tests for any of these functions (they were only covered indirectly through end-to-end parse tests).

- **`tests/test_ptt_transformers.py` (new)** — `transform_resolution` (all resolution aliases, PR #116) and `convert_months` (truncated month-name conversion, PR #119)
- **`tests/test_ptt_parse.py`** — 34-case parametrized `clean_title` suite and `translate_langs` coverage including full-table round-trip (PRs #115, #113)
- **`tests/test_newznab_caps.py`** — `normalize_api_endpoint` edge cases: bare host, trailing slash, existing `/api`, non-standard `/api/v1` paths, empty/None (PR #112)

Imports were adjusted to the current `resources.lib` layout; test bodies are otherwise as recovered. All pass unmodified against today's vendored PTT and `newznab_caps` implementations.

## Test plan

- `just lint` clean (after `just lint-fix` import-order fix)
- `just test`: 2612 passed, 2 skipped (+16 tests vs main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)