### PR TITLE
Redact path-embedded Newznab credentials

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -124,22 +124,14 @@ def _redact_netloc_userinfo(netloc):
     return "{}@{}".format(userinfo, host)
 
 
-def _redact_url_userinfo_span(match):
-    """Strip the password from a URL span's ``user:pass@host`` userinfo.
+def _redact_url_span(match):
+    """Redact credentials only within a matched URL span.
 
-    Reuses the same ``rpartition('@')`` / ``partition(':')`` logic as
-    ``redact_url`` so an ``@`` *inside* the password (or an empty username)
-    can't leak. Spans with no userinfo round-trip unchanged.
+    Reusing ``redact_url`` covers both URL userinfo and non-standard Newznab
+    path credentials without applying short ``i``/``r`` parameter names to
+    unrelated text elsewhere in the same message.
     """
-    span = match.group(0)
-    try:
-        parts = urlsplit(span)
-    except (ValueError, TypeError):
-        return span
-    if not parts.netloc or "@" not in parts.netloc:
-        return span
-    netloc = _redact_netloc_userinfo(parts.netloc)
-    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+    return redact_url(match.group(0))
 
 
 def redact_text(text):
@@ -157,9 +149,7 @@ def redact_text(text):
     # ``\1`` is the key group; a backreference replacement avoids a per-match
     # Python callback on this hot logging/error path.
     redacted = _EMBEDDED_CRED_RE.sub(r"\1=REDACTED", str(text))
-    if "getnzb" in redacted.lower() or ".nzb&" in redacted.lower():
-        redacted = _GETNZB_PATH_CRED_RE.sub(r"\1=REDACTED", redacted)
-    return _EMBEDDED_URL_RE.sub(_redact_url_userinfo_span, redacted)
+    return _EMBEDDED_URL_RE.sub(_redact_url_span, redacted)
 
 
 _WHITESPACE_RE = re.compile(r"\s+")

--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -41,6 +41,16 @@ _EMBEDDED_CRED_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Some Newznab indexers return download URLs shaped like
+# ``/getnzb/id.nzb&i=ACCOUNT&r=APIKEY``. Because there is no ``?``, both
+# credentials are parsed as part of the URL path rather than query params.
+# Restrict the short ``i``/``r`` names to getnzb-looking paths so ordinary
+# application URLs using those names are not over-redacted.
+_GETNZB_PATH_CRED_RE = re.compile(
+    r"([&;](?:i|r))=([^&\s\"'<>]+)",
+    re.IGNORECASE,
+)
+
 # Catch ``scheme://user:password@host`` userinfo embedded in free-form text.
 # urllib / socket / xbmcvfs errors sometimes echo the failing URL — e.g. the
 # NZBGet JSON-RPC URL or the ``smb://user:pass@host/...`` completed-folder
@@ -91,9 +101,10 @@ def redact_url(url):
     # WebDAV stack used to accept). Strip the password half before
     # logging. TODO.md §H.2-H2d.
     netloc = _redact_netloc_userinfo(parts.netloc)
-    return urlunsplit(
-        (parts.scheme, netloc, parts.path, urlencode(query), parts.fragment)
-    )
+    path = parts.path
+    if "getnzb" in path.lower() or ".nzb&" in path.lower():
+        path = _GETNZB_PATH_CRED_RE.sub(r"\1=REDACTED", path)
+    return urlunsplit((parts.scheme, netloc, path, urlencode(query), parts.fragment))
 
 
 def _redact_netloc_userinfo(netloc):
@@ -146,6 +157,8 @@ def redact_text(text):
     # ``\1`` is the key group; a backreference replacement avoids a per-match
     # Python callback on this hot logging/error path.
     redacted = _EMBEDDED_CRED_RE.sub(r"\1=REDACTED", str(text))
+    if "getnzb" in redacted.lower() or ".nzb&" in redacted.lower():
+        redacted = _GETNZB_PATH_CRED_RE.sub(r"\1=REDACTED", redacted)
     return _EMBEDDED_URL_RE.sub(_redact_url_userinfo_span, redacted)
 
 

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -317,6 +317,21 @@ def test_redact_text_hides_getnzb_path_credentials():
     assert "&r=REDACTED" in result
 
 
+def test_redact_text_scopes_getnzb_path_credentials_to_url():
+    """Short Newznab credential names must not redact unrelated message data."""
+    msg = (
+        "fetch failed for "
+        "https://indexer.example/getnzb/id.nzb&i=12345&r=secretkey123 "
+        "while callback metadata remained &i=keep&r=visible"
+    )
+    result = redact_text(msg)
+
+    assert "12345" not in result
+    assert "secretkey123" not in result
+    assert "&i=REDACTED&r=REDACTED" in result
+    assert "metadata remained &i=keep&r=visible" in result
+
+
 def test_redact_text_redacts_digit_prefixed_values():
     """The ``\\1=REDACTED`` backreference must not misfire when the secret value
     begins with a digit — the literal ``=`` terminates the group, so there is no

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -229,6 +229,24 @@ def test_redact_url_preserves_url_without_apikey():
     assert result == url
 
 
+def test_redact_url_hides_getnzb_path_credentials():
+    """Newznab links may put account/API credentials in the path."""
+    url = "https://indexer.example/getnzb/id.nzb&i=12345&r=secretkey123"
+    result = redact_url(url)
+
+    assert "12345" not in result
+    assert "secretkey123" not in result
+    assert "&i=REDACTED" in result
+    assert "&r=REDACTED" in result
+
+
+def test_redact_url_preserves_short_params_outside_getnzb_paths():
+    """Short i/r parameters are not credentials in arbitrary URLs."""
+    url = "https://example.com/report&i=12345&r=summary"
+
+    assert redact_url(url) == url
+
+
 def test_redact_url_hides_extended_credential_keys():
     """TODO.md §H.2-H2c: the redaction set covers more than just apikey.
     `key`, `access_token`, `bearer`, `session`, `sessionid`, `password`,
@@ -283,6 +301,20 @@ def test_redact_text_redacts_multiple_credential_params():
     # Non-credential params are untouched.
     assert "imdbid=tt1" in result
     assert "t=movie" in result
+
+
+def test_redact_text_hides_getnzb_path_credentials():
+    """Free-form HTTP errors must scrub non-standard Newznab path secrets."""
+    msg = (
+        "fetch failed for "
+        "https://indexer.example/getnzb/id.nzb&i=12345&r=secretkey123"
+    )
+    result = redact_text(msg)
+
+    assert "12345" not in result
+    assert "secretkey123" not in result
+    assert "&i=REDACTED" in result
+    assert "&r=REDACTED" in result
 
 
 def test_redact_text_redacts_digit_prefixed_values():


### PR DESCRIPTION
## What changed

- redact Newznab download credentials embedded in non-standard `/getnzb/*.nzb&i=...&r=...` URL paths
- apply the same protection to free-form exception and error text
- keep short `i` and `r` parameters untouched outside getnzb-shaped paths
- add regression coverage for URL and text redaction

## Why

Some Newznab indexers return NZB download links without a `?`, which makes account and API credentials part of the parsed URL path. Existing query-parameter redaction therefore leaves those values visible in logs and error messages.

## Validation

- `just lint`: passed (Ruff, Black, Pylint 10.00/10, Python 3.8 Vermin gate)
- focused HTTP utility tests: passed as part of the full suite
- `just test`: 2,587 passed, 2 skipped; 3 unrelated existing Windows-environment/timing failures (`test_install_nzbdav_addon_script` and two completed-hint latency tests)