### PR TITLE
🎨 Palette: [UX improvement] Add empty state message for results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -252,6 +252,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state message for when no results are found -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1910</width><height>975</height>
+      <align>center</align>
+      <aligny>center</aligny>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
**💡 What:** Added a clear, centralized "No results found" label message to the main results dialog (`results-dialog.xml`) that displays when the list contains no items.

**🎯 Why:** Kodi custom list controls (like the search results container) do not inherently handle empty states. Before this change, searching for something with zero matches resulted in a confusing completely blank screen, leaving the user unsure if a search had actually failed, was still loading, or had produced no results.

**📸 Before/After:** 
Before: Blank, dark screen with no feedback when a query yields 0 matches.
After: Centered, readable "No results found" placeholder text clearly communicating the outcome.

**♿ Accessibility:** Improves cognitive accessibility and overall UX by adhering to the heuristic of system status visibility. Users are provided explicit and immediate textual feedback when no results are present, rather than requiring them to guess the application's state.

---
*PR created automatically by Jules for task [10224837241783589639](https://jules.google.com/task/10224837241783589639) started by @xbmc4lyfe*