### PR TITLE
🛡️ Sentinel: [HIGH] Fix authentication bypass in loopback proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** Inconsistent, incomplete, and fragile XXE (XML External Entity) and Billion Laughs DoS protection across various files (`webdav.py`, `webdav_discovery.py`, `kodi_advancedsettings.py`, `nzb_manifest.py`). The standard library fallback in Python >= 3.3 does not have `.parser` attribute for `ET.XMLParser()`, resulting in `AttributeError` that was caught but silently allowed the parser to continue with entities enabled (failing open).
 **Learning:** Python's C-implementation of ElementTree doesn't expose external entity resolution handlers. You cannot disable entities via `parser.parser.ExternalEntityRefHandler = lambda *_: False` because `parser` lacks a `.parser` attribute. `xml_safety.py` provides a centralized, robust text-scanning fallback for when `defusedxml` is not available.
 **Prevention:** Always use `safe_fromstring` from `xml_safety.py` for parsing XML instead of ad-hoc parser customizations.
+## 2025-05-24 - Fail-Closed Authentication Check
+
+**Vulnerability:** Combining a precondition truthiness check with a negative comparison (e.g., `if expected_token and not compare(...)`) results in failing open when `expected_token` is missing or empty.
+**Learning:** The loopback proxy endpoints `/prepare` and `/stream/<id>/fallbacks` bypass authentication entirely if the server's `prepare_token` isn't initialized or evaluates to a falsy value.
+**Prevention:** Explicitly fail-closed by verifying the secret's presence first (e.g., `if not expected_token: return False`).

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_dispatch.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_dispatch.py
@@ -27,8 +27,10 @@ class _DispatchMixin:  # pylint: disable=too-few-public-methods
         """
         expected_token = getattr(self.server, "prepare_token", "")
         supplied_token = self.headers.get(_sp._PREPARE_TOKEN_HEADER)
-        if expected_token and not _sp.hmac.compare_digest(
-            supplied_token or "", expected_token or ""
+        if not expected_token:
+            return False
+        if not _sp.hmac.compare_digest(
+            supplied_token or "", expected_token
         ):
             return False
         return True

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_dispatch.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_dispatch.py
@@ -29,9 +29,7 @@ class _DispatchMixin:  # pylint: disable=too-few-public-methods
         supplied_token = self.headers.get(_sp._PREPARE_TOKEN_HEADER)
         if not expected_token:
             return False
-        if not _sp.hmac.compare_digest(
-            supplied_token or "", expected_token
-        ):
+        if not _sp.hmac.compare_digest(supplied_token or "", expected_token):
             return False
         return True
 


### PR DESCRIPTION
Severity: HIGH
Vulnerability: The loopback proxy endpoints `/prepare` and `/stream/<id>/fallbacks` combined a precondition truthiness check (`if expected_token`) with a negative comparison, causing them to fail open and bypass authentication if the server's `prepare_token` was missing or empty.
Impact: An attacker with access to the local machine could trigger stream preparation or inject fallback sources without knowing the required token, potentially allowing SSRF or unauthenticated proxy usage.
Fix: Refactored the `_prepare_token_ok` method to explicitly fail-closed if `expected_token` is missing or empty, checking `if not expected_token: return False` before proceeding to the time-constant comparison.
Verification: Ran the unit test suite (`pytest`) to ensure no regressions. Manually verified logic to confirm that a falsy expected token results in a `False` return.

---
*PR created automatically by Jules for task [15007920846754741600](https://jules.google.com/task/15007920846754741600) started by @xbmc4lyfe*