### PR TITLE
🎨 Palette: Add empty state handling for results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -252,6 +252,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state handling -->
+    <control type="label">
+      <left>0</left><top>400</top><width>1920</width><height>50</height>
+      <align>center</align>
+      <aligny>center</aligny>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <label>No results found</label>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
💡 **What:** Added an explicit "No results found" label to the results dialog that appears only when the results list is empty.
🎯 **Why:** Custom lists in Kodi XML skins do not automatically handle empty states, which previously resulted in a confusing blank screen when no items were present. This makes it clear to the user that a search completed but yielded no results, rather than making it look like the addon is hanging or broken.
📸 **Before/After:** Not applicable (XML structure change, visual empty state introduced).
♿ **Accessibility:** Improves cognitive accessibility by providing clear textual feedback about system state instead of relying on the absence of content.

---
*PR created automatically by Jules for task [2073093211786224459](https://jules.google.com/task/2073093211786224459) started by @xbmc4lyfe*