### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix auth bypass when prepare_token is empty

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** Inconsistent, incomplete, and fragile XXE (XML External Entity) and Billion Laughs DoS protection across various files (`webdav.py`, `webdav_discovery.py`, `kodi_advancedsettings.py`, `nzb_manifest.py`). The standard library fallback in Python >= 3.3 does not have `.parser` attribute for `ET.XMLParser()`, resulting in `AttributeError` that was caught but silently allowed the parser to continue with entities enabled (failing open).
 **Learning:** Python's C-implementation of ElementTree doesn't expose external entity resolution handlers. You cannot disable entities via `parser.parser.ExternalEntityRefHandler = lambda *_: False` because `parser` lacks a `.parser` attribute. `xml_safety.py` provides a centralized, robust text-scanning fallback for when `defusedxml` is not available.
 **Prevention:** Always use `safe_fromstring` from `xml_safety.py` for parsing XML instead of ad-hoc parser customizations.
+## 2025-05-24 - Fix Auth Bypass when Loopback Proxy Secret is Empty
+
+**Vulnerability:** The loopback proxy authentication check (`_prepare_token_ok`) used the logic `if expected_token and not ...compare_digest(...)`. This caused the check to short-circuit and return `True` (authorized) if the expected secret token was empty or uninitialized.
+**Learning:** Security checks that use `and not` with a precondition (like `expected_token`) will fail-open if the precondition is false.
+**Prevention:** Explicitly return `False` if required authentication secrets are missing or empty before attempting comparison, ensuring a fail-secure design.

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_dispatch.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_dispatch.py
@@ -26,12 +26,10 @@ class _DispatchMixin:  # pylint: disable=too-few-public-methods
         both sides to str("") if None.
         """
         expected_token = getattr(self.server, "prepare_token", "")
-        supplied_token = self.headers.get(_sp._PREPARE_TOKEN_HEADER)
-        if expected_token and not _sp.hmac.compare_digest(
-            supplied_token or "", expected_token or ""
-        ):
+        if not expected_token:
             return False
-        return True
+        supplied_token = self.headers.get(_sp._PREPARE_TOKEN_HEADER)
+        return _sp.hmac.compare_digest(supplied_token or "", expected_token)
 
     def _read_json_post_body(self):
         """Read + JSON-parse a POST body, returning a dict or None.


### PR DESCRIPTION
- 🚨 Severity: CRITICAL
- 💡 Vulnerability: The `_prepare_token_ok` method bypassed authentication by returning True when `expected_token` was empty, due to the short-circuiting logic `if expected_token and not ...`.
- 🎯 Impact: If the loopback proxy service initialized with an empty token (or failed to load it), it would accept any unauthenticated requests to restricted loopback endpoints.
- 🔧 Fix: Ensure the method explicitly returns `False` if `expected_token` is empty before performing the HMAC check.
- ✅ Verification: Run tests and linting to ensure security logic works correctly.

---
*PR created automatically by Jules for task [16682488101616575226](https://jules.google.com/task/16682488101616575226) started by @xbmc4lyfe*