### PR TITLE
Harden content selection and retry distinct releases

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/filter.py
+++ b/repo/plugin.video.nzbdav/resources/lib/filter.py
@@ -4,6 +4,7 @@
 """Result filtering and sorting using PTT for title parsing."""
 
 import math
+import re
 import time
 from copy import deepcopy
 from types import SimpleNamespace
@@ -512,6 +513,94 @@ def filter_results(results, settings_getter=None):
         shown=len(filtered),
     )
     return filtered, all_parsed
+
+
+_CONTENT_EXTRA_MARKERS = re.compile(
+    r"\b(?:behind[\W_]+the[\W_]+scenes|making[\W_]+of|featurette|"
+    r"documentary|interview|trailer|sample|extras?)\b",
+    re.I,
+)
+_SEASON_EPISODE_RE = re.compile(
+    r"(?<![A-Za-z0-9])S(\d{1,2})[\W_]*E(\d{1,3})(?![A-Za-z0-9])",
+    re.I,
+)
+_YEAR_RE = re.compile(r"(?<!\d)((?:19|20)\d{2})(?!\d)")
+
+
+def _content_phrase_pattern(title):
+    """Return a boundary-safe release-title pattern for a requested title."""
+    words = re.findall(r"[A-Za-z0-9]+", str(title or "").lower())
+    words = [word for word in words if len(word) > 1 or word.isdigit()]
+    if not words:
+        return None
+    return re.compile(
+        r"(?<![A-Za-z0-9])"
+        + r"[\W_]+".join(re.escape(word) for word in words)
+        + r"(?![A-Za-z0-9])",
+        re.I,
+    )
+
+
+def result_matches_requested_content(result, identity):
+    """Fail closed on an obvious wrong-title, movie, or episode result."""
+    if not isinstance(result, dict):
+        return False
+    candidate_title = str(result.get("title", "") or "")
+    phrase = _content_phrase_pattern(identity.get("title", ""))
+    phrase_match = phrase.search(candidate_title) if phrase is not None else None
+    if phrase is not None and phrase_match is None:
+        return False
+
+    content_type = str(identity.get("type", "") or "").lower()
+    season = str(identity.get("season", "") or "")
+    episode = str(identity.get("episode", "") or "")
+    episode_match = _SEASON_EPISODE_RE.search(candidate_title)
+    if content_type == "episode" or (season and episode):
+        try:
+            requested_pair = (int(season), int(episode))
+        except (TypeError, ValueError):
+            requested_pair = None
+        if requested_pair is not None and (
+            episode_match is None
+            or (int(episode_match.group(1)), int(episode_match.group(2)))
+            != requested_pair
+        ):
+            return False
+        if (
+            phrase_match is not None
+            and episode_match is not None
+            and phrase_match.start() > episode_match.start()
+        ):
+            # The requested show name occurs only as another show's episode
+            # title (for example The.Rookie.S01E03.<requested title>).
+            return False
+    elif content_type == "movie" and episode_match is not None:
+        return False
+
+    requested_year = str(identity.get("year", "") or "")
+    candidate_years = set(_YEAR_RE.findall(candidate_title))
+    if requested_year and candidate_years and requested_year not in candidate_years:
+        return False
+    return not _CONTENT_EXTRA_MARKERS.search(candidate_title)
+
+
+def filter_requested_content(results, identity):
+    """Keep only rows that strictly match the requested content identity."""
+    matched = [
+        result
+        for result in results or []
+        if result_matches_requested_content(result, identity or {})
+    ]
+    rejected = len(results or []) - len(matched)
+    if rejected:
+        xbmc.log(
+            "NZB-DAV: Strict identity filter rejected {} of {} candidates for "
+            "'{}'".format(
+                rejected, len(results or []), (identity or {}).get("title", "")
+            ),
+            xbmc.LOGINFO,
+        )
+    return matched
 
 
 def _pubdate_sort_key(result):

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -487,6 +487,10 @@ from resources.lib.resolver_resume import (  # noqa: E402,F401
     _set_playback_monitor_properties,
     _show_cache_prompt_after_playback,
 )
+from resources.lib.resolver_retry import (  # noqa: E402,F401
+    _poll_with_release_retries,
+    _retry_attempts,
+)
 from resources.lib.resolver_submit import (  # noqa: E402,F401
     _adopt_queued_or_completed_job,
     _await_adoptable_probe_result,

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
@@ -198,13 +198,24 @@ def _invoke_poll_until_ready(
         download_pubdate=params_src.get("_download_pubdate"),
         download_size=params_src.get("_download_size"),
     )
-    return _resolver._poll_until_ready(
+    retry_candidates = params_src.get("_retry_candidates", [])
+    if not retry_candidates:
+        return _resolver._poll_until_ready(
+            nzb_url,
+            title,
+            dialog,
+            poll_interval,
+            download_timeout,
+            poll_ctx=poll_ctx,
+        )
+    return _resolver._poll_with_release_retries(
         nzb_url,
         title,
+        retry_candidates,
         dialog,
         poll_interval,
         download_timeout,
-        poll_ctx=poll_ctx,
+        poll_ctx,
     )
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_retry.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_retry.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+# pylint: disable=cyclic-import
+
+"""Sequential distinct-release retry orchestration."""
+
+import resources.lib.resolver as _resolver
+
+
+def _retry_attempts(nzb_url, title, candidates):
+    attempts = [{"link": nzb_url, "title": title, "primary": True}]
+    for candidate in candidates or []:
+        if not isinstance(candidate, dict):
+            continue
+        link = candidate.get("link")
+        candidate_title = candidate.get("title")
+        if link and candidate_title:
+            attempt = dict(candidate)
+            attempt["link"] = link
+            attempt["title"] = candidate_title
+            attempt["primary"] = False
+            attempts.append(attempt)
+    return attempts
+
+
+def _poll_with_release_retries(
+    nzb_url,
+    title,
+    retry_candidates,
+    dialog,
+    poll_interval,
+    download_timeout,
+    poll_ctx,
+):
+    """Try a new release only after the preceding release is provably dead."""
+    attempts = _retry_attempts(nzb_url, title, retry_candidates)
+    for index, attempt in enumerate(attempts):
+        if index:
+            _resolver.xbmc.log(
+                "NZB-DAV: Trying distinct release fallback {}/{}: '{}'".format(
+                    index, len(attempts) - 1, attempt["title"]
+                ),
+                _resolver.xbmc.LOGINFO,
+            )
+            _resolver._safe_dialog_update(
+                dialog,
+                0,
+                "Previous release was unavailable. Trying another posting...",
+            )
+        attempt_ctx = poll_ctx
+        if index:
+            attempt_ctx = poll_ctx._replace(
+                completed_job_hint=None,
+                completed_job_lookup_done=False,
+                selected_indexer=attempt.get("indexer", ""),
+                download_pubdate=attempt.get("pubdate"),
+                download_size=attempt.get("size"),
+            )
+        stream = _resolver._poll_until_ready(
+            attempt["link"],
+            attempt["title"],
+            dialog,
+            poll_interval,
+            download_timeout,
+            poll_ctx=attempt_ctx,
+        )
+        if stream[0]:
+            return stream
+        dead = attempt_ctx.dead
+        if dead is None or not dead.has_url(attempt["link"]):
+            break
+    return None, None

--- a/repo/plugin.video.nzbdav/resources/lib/router_play.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_play.py
@@ -328,10 +328,11 @@ def _available_filtered_rows(filtered, all_parsed, title, notify, pack_result):
     return [] if pack_result is not None else None
 
 
-def _prepare_picker_rows(results, title, notify, pack_result):
+def _prepare_picker_rows(results, title, notify, pack_result, identity=None):
     """Filter provider rows and prepend one exact local-pack row."""
-    from resources.lib.filter import filter_results
+    from resources.lib.filter import filter_requested_content, filter_results
 
+    results = filter_requested_content(results, identity) if identity else results
     filtered, all_parsed = filter_results(results)
     filtered = _available_filtered_rows(
         filtered, all_parsed, title, notify, pack_result
@@ -362,7 +363,9 @@ def _handle_play_filter_and_select(
         xbmc.LOGDEBUG,
     )
 
-    prepared = _prepare_picker_rows(results, title, notify, pack_result)
+    prepared = _prepare_picker_rows(
+        results, title, notify, pack_result, identity=identity
+    )
     if prepared is None:
         xbmcplugin.setResolvedUrl(handle, False, xbmcgui.ListItem())
         return
@@ -435,6 +438,7 @@ def _handle_play_auto_select(handle, best, filtered, identity=None):
         "_fallback_candidates": [],
         "_fallback_candidate_loader": _selection_fallback_loader(target, provider_rows),
     }
+    _attach_retry_candidates(resolver_params, target, provider_rows)
     _attach_episode_context(resolver_params, identity or {})
     _attach_nzbget_dupe(resolver_params, target, provider_rows, identity)
     _ensure_nzbget_completed_hint(target)
@@ -463,6 +467,43 @@ def _identity_from_params(params):
 def _normalize_release_name(title):
     """Case/whitespace-normalized release name for same-name matching (#372)."""
     return " ".join(str(title or "").split()).casefold()
+
+
+def _release_retry_key(result):
+    """Collapse cosmetic duplicate listings of one release."""
+    title = str((result or {}).get("title", "") or "").lower()
+    title = re.sub(r"\s*\[fallback-\d+-[0-9a-f]+\]\s*$", "", title)
+    title = re.sub(r"[\W_]+", " ", title)
+    return " ".join(title.split())
+
+
+def _attach_retry_candidates(resolver_params, selected, results, max_candidates=5):
+    """Attach distinct retry releases from the already-filtered picker pool."""
+    selected_link = str(selected.get("link", "") or "")
+    seen_links = {selected_link}
+    seen_releases = {_release_retry_key(selected)}
+    retries = []
+    for candidate in results or []:
+        if candidate is selected or not isinstance(candidate, dict):
+            continue
+        link = str(candidate.get("link", "") or "")
+        release_key = _release_retry_key(candidate)
+        if (
+            not link
+            or link in seen_links
+            or not release_key
+            or release_key in seen_releases
+        ):
+            continue
+        seen_links.add(link)
+        seen_releases.add(release_key)
+        retries.append(candidate)
+        if len(retries) >= max_candidates:
+            break
+    if retries:
+        resolver_params["_retry_candidates"] = retries
+    else:
+        resolver_params.pop("_retry_candidates", None)
 
 
 _IMDB_DIGITS_RE = re.compile(r"(\d+)")
@@ -777,6 +818,7 @@ def _handle_play_resolve_selection(
         "_fallback_candidates": [],
         "_fallback_candidate_loader": _selection_fallback_loader(target, provider_rows),
     }
+    _attach_retry_candidates(resolver_params, target, provider_rows)
     _attach_episode_context(resolver_params, identity or {})
     _attach_nzbget_dupe(resolver_params, target, provider_rows, identity)
     _apply_completed_job_hint(resolver_params, target, completed_jobs)
@@ -802,7 +844,10 @@ def _handle_search_filter_and_select(
         ),
         xbmc.LOGDEBUG,
     )
-    prepared = _prepare_picker_rows(results, title, notify, pack_result)
+    identity = _identity_from_params(params)
+    prepared = _prepare_picker_rows(
+        results, title, notify, pack_result, identity=identity
+    )
     if prepared is None:
         xbmcplugin.endOfDirectory(handle, succeeded=False)
         return
@@ -857,6 +902,7 @@ def _handle_search_auto_select(params, best, filtered):
     resolver_params["_fallback_candidate_loader"] = _selection_fallback_loader(
         target, provider_rows
     )
+    _attach_retry_candidates(resolver_params, target, provider_rows)
     _attach_nzbget_dupe(
         resolver_params, target, provider_rows, _identity_from_params(params)
     )
@@ -878,6 +924,7 @@ def _handle_search_resolve_selection(params, selected, filtered, completed_jobs)
     resolver_params["_fallback_candidate_loader"] = _selection_fallback_loader(
         target, provider_rows
     )
+    _attach_retry_candidates(resolver_params, target, provider_rows)
     _attach_nzbget_dupe(
         resolver_params, target, provider_rows, _identity_from_params(params)
     )

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from resources.lib.filter import (
     _has_filter_metadata_shape,
     _sort_results,
+    filter_requested_content,
     filter_results,
     matches_filters,
     parse_title_metadata,
@@ -32,6 +33,40 @@ def _make_result(title, size="5000000000", pubdate="", link="http://example.com/
         "pubdate": pubdate,
         "age": "1 day",
     }
+
+
+def test_strict_identity_filter_rejects_wrong_title_episode_and_extras():
+    identity = {
+        "type": "episode",
+        "title": "The Good the Bad and the Ugly",
+        "year": "2025",
+        "season": "1",
+        "episode": "3",
+    }
+    wanted = _make_result(
+        "The.Good.the.Bad.and.the.Ugly.2025.S01E03.1080p.WEB-DL-GROUP"
+    )
+    rows = [
+        wanted,
+        _make_result(
+            "The.Rookie.S01E03.The.Good.the.Bad.and.the.Ugly.1080p.WEB-DL-GROUP"
+        ),
+        _make_result("The.Good.the.Bad.and.the.Ugly.2025.S01E04.1080p.WEB-DL-GROUP"),
+        _make_result("The.Good.the.Bad.and.the.Ugly.2025.S01E03.Behind.the.Scenes"),
+    ]
+    assert filter_requested_content(rows, identity) == [wanted]
+
+
+def test_strict_identity_filter_rejects_episode_and_wrong_year_for_movie():
+    identity = {"type": "movie", "title": "Interstellar", "year": "2014"}
+    wanted = _make_result("Interstellar.2014.1080p.BluRay-GROUP")
+    rows = [
+        wanted,
+        _make_result("Doctor.Who.S01E02.The.Interstellar.Song.Contest.1080p"),
+        _make_result("Interstellar.2025.1080p.WEB-DL-GROUP"),
+        _make_result("Another.Movie.2014.1080p.WEB-DL-GROUP"),
+    ]
+    assert filter_requested_content(rows, identity) == [wanted]
 
 
 def test_filter_uses_module_scope_kodi_imports():

--- a/tests/test_release_retry.py
+++ b/tests/test_release_retry.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+from unittest.mock import MagicMock, patch
+
+from resources.lib.dead_candidates import DeadCandidates
+from resources.lib.resolver import PollContext, _poll_with_release_retries
+from resources.lib.router_play import _attach_retry_candidates
+
+
+def _row(title, link, **extra):
+    row = {"title": title, "link": link}
+    row.update(extra)
+    return row
+
+
+def test_retry_candidates_are_distinct_and_capped():
+    selected = _row("Movie.2026.1080p-GROUP", "https://indexer/primary")
+    duplicate = _row(
+        "Movie 2026 1080p GROUP [fallback-2-deadbeef]",
+        "https://indexer/duplicate",
+    )
+    distinct = [
+        _row(
+            "Movie.2026.{}p-GROUP{}".format(720 + index, index),
+            "https://i/{}".format(index),
+        )
+        for index in range(7)
+    ]
+    params = {}
+    _attach_retry_candidates(params, selected, [selected, duplicate] + distinct)
+    assert params["_retry_candidates"] == distinct[:5]
+
+
+def test_release_retry_runs_only_after_provably_dead_attempt():
+    dead = DeadCandidates()
+    context = PollContext(dead=dead)
+    dialog = MagicMock()
+
+    def poll(url, _title, _dialog, _interval, _timeout, poll_ctx=None):
+        if url.endswith("primary"):
+            poll_ctx.dead.add(nzb_url=url)
+            return None, None
+        return "https://webdav/movie.mkv", {"Authorization": "Basic x"}
+
+    with patch("resources.lib.resolver._poll_until_ready", side_effect=poll) as mocked:
+        result = _poll_with_release_retries(
+            "https://indexer/primary",
+            "Movie.2026.1080p-GROUP",
+            [_row("Movie.2026.2160p-GROUP", "https://indexer/retry")],
+            dialog,
+            2,
+            600,
+            context,
+        )
+
+    assert result[0] == "https://webdav/movie.mkv"
+    assert [item.args[0] for item in mocked.call_args_list] == [
+        "https://indexer/primary",
+        "https://indexer/retry",
+    ]
+
+
+def test_release_retry_stops_after_nonterminal_failure():
+    context = PollContext(dead=DeadCandidates())
+    dialog = MagicMock()
+    with patch(
+        "resources.lib.resolver._poll_until_ready", return_value=(None, None)
+    ) as mocked:
+        result = _poll_with_release_retries(
+            "https://indexer/primary",
+            "Movie.2026.1080p-GROUP",
+            [_row("Movie.2026.2160p-GROUP", "https://indexer/retry")],
+            dialog,
+            2,
+            600,
+            context,
+        )
+    assert result == (None, None)
+    assert mocked.call_count == 1


### PR DESCRIPTION
## What changed
- reject search results that do not strictly match the requested title, content type, year, and episode coordinates, including bonus-material markers and episode-title collisions
- carry up to five distinct releases from the already-filtered picker pool into the resolver
- retry those releases sequentially only after the current candidate is marked provably dead; timeouts, cancellation, and other non-terminal failures do not advance the ladder
- preserve the existing resolver fast path when no retry candidates exist

## Why
Indexer phrase matching can return a different show whose episode title contains the requested series name, the wrong year or episode, or bonus material. A selected Usenet posting can also be permanently unavailable even when another distinct release was already returned by the same search. The resolver should fail closed on content identity and use already-fetched alternatives without speculative provider traffic.

## Validation
- full lint gates: ruff, black, pylint, vermin (pass)
- focused tests: 68 passed
- full default suite: 2,586 passed, 2 skipped; three Windows-only baseline failures remain and reproduce on untouched upstream (two timing assertions) or require /bin/bash (install-script test)

The live Kodi profile was not copied into this repository and no settings, credentials, logs, databases, caches, packages, or runtime state are included.