### PR TITLE
🎨 Palette: [UX improvement] Add empty state message to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -268,6 +268,17 @@
       <textureslidernibfocus></textureslidernibfocus>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Footer background -->
     <control type="image">
       <left>0</left><top>1035</top><width>1920</width><height>45</height>


### PR DESCRIPTION
💡 What: Added an explicit "No results found" message to the results list when empty.
🎯 Why: Kodi lists don't handle empty states by default, leaving users staring at a blank screen wondering if it's loading or empty.
📸 Before/After: Blank area under the header -> Clear "No results found" text in center.
♿ Accessibility: Improves cognitive accessibility by clearly communicating the state instead of requiring the user to guess.

---
*PR created automatically by Jules for task [11534063451221083221](https://jules.google.com/task/11534063451221083221) started by @xbmc4lyfe*