### PR TITLE
🎨 Palette: [UX improvement] Add empty state for results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -252,6 +252,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
### What
Added an empty state label to the results dialog when no items are returned.

### Why
To provide clear feedback to the user instead of showing a confusing blank screen when a search yields no results.

### Before/After
Before: Blank screen with headers and footer.
After: Centered "No results found" message.

### Accessibility
Provides explicit text context when results are empty, avoiding confusion for users relying on visual or screen reader feedback.

---
*PR created automatically by Jules for task [2108424479646151487](https://jules.google.com/task/2108424479646151487) started by @xbmc4lyfe*