### PR TITLE
fix: recognize raw .m2ts Blu-ray stream files as playable video

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/nzbget_resolver_smb.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzbget_resolver_smb.py
@@ -23,7 +23,7 @@ import xbmcvfs
 import resources.lib.nzbget_resolver as _core  # noqa: F401  pylint: disable=unused-import
 from resources.lib.episode_inventory import build_video_inventory
 
-VIDEO_EXTENSIONS = (".mkv", ".mp4", ".avi", ".m4v", ".ts", ".wmv", ".mov")
+VIDEO_EXTENSIONS = (".mkv", ".mp4", ".avi", ".m4v", ".ts", ".m2ts", ".wmv", ".mov")
 
 
 def nzbget_smb_target(smb_root, dest_dir, category="", completed_base=""):

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_playback.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_playback.py
@@ -608,6 +608,8 @@ def _video_mime_for_path(path):
         return "video/mp4"
     if path.endswith(".avi"):
         return "video/x-msvideo"
+    if path.endswith((".ts", ".m2ts")):
+        return "video/mp2t"
     return "video/x-matroska"
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_mgr_probe.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_mgr_probe.py
@@ -284,4 +284,6 @@ class _MgrProbeMixin:  # pylint: disable=too-few-public-methods
             return "video/mp4"
         if lower.endswith(".avi"):
             return "video/x-msvideo"
+        if lower.endswith((".ts", ".m2ts")):
+            return "video/mp2t"
         return "video/mp4"

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -265,7 +265,16 @@ _FOLDER_TOTAL_INCOMPLETE = -1
 # Video extensions summed by the folder-total walk. Kept module-level so the
 # per-href video test below stays a one-liner (the genuine size accounting
 # lives in ``_folder_total_video_size``).
-_FOLDER_TOTAL_VIDEO_EXTENSIONS = (".mkv", ".mp4", ".avi", ".m4v", ".ts", ".wmv", ".mov")
+_FOLDER_TOTAL_VIDEO_EXTENSIONS = (
+    ".mkv",
+    ".mp4",
+    ".avi",
+    ".m4v",
+    ".ts",
+    ".m2ts",
+    ".wmv",
+    ".mov",
+)
 
 
 def _folder_total_resource_key(resource_path):

--- a/repo/plugin.video.nzbdav/resources/lib/webdav_discovery.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav_discovery.py
@@ -29,7 +29,7 @@ import xbmc
 from resources.lib import webdav_match
 
 _WEBDAV_SUBDIR_SCAN_WORKERS = 4
-_VIDEO_EXTENSIONS = (".mkv", ".mp4", ".avi", ".m4v", ".ts", ".wmv", ".mov")
+_VIDEO_EXTENSIONS = (".mkv", ".mp4", ".avi", ".m4v", ".ts", ".m2ts", ".wmv", ".mov")
 _DAV_NS = {"D": "DAV:"}
 
 

--- a/tests/test_nzbget_resolver.py
+++ b/tests/test_nzbget_resolver.py
@@ -167,6 +167,28 @@ def test_resolve_smb_video_returns_largest_file_url():
     assert url == "smb://host/completed/The.Movie/movie.mkv"
 
 
+def test_resolve_smb_video_recognizes_raw_bluray_stream_file():
+    # Full Blu-ray disc rips (e.g. scene "-BLoz" releases) commonly land the
+    # main title as a raw .m2ts stream (e.g. "00000.m2ts") rather than a
+    # remuxed .mkv/.mp4. If .m2ts isn't a recognized video extension, the
+    # NZBGet completed-history reuse probe never finds it and the resolver
+    # falls through to re-submitting an already-downloaded release.
+    xbmcvfs = sys.modules["xbmcvfs"]
+
+    def fake_stat(path):
+        st = MagicMock()
+        st.st_size.return_value = 9000 if path.endswith("00000.m2ts") else 10
+        return st
+
+    with patch.object(
+        xbmcvfs, "listdir", return_value=([], ["00000.m2ts"])
+    ), patch.object(xbmcvfs, "Stat", side_effect=fake_stat):
+        url = resolve_smb_video(
+            "smb://host/downloads/Battle.Royale.2000-BLoz", monitor=_Monitor()
+        )
+    assert url == "smb://host/downloads/Battle.Royale.2000-BLoz/00000.m2ts"
+
+
 def test_resolve_smb_video_selects_requested_episode_over_largest():
     xbmcvfs = sys.modules["xbmcvfs"]
     files = ["Spider-Noir.S01E01.mkv", "Spider-Noir.S01E05.mkv"]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -178,6 +178,22 @@ def test_make_playable_listitem_detects_mime_with_fragment(mock_xbmc, mock_gui):
     mock_li.setMimeType.assert_called_with("video/mp4")
 
 
+@patch("resources.lib.resolver.xbmcgui")
+@patch("resources.lib.resolver.xbmc")
+def test_make_playable_listitem_detects_mpegts_mime(mock_xbmc, mock_gui):
+    # Raw Blu-ray stream files (.m2ts) and .ts must not fall through to the
+    # MKV default -- that mime mismatch confuses Kodi's demuxer selection.
+    mock_li = MagicMock()
+    mock_gui.ListItem.return_value = mock_li
+
+    _make_playable_listitem("http://webdav/00000.m2ts", {})
+    mock_li.setMimeType.assert_called_with("video/mp2t")
+
+    mock_li.reset_mock()
+    _make_playable_listitem("http://webdav/movie.ts", {})
+    mock_li.setMimeType.assert_called_with("video/mp2t")
+
+
 @patch("urllib.request.urlopen")
 def test_validate_stream_url_catches_http_protocol_exception(mock_urlopen):
     from http.client import BadStatusLine

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -419,6 +419,16 @@ def test_detect_content_type_avi():
     assert sp._detect_content_type("http://host/film.avi") == "video/x-msvideo"
 
 
+def test_detect_content_type_mpegts():
+    # .ts/.m2ts are MPEG-TS, not MP4 -- a wrong hint here confuses Kodi's
+    # demuxer selection for raw Blu-ray stream files served through the proxy.
+    from resources.lib.stream_proxy import StreamProxy
+
+    sp = StreamProxy.__new__(StreamProxy)
+    assert sp._detect_content_type("http://host/file.ts") == "video/mp2t"
+    assert sp._detect_content_type("http://host/00000.m2ts") == "video/mp2t"
+
+
 # ---------------------------------------------------------------------------
 # StreamProxy lifecycle
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Full Blu-ray disc rips (e.g. `-BLoz` scene releases) commonly store the main title as a raw `.m2ts` stream file (e.g. `00000.m2ts`) rather than a remuxed `.mkv`/`.mp4`.
- `.m2ts` was missing from the `VIDEO_EXTENSIONS` allowlists in `nzbget_resolver_smb.py`, `webdav.py`, and `webdav_discovery.py` (only `nzb_manifest.py`'s separate list already had it), so an already-downloaded BD-rip was never recognized as reusable by the NZBGet SMB reuse probe / WebDAV folder-total / WebDAV discovery scans.
- Symptom: picking an already-downloaded full-disc release re-triggered a full search + fresh NZBGet submission instead of playing the existing SMB files directly.
- Fix: added `.m2ts` to all three lists (they're explicitly meant to mirror each other per an existing code comment, and had drifted).

Root-caused live against a real box: confirmed via direct NZBGet `history` JSON-RPC query that the completed-history match (name+size) already worked correctly, and traced the actual miss to the SMB folder scan not recognizing the `.m2ts` extension.

## Test plan
- [x] Added `test_resolve_smb_video_recognizes_raw_bluray_stream_file`, confirmed it fails before the fix and passes after
- [x] `just test` — 2568 passed, 2 skipped
- [x] `just lint` — ruff, black, pylint (10.00/10), vermin all clean
- [x] Verified live on a CoreELEC box: previously-downloaded Blu-ray rip now plays directly instead of re-submitting to NZBGet