### PR TITLE
🎨 Palette: Handle Kodi List Empty States in Results Dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -252,6 +252,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <align>center</align>
+      <aligny>center</aligny>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <label>No results found.</label>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
**💡 What**: Adds an empty state label ("No results found.") to the results dialog.
**🎯 Why**: In Kodi XML skins, custom lists do not automatically handle empty states. When no results are found, the user is left with a confusing blank screen. This change provides explicit feedback that a search completed but returned zero items.
**📸 Before/After**: N/A (XML change)
**♿ Accessibility**: Reduces cognitive load by explicitly communicating system status when no results are found, instead of forcing the user to guess why the screen is blank.

---
*PR created automatically by Jules for task [13210267982164975760](https://jules.google.com/task/13210267982164975760) started by @xbmc4lyfe*