### PR TITLE
🎨 Palette: [UX improvement] Add empty state message to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -299,5 +299,16 @@
       <aligny>center</aligny>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>440</top><width>1920</width><height>100</height>
+      <align>center</align>
+      <aligny>center</aligny>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <label>No results found</label>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
   </controls>
 </window>


### PR DESCRIPTION
💡 What: Added an explicit "No results found" message to the center of the results dialog when the list container is empty.
🎯 Why: In Kodi XML skins, custom lists do not automatically handle empty states. If a search returned 0 items, the user was left with a confusing blank screen without feedback.
📸 Before/After: N/A (XML change, no visual screenshot possible in headless sandbox)
♿ Accessibility: Provides explicit textual feedback for a zero-results state instead of relying on the user inferring meaning from a lack of visual elements.

---
*PR created automatically by Jules for task [17777620534783249809](https://jules.google.com/task/17777620534783249809) started by @xbmc4lyfe*