### PR TITLE
🎨 Palette: Add empty state for search results

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -62,6 +62,17 @@
       <texture>white.png</texture>
     </control>
 
+    <!-- Empty State -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Results list — 2 lines per item, 66px each -->
     <control type="list" id="50">
       <left>0</left><top>60</top><width>1910</width><height>975</height>


### PR DESCRIPTION
💡 What: Added an empty state message for the results list.
🎯 Why: Prevent confusing blank screens when there are no items found in search.
📸 Before/After: Before, a blank screen; After, a clear "No results found" message.
♿ Accessibility: Provides clear textual feedback when the UI has no data to display, improving the user experience for everyone.

---
*PR created automatically by Jules for task [16983469953847756651](https://jules.google.com/task/16983469953847756651) started by @xbmc4lyfe*