### PR TITLE
🎨 Palette: [UX improvement] Add empty state handling for search results

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -62,6 +62,17 @@
       <texture>white.png</texture>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Results list — 2 lines per item, 66px each -->
     <control type="list" id="50">
       <left>0</left><top>60</top><width>1910</width><height>975</height>


### PR DESCRIPTION
💡 What: Adds an empty state `<label>` message in `results-dialog.xml` that displays when the results list `Container(50)` is empty.
🎯 Why: Custom lists in Kodi XML skins do not automatically handle empty states, which results in a confusing blank screen for users when a search returns zero results.
📸 Before/After: Visual change to the results dialog when no results are found (shows "No results found" in the center instead of a dark blank screen).
♿ Accessibility: Provides explicit text feedback for users rather than relying on the visual absence of elements.

---
*PR created automatically by Jules for task [7790155060964512654](https://jules.google.com/task/7790155060964512654) started by @xbmc4lyfe*