### PR TITLE
🎨 Palette: Add empty state to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -268,6 +268,17 @@
       <textureslidernibfocus></textureslidernibfocus>
     </control>
 
+    <!-- Empty state for results list -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Footer background -->
     <control type="image">
       <left>0</left><top>1035</top><width>1920</width><height>45</height>


### PR DESCRIPTION
### What
Added an empty state message ("No results found") to the results dialog when the list has no items.

### Why
In Kodi XML skins, custom lists do not automatically handle empty states. This results in a confusing blank screen when no items are present, leaving users unsure if the app is still loading or if there are genuinely no results.

### Before/After
Before: Blank screen between the header and footer when there are 0 results.
After: Centered text reading "No results found" appears when the list is empty.

### Accessibility
Improves cognitive accessibility by explicitly confirming the state of the system (empty results) rather than relying on the absence of information.

---
*PR created automatically by Jules for task [1494920801053529833](https://jules.google.com/task/1494920801053529833) started by @xbmc4lyfe*