### PR TITLE
🎨 Palette: Add empty state for search results

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -299,5 +299,16 @@
       <aligny>center</aligny>
     </control>
 
+    <!-- Empty state handling -->
+    <control type="label">
+      <left>0</left><top>0</top><width>1920</width><height>1080</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
   </controls>
 </window>


### PR DESCRIPTION
💡 What: Added an explicit "No results found" empty state handling label to the Kodi results dialog.
🎯 Why: Custom lists in Kodi XML do not automatically handle empty states, which leaves a confusing blank screen when a user's search returns zero items.
📸 Before/After: Before, an empty list showed a blank dark screen. After, the UI gracefully displays a centered "No results found" message.
♿ Accessibility: Improves cognitive accessibility by providing immediate, clear feedback that the search finished but yielded no results, rather than leaving the user wondering if the add-on crashed or is still loading.

---
*PR created automatically by Jules for task [543023955769556120](https://jules.google.com/task/543023955769556120) started by @xbmc4lyfe*