### PR TITLE
test: guard SMB playback URLs against double-encoding regression

### DIFF
--- a/tests/test_nzbget_resolver.py
+++ b/tests/test_nzbget_resolver.py
@@ -167,6 +167,36 @@ def test_resolve_smb_video_returns_largest_file_url():
     assert url == "smb://host/completed/The.Movie/movie.mkv"
 
 
+def test_resolve_smb_video_keeps_literal_spaces_unencoded_in_returned_url():
+    # NZBGet's DestDir mirrors the NZB post title verbatim, so real release
+    # folders routinely contain literal spaces. Kodi's own SMB VFS percent-
+    # encodes the path internally before it hits the wire, so this module
+    # must NOT pre-encode: doing so double-encodes ("%20" becomes literal
+    # "%2520" on the wire) and 404s with "No such file or directory" even
+    # though the identical raw path lists/stats/reads fine through xbmcvfs.
+    xbmcvfs = sys.modules["xbmcvfs"]
+    folder = "smb://host/completed/Logan 2017 2160p WEB-DL DV HDR-FLUX"
+
+    def fake_listdir(path):
+        assert path == folder, "listdir must receive the raw, unencoded path"
+        return [], ["Logan 2017 2160p WEB-DL DV HDR-FLUX.mkv"]
+
+    def fake_stat(path):
+        assert " " in path, "the read/stat probe must receive the raw path"
+        st = MagicMock()
+        st.st_size.return_value = 9000
+        return st
+
+    with patch.object(xbmcvfs, "listdir", side_effect=fake_listdir), patch.object(
+        xbmcvfs, "Stat", side_effect=fake_stat
+    ):
+        url = resolve_smb_video(folder, monitor=_Monitor())
+    assert url == (
+        "smb://host/completed/Logan 2017 2160p WEB-DL DV HDR-FLUX/"
+        "Logan 2017 2160p WEB-DL DV HDR-FLUX.mkv"
+    )
+
+
 def test_resolve_smb_video_selects_requested_episode_over_largest():
     xbmcvfs = sys.modules["xbmcvfs"]
     files = ["Spider-Noir.S01E01.mkv", "Spider-Noir.S01E05.mkv"]

--- a/tests/test_nzbget_resolver.py
+++ b/tests/test_nzbget_resolver.py
@@ -187,9 +187,15 @@ def test_resolve_smb_video_keeps_literal_spaces_unencoded_in_returned_url():
         st.st_size.return_value = 9000
         return st
 
+    def fake_file(path):
+        assert " " in path, "the readability probe must receive the raw path"
+        handle = MagicMock()
+        handle.readBytes.return_value = b"data"
+        return handle
+
     with patch.object(xbmcvfs, "listdir", side_effect=fake_listdir), patch.object(
         xbmcvfs, "Stat", side_effect=fake_stat
-    ):
+    ), patch.object(xbmcvfs, "File", side_effect=fake_file):
         url = resolve_smb_video(folder, monitor=_Monitor())
     assert url == (
         "smb://host/completed/Logan 2017 2160p WEB-DL DV HDR-FLUX/"


### PR DESCRIPTION
## Summary
- `resolve_smb_video()` correctly hands `xbmcvfs` raw (unescaped) NZBGet folder/file names and returns them unencoded too — Kodi's own SMB VFS percent-encodes the path internally before it hits the wire.
- While chasing a live playback failure I briefly "fixed" this to pre-encode the returned URL, which actually double-encodes (`%20` → literal `%2520`) and 404s with "No such file or directory" — confirmed against a live CoreELEC box. Reverted that change; the module needed no fix.
- This PR adds a regression test only, so that mistake doesn't get reintroduced later.

## Test plan
- [x] `just test` — 2568 passed, 2 skipped
- [x] `just lint` — ruff/black/pylint all clean, 10.00/10
- [x] Verified live on a CoreELEC box that unencoded paths with literal spaces play correctly through this resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)