### PR TITLE
Stop polling when backend state is unavailable

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/filter.py
+++ b/repo/plugin.video.nzbdav/resources/lib/filter.py
@@ -550,18 +550,18 @@ def _episode_identity_matches(candidate_title, phrase_match, identity):
         requested_pair = (int(season), int(episode))
     except (TypeError, ValueError):
         requested_pair = None
-    if requested_pair is not None and (
-        episode_match is None
-        or (int(episode_match.group(1)), int(episode_match.group(2))) != requested_pair
-    ):
+    actual_pair = (
+        (int(episode_match.group(1)), int(episode_match.group(2)))
+        if episode_match is not None
+        else None
+    )
+    if requested_pair is not None and actual_pair != requested_pair:
         return False
     # The requested show name must not occur only as another show's episode
     # title (for example The.Rookie.S01E03.<requested title>).
-    return not (
-        phrase_match is not None
-        and episode_match is not None
-        and phrase_match.start() > episode_match.start()
-    )
+    if phrase_match is None or episode_match is None:
+        return True
+    return phrase_match.start() <= episode_match.start()
 
 
 def _media_type_matches(candidate_title, phrase_match, identity):

--- a/repo/plugin.video.nzbdav/resources/lib/filter.py
+++ b/repo/plugin.video.nzbdav/resources/lib/filter.py
@@ -541,20 +541,28 @@ def _content_phrase_pattern(title):
     )
 
 
-def _episode_identity_matches(candidate_title, phrase_match, identity):
-    """Return whether an episode candidate has the requested identity."""
+def _requested_episode_pair(identity):
+    """Return the requested numeric episode pair when both fields are valid."""
     season = str(identity.get("season", "") or "")
     episode = str(identity.get("episode", "") or "")
-    episode_match = _SEASON_EPISODE_RE.search(candidate_title)
     try:
-        requested_pair = (int(season), int(episode))
+        return int(season), int(episode)
     except (TypeError, ValueError):
-        requested_pair = None
-    actual_pair = (
-        (int(episode_match.group(1)), int(episode_match.group(2)))
-        if episode_match is not None
-        else None
-    )
+        return None
+
+
+def _candidate_episode_pair(episode_match):
+    """Return the release's numeric episode pair when it has one."""
+    if episode_match is None:
+        return None
+    return int(episode_match.group(1)), int(episode_match.group(2))
+
+
+def _episode_identity_matches(candidate_title, phrase_match, identity):
+    """Return whether an episode candidate has the requested identity."""
+    episode_match = _SEASON_EPISODE_RE.search(candidate_title)
+    requested_pair = _requested_episode_pair(identity)
+    actual_pair = _candidate_episode_pair(episode_match)
     if requested_pair is not None and actual_pair != requested_pair:
         return False
     # The requested show name must not occur only as another show's episode

--- a/repo/plugin.video.nzbdav/resources/lib/filter.py
+++ b/repo/plugin.video.nzbdav/resources/lib/filter.py
@@ -541,6 +541,48 @@ def _content_phrase_pattern(title):
     )
 
 
+def _episode_identity_matches(candidate_title, phrase_match, identity):
+    """Return whether an episode candidate has the requested identity."""
+    season = str(identity.get("season", "") or "")
+    episode = str(identity.get("episode", "") or "")
+    episode_match = _SEASON_EPISODE_RE.search(candidate_title)
+    try:
+        requested_pair = (int(season), int(episode))
+    except (TypeError, ValueError):
+        requested_pair = None
+    if requested_pair is not None and (
+        episode_match is None
+        or (int(episode_match.group(1)), int(episode_match.group(2))) != requested_pair
+    ):
+        return False
+    # The requested show name must not occur only as another show's episode
+    # title (for example The.Rookie.S01E03.<requested title>).
+    return not (
+        phrase_match is not None
+        and episode_match is not None
+        and phrase_match.start() > episode_match.start()
+    )
+
+
+def _media_type_matches(candidate_title, phrase_match, identity):
+    """Return whether movie/episode markers agree with the request."""
+    content_type = str(identity.get("type", "") or "").lower()
+    season = str(identity.get("season", "") or "")
+    episode = str(identity.get("episode", "") or "")
+    if content_type == "episode" or (season and episode):
+        return _episode_identity_matches(candidate_title, phrase_match, identity)
+    return content_type != "movie" or _SEASON_EPISODE_RE.search(candidate_title) is None
+
+
+def _year_matches(candidate_title, identity):
+    """Return whether an explicit release year agrees with the request."""
+    requested_year = str(identity.get("year", "") or "")
+    candidate_years = set(_YEAR_RE.findall(candidate_title))
+    return not (
+        requested_year and candidate_years and requested_year not in candidate_years
+    )
+
+
 def result_matches_requested_content(result, identity):
     """Fail closed on an obvious wrong-title, movie, or episode result."""
     if not isinstance(result, dict):
@@ -551,53 +593,27 @@ def result_matches_requested_content(result, identity):
     if phrase is not None and phrase_match is None:
         return False
 
-    content_type = str(identity.get("type", "") or "").lower()
-    season = str(identity.get("season", "") or "")
-    episode = str(identity.get("episode", "") or "")
-    episode_match = _SEASON_EPISODE_RE.search(candidate_title)
-    if content_type == "episode" or (season and episode):
-        try:
-            requested_pair = (int(season), int(episode))
-        except (TypeError, ValueError):
-            requested_pair = None
-        if requested_pair is not None and (
-            episode_match is None
-            or (int(episode_match.group(1)), int(episode_match.group(2)))
-            != requested_pair
-        ):
-            return False
-        if (
-            phrase_match is not None
-            and episode_match is not None
-            and phrase_match.start() > episode_match.start()
-        ):
-            # The requested show name occurs only as another show's episode
-            # title (for example The.Rookie.S01E03.<requested title>).
-            return False
-    elif content_type == "movie" and episode_match is not None:
+    if not _media_type_matches(candidate_title, phrase_match, identity):
         return False
-
-    requested_year = str(identity.get("year", "") or "")
-    candidate_years = set(_YEAR_RE.findall(candidate_title))
-    if requested_year and candidate_years and requested_year not in candidate_years:
+    if not _year_matches(candidate_title, identity):
         return False
     return not _CONTENT_EXTRA_MARKERS.search(candidate_title)
 
 
 def filter_requested_content(results, identity):
     """Keep only rows that strictly match the requested content identity."""
+    rows = results or []
+    requested_identity = identity or {}
     matched = [
         result
-        for result in results or []
-        if result_matches_requested_content(result, identity or {})
+        for result in rows
+        if result_matches_requested_content(result, requested_identity)
     ]
-    rejected = len(results or []) - len(matched)
+    rejected = len(rows) - len(matched)
     if rejected:
         xbmc.log(
             "NZB-DAV: Strict identity filter rejected {} of {} candidates for "
-            "'{}'".format(
-                rejected, len(results or []), (identity or {}).get("title", "")
-            ),
+            "'{}'".format(rejected, len(rows), requested_identity.get("title", "")),
             xbmc.LOGINFO,
         )
     return matched

--- a/repo/plugin.video.nzbdav/resources/lib/filter.py
+++ b/repo/plugin.video.nzbdav/resources/lib/filter.py
@@ -4,6 +4,7 @@
 """Result filtering and sorting using PTT for title parsing."""
 
 import math
+import re
 import time
 from copy import deepcopy
 from types import SimpleNamespace
@@ -512,6 +513,94 @@ def filter_results(results, settings_getter=None):
         shown=len(filtered),
     )
     return filtered, all_parsed
+
+
+_CONTENT_EXTRA_MARKERS = re.compile(
+    r"\b(?:behind[\W_]+the[\W_]+scenes|making[\W_]+of|featurette|"
+    r"documentary|interview|trailer|sample|extras?)\b",
+    re.I,
+)
+_SEASON_EPISODE_RE = re.compile(
+    r"(?<![A-Za-z0-9])S(\d{1,2})[\W_]*E(\d{1,3})(?![A-Za-z0-9])",
+    re.I,
+)
+_YEAR_RE = re.compile(r"(?<!\d)((?:19|20)\d{2})(?!\d)")
+
+
+def _content_phrase_pattern(title):
+    """Return a boundary-safe release-title pattern for a requested title."""
+    words = re.findall(r"[A-Za-z0-9]+", str(title or "").lower())
+    words = [word for word in words if len(word) > 1 or word.isdigit()]
+    if not words:
+        return None
+    return re.compile(
+        r"(?<![A-Za-z0-9])"
+        + r"[\W_]+".join(re.escape(word) for word in words)
+        + r"(?![A-Za-z0-9])",
+        re.I,
+    )
+
+
+def result_matches_requested_content(result, identity):
+    """Fail closed on an obvious wrong-title, movie, or episode result."""
+    if not isinstance(result, dict):
+        return False
+    candidate_title = str(result.get("title", "") or "")
+    phrase = _content_phrase_pattern(identity.get("title", ""))
+    phrase_match = phrase.search(candidate_title) if phrase is not None else None
+    if phrase is not None and phrase_match is None:
+        return False
+
+    content_type = str(identity.get("type", "") or "").lower()
+    season = str(identity.get("season", "") or "")
+    episode = str(identity.get("episode", "") or "")
+    episode_match = _SEASON_EPISODE_RE.search(candidate_title)
+    if content_type == "episode" or (season and episode):
+        try:
+            requested_pair = (int(season), int(episode))
+        except (TypeError, ValueError):
+            requested_pair = None
+        if requested_pair is not None and (
+            episode_match is None
+            or (int(episode_match.group(1)), int(episode_match.group(2)))
+            != requested_pair
+        ):
+            return False
+        if (
+            phrase_match is not None
+            and episode_match is not None
+            and phrase_match.start() > episode_match.start()
+        ):
+            # The requested show name occurs only as another show's episode
+            # title (for example The.Rookie.S01E03.<requested title>).
+            return False
+    elif content_type == "movie" and episode_match is not None:
+        return False
+
+    requested_year = str(identity.get("year", "") or "")
+    candidate_years = set(_YEAR_RE.findall(candidate_title))
+    if requested_year and candidate_years and requested_year not in candidate_years:
+        return False
+    return not _CONTENT_EXTRA_MARKERS.search(candidate_title)
+
+
+def filter_requested_content(results, identity):
+    """Keep only rows that strictly match the requested content identity."""
+    matched = [
+        result
+        for result in results or []
+        if result_matches_requested_content(result, identity or {})
+    ]
+    rejected = len(results or []) - len(matched)
+    if rejected:
+        xbmc.log(
+            "NZB-DAV: Strict identity filter rejected {} of {} candidates for "
+            "'{}'".format(
+                rejected, len(results or []), (identity or {}).get("title", "")
+            ),
+            xbmc.LOGINFO,
+        )
+    return matched
 
 
 def _pubdate_sort_key(result):

--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -124,22 +124,14 @@ def _redact_netloc_userinfo(netloc):
     return "{}@{}".format(userinfo, host)
 
 
-def _redact_url_userinfo_span(match):
-    """Strip the password from a URL span's ``user:pass@host`` userinfo.
+def _redact_url_span(match):
+    """Redact credentials only within a matched URL span.
 
-    Reuses the same ``rpartition('@')`` / ``partition(':')`` logic as
-    ``redact_url`` so an ``@`` *inside* the password (or an empty username)
-    can't leak. Spans with no userinfo round-trip unchanged.
+    Reusing ``redact_url`` covers both URL userinfo and non-standard Newznab
+    path credentials without applying short ``i``/``r`` parameter names to
+    unrelated text elsewhere in the same message.
     """
-    span = match.group(0)
-    try:
-        parts = urlsplit(span)
-    except (ValueError, TypeError):
-        return span
-    if not parts.netloc or "@" not in parts.netloc:
-        return span
-    netloc = _redact_netloc_userinfo(parts.netloc)
-    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+    return redact_url(match.group(0))
 
 
 def redact_text(text):
@@ -157,9 +149,7 @@ def redact_text(text):
     # ``\1`` is the key group; a backreference replacement avoids a per-match
     # Python callback on this hot logging/error path.
     redacted = _EMBEDDED_CRED_RE.sub(r"\1=REDACTED", str(text))
-    if "getnzb" in redacted.lower() or ".nzb&" in redacted.lower():
-        redacted = _GETNZB_PATH_CRED_RE.sub(r"\1=REDACTED", redacted)
-    return _EMBEDDED_URL_RE.sub(_redact_url_userinfo_span, redacted)
+    return _EMBEDDED_URL_RE.sub(_redact_url_span, redacted)
 
 
 _WHITESPACE_RE = re.compile(r"\s+")

--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -41,6 +41,16 @@ _EMBEDDED_CRED_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Some Newznab indexers return download URLs shaped like
+# ``/getnzb/id.nzb&i=ACCOUNT&r=APIKEY``. Because there is no ``?``, both
+# credentials are parsed as part of the URL path rather than query params.
+# Restrict the short ``i``/``r`` names to getnzb-looking paths so ordinary
+# application URLs using those names are not over-redacted.
+_GETNZB_PATH_CRED_RE = re.compile(
+    r"([&;](?:i|r))=([^&\s\"'<>]+)",
+    re.IGNORECASE,
+)
+
 # Catch ``scheme://user:password@host`` userinfo embedded in free-form text.
 # urllib / socket / xbmcvfs errors sometimes echo the failing URL — e.g. the
 # NZBGet JSON-RPC URL or the ``smb://user:pass@host/...`` completed-folder
@@ -91,9 +101,10 @@ def redact_url(url):
     # WebDAV stack used to accept). Strip the password half before
     # logging. TODO.md §H.2-H2d.
     netloc = _redact_netloc_userinfo(parts.netloc)
-    return urlunsplit(
-        (parts.scheme, netloc, parts.path, urlencode(query), parts.fragment)
-    )
+    path = parts.path
+    if "getnzb" in path.lower() or ".nzb&" in path.lower():
+        path = _GETNZB_PATH_CRED_RE.sub(r"\1=REDACTED", path)
+    return urlunsplit((parts.scheme, netloc, path, urlencode(query), parts.fragment))
 
 
 def _redact_netloc_userinfo(netloc):
@@ -146,6 +157,8 @@ def redact_text(text):
     # ``\1`` is the key group; a backreference replacement avoids a per-match
     # Python callback on this hot logging/error path.
     redacted = _EMBEDDED_CRED_RE.sub(r"\1=REDACTED", str(text))
+    if "getnzb" in redacted.lower() or ".nzb&" in redacted.lower():
+        redacted = _GETNZB_PATH_CRED_RE.sub(r"\1=REDACTED", redacted)
     return _EMBEDDED_URL_RE.sub(_redact_url_userinfo_span, redacted)
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/player_installer.py
+++ b/repo/plugin.video.nzbdav/resources/lib/player_installer.py
@@ -32,7 +32,7 @@ TMDBHELPER_PLAYER_PATH = _player_path_for(TMDBHELPER_ADDON_ID)
 # Bump this when PLAYER_JSON's shape changes in a way that requires the
 # installer to overwrite an older generation. We ignore the user's manual
 # edits only when the stored schema_version differs from ours.
-_PLAYER_SCHEMA_VERSION = 7
+_PLAYER_SCHEMA_VERSION = 8
 
 PLAYER_JSON = {
     "name": "NZB-DAV",
@@ -49,7 +49,8 @@ PLAYER_JSON = {
         "executebuiltin://RunScript("
         "special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,"
         "type=episode,title={showname_url},year={showyear},season={season},"
-        "episode={episode},imdb={imdb},tmdb_id={tmdb_id},tvdb={tvdb},"
+        "episode={episode},imdb={imdb},tmdb_id={tmdb},"
+        "show_tmdb_id={tmdb},episode_tmdb_id={eptmdb},tvdb={tvdb},"
         "ep_season={ep_showseason},ep_episode={ep_showepisode})"
     ),
 }

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -377,6 +377,13 @@ from resources.lib.resolver_history import (  # noqa: E402,F401
     _status_dialog_message,
     _stub_min_size_floor,
 )
+from resources.lib.resolver_metadata import (  # noqa: E402,F401
+    _apply_playback_identity,
+    _episode_identity,
+    _fallback_info,
+    _stable_unique_ids,
+    _tmdb_helper_metadata,
+)
 from resources.lib.resolver_playback import (  # noqa: E402,F401
     _add_own_plugin_target_ids,
     _add_request_headers,

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -93,6 +93,8 @@ _POLL_NEAR_COMPLETE_FAST_REPOLL_SECONDS = 0.1
 
 _POLL_NEAR_COMPLETE_FAST_REPOLL_COUNT = 5
 
+_POLL_OBSERVABILITY_TIMEOUT_SECONDS = 60
+
 _PLAYBACK_CLEANUP_HANDOFF_GRACE_SECONDS = 0.25
 
 _PLAYBACK_PREPARE_HANDOFF_GRACE_SECONDS = 8.0
@@ -439,9 +441,11 @@ from resources.lib.resolver_pollloop import (  # noqa: E402,F401
     _mark_dead_on_failed_history,
     _mark_dead_on_terminal_job_status,
     _notify_primary_submitted,
+    _poll_observation_unavailable,
     _poll_until_ready,
     _record_download_soft,
     _submit_and_announce,
+    _surface_poll_observation_timeout,
     _wait_between_polls,
 )
 from resources.lib.resolver_prepare import (  # noqa: E402,F401

--- a/repo/plugin.video.nzbdav/resources/lib/resolver.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver.py
@@ -487,6 +487,10 @@ from resources.lib.resolver_resume import (  # noqa: E402,F401
     _set_playback_monitor_properties,
     _show_cache_prompt_after_playback,
 )
+from resources.lib.resolver_retry import (  # noqa: E402,F401
+    _poll_with_release_retries,
+    _retry_attempts,
+)
 from resources.lib.resolver_submit import (  # noqa: E402,F401
     _adopt_queued_or_completed_job,
     _await_adoptable_probe_result,

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
@@ -343,7 +343,11 @@ def _resolve_play_ready_stream(
         return dialog
     _resolver._arm_live_fallback_push(prepared, fallback_state, stream_url, dead=dead)
     _resolver._finish_direct_playback(
-        handle, prepared, resume_key=release_id, resume_seconds=chosen
+        handle,
+        prepared,
+        resume_key=release_id,
+        resume_seconds=chosen,
+        params=params,
     )
     # Playback handed off to Kodi: start the fallback worker's "minutes
     # into playback" countdown now, not from the earlier primary submit.
@@ -513,7 +517,10 @@ def _resolve_and_play_ready_stream(
         return dialog
     _resolver._arm_live_fallback_push(prepared, fallback_state, stream_url, dead=dead)
     _resolver._finish_player_playback(
-        prepared, resume_key=release_id, resume_seconds=chosen
+        prepared,
+        resume_key=release_id,
+        resume_seconds=chosen,
+        params=resume_params,
     )
     # Playback handed off to the player: start the fallback worker's
     # "minutes into playback" countdown now, not from the primary submit.

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
@@ -198,13 +198,24 @@ def _invoke_poll_until_ready(
         download_pubdate=params_src.get("_download_pubdate"),
         download_size=params_src.get("_download_size"),
     )
-    return _resolver._poll_until_ready(
+    retry_candidates = params_src.get("_retry_candidates", [])
+    if not retry_candidates:
+        return _resolver._poll_until_ready(
+            nzb_url,
+            title,
+            dialog,
+            poll_interval,
+            download_timeout,
+            poll_ctx=poll_ctx,
+        )
+    return _resolver._poll_with_release_retries(
         nzb_url,
         title,
+        retry_candidates,
         dialog,
         poll_interval,
         download_timeout,
-        poll_ctx=poll_ctx,
+        poll_ctx,
     )
 
 

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_metadata.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_metadata.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Kodi ListItem identity for resolved movie and episode playback."""
+
+import json
+from urllib.parse import unquote, urlencode
+
+from resources.lib import resolver as _resolver
+
+
+def _clean_id(params, *keys):
+    for key in keys:
+        value = str((params or {}).get(key, "") or "").strip()
+        if value and value != "_":
+            return value
+    return ""
+
+
+def _episode_identity(params):
+    """Return stable show/episode identity carried by a TMDBHelper action."""
+    params = params or {}
+    return {
+        "show_tmdb_id": _clean_id(params, "show_tmdb_id", "tmdb_id"),
+        "episode_tmdb_id": _clean_id(params, "episode_tmdb_id"),
+        "show_imdb_id": _clean_id(params, "imdb"),
+        "showtitle": unquote(str(params.get("title", "") or "")),
+        "season": params.get("season", params.get("ep_season", "")),
+        "episode": params.get("episode", params.get("ep_episode", "")),
+    }
+
+
+def _tmdb_helper_metadata(params):
+    """Return TMDBHelper's rich metadata using the TV-show id for episodes."""
+    params = params or {}
+    media_type = str(params.get("type", "movie") or "movie").lower()
+    identity = _episode_identity(params)
+    tmdb_id = (
+        identity["show_tmdb_id"]
+        if media_type == "episode"
+        else _clean_id(params, "tmdb_id")
+    )
+    if not tmdb_id:
+        return {}
+
+    query = {
+        "info": "details",
+        "tmdb_type": "tv" if media_type == "episode" else "movie",
+        "tmdb_id": tmdb_id,
+    }
+    if media_type == "episode":
+        query["season"] = identity["season"]
+        query["episode"] = identity["episode"]
+
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "Files.GetDirectory",
+        "params": {
+            "directory": (
+                "plugin://plugin.video.themoviedb.helper/?" + urlencode(query)
+            ),
+            "media": "video",
+            "properties": [
+                "title",
+                "year",
+                "plot",
+                "cast",
+                "director",
+                "writer",
+                "art",
+                "thumbnail",
+                "fanart",
+                "imdbnumber",
+                "uniqueid",
+                "genre",
+                "rating",
+                "userrating",
+                "premiered",
+                "originaltitle",
+                "tagline",
+                "studio",
+                "duration",
+                "showtitle",
+                "season",
+                "episode",
+            ],
+        },
+    }
+    try:
+        response = json.loads(_resolver.xbmc.executeJSONRPC(json.dumps(request)))
+        files = response.get("result", {}).get("files", [])
+        if files:
+            return files[0]
+    except (AttributeError, RuntimeError, TypeError, ValueError) as error:
+        _resolver.xbmc.log(
+            "NZB-DAV: TMDBHelper metadata lookup failed: {}".format(error),
+            _resolver.xbmc.LOGWARNING,
+        )
+    return {}
+
+
+def _fallback_info(params):
+    params = params or {}
+    media_type = str(params.get("type", "") or "").lower()
+    if media_type == "episode":
+        identity = _episode_identity(params)
+        return {
+            "title": identity["showtitle"],
+            "tvshowtitle": identity["showtitle"],
+            "year": params.get("year", ""),
+            "season": identity["season"],
+            "episode": identity["episode"],
+            "mediatype": "episode",
+        }
+    return {
+        "title": unquote(str(params.get("title", "") or "")),
+        "year": params.get("year", ""),
+        "mediatype": "movie",
+    }
+
+
+def _stable_unique_ids(params, metadata):
+    params = params or {}
+    unique_ids = dict((metadata or {}).get("uniqueid") or {})
+    media_type = str(params.get("type", "") or "").lower()
+    if media_type == "episode":
+        identity = _episode_identity(params)
+        if identity["show_tmdb_id"]:
+            unique_ids["tvshow.tmdb"] = identity["show_tmdb_id"]
+        if identity["episode_tmdb_id"]:
+            unique_ids["tmdb"] = identity["episode_tmdb_id"]
+        if identity["show_imdb_id"]:
+            unique_ids["tvshow.imdb"] = identity["show_imdb_id"]
+    else:
+        tmdb_id = _clean_id(params, "tmdb_id")
+        imdb_id = _clean_id(params, "imdb")
+        if tmdb_id:
+            unique_ids["tmdb"] = tmdb_id
+        if imdb_id:
+            unique_ids["imdb"] = imdb_id
+    return unique_ids
+
+
+def _apply_playback_identity(li, params):
+    """Attach rich metadata plus stable fallback identity to a playback item."""
+    params = params or {}
+    metadata = _tmdb_helper_metadata(params)
+    info_keys = (
+        "title",
+        "year",
+        "plot",
+        "director",
+        "writer",
+        "genre",
+        "rating",
+        "userrating",
+        "premiered",
+        "originaltitle",
+        "tagline",
+        "studio",
+        "duration",
+        "showtitle",
+        "season",
+        "episode",
+    )
+    info = {
+        key: metadata[key] for key in info_keys if metadata.get(key) not in (None, "")
+    }
+    for key, value in _fallback_info(params).items():
+        if value not in (None, ""):
+            info.setdefault(key, value)
+    li.setInfo("video", info)
+
+    art = dict(metadata.get("art") or {})
+    if metadata.get("thumbnail") and not art.get("thumb"):
+        art["thumb"] = metadata["thumbnail"]
+    if metadata.get("fanart") and not art.get("fanart"):
+        art["fanart"] = metadata["fanart"]
+    if art:
+        li.setArt(art)
+    if metadata.get("cast"):
+        li.setCast(metadata["cast"])
+
+    unique_ids = _stable_unique_ids(params, metadata)
+    if unique_ids:
+        default_id = "tmdb" if unique_ids.get("tmdb") else ""
+        li.setUniqueIDs(unique_ids, default_id)

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_pollloop.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_pollloop.py
@@ -81,6 +81,30 @@ def _wait_between_polls(monitor, wait_seconds, nzo_id, settings_getter):
     return _resolver._POLL_CONTINUE
 
 
+def _poll_observation_unavailable(job_status, history, webdav_error):
+    """Return whether every backend observation failed for this poll."""
+    return (
+        job_status is None
+        and history is None
+        and webdav_error in ("server_error", "connection_error")
+    )
+
+
+def _surface_poll_observation_timeout(nzo_id, settings_getter):
+    """Surface a bounded backend-observation failure without cancelling the job."""
+    message = _resolver._string(_resolver._ERROR_MESSAGES["connection_error"])
+    _resolver.xbmc.log(
+        "NZB-DAV: Backend state remained unavailable for {}s; "
+        "stopping local poll for nzo_id={} without cancelling the remote "
+        "job".format(_resolver._POLL_OBSERVABILITY_TIMEOUT_SECONDS, nzo_id),
+        _resolver.xbmc.LOGERROR,
+    )
+    if settings_getter is None:
+        _resolver.xbmcgui.Dialog().ok(_resolver._addon_name(), message)
+    else:
+        _resolver._notify(_resolver._addon_name(), message, 5000)
+
+
 def _notify_primary_submitted(on_primary_submitted, nzo_id):
     """Fire the primary-submitted callback, never letting it break the poll loop."""
     if on_primary_submitted is None:
@@ -185,18 +209,20 @@ def _poll_until_ready(
     no_video_retries = 0
     max_no_video_retries = 5
     near_complete_fast_repolls = 0
+    observation_error_started = None
 
     def _mark_dead(nzo):
         if poll_ctx.dead is not None:
             poll_ctx.dead.add(nzb_url=nzb_url, nzo_id=nzo)
 
-    def _run_one_poll():
+    def _run_one_poll(elapsed):
         """Run one poll iteration.
 
         Returns the ``(stream_url, stream_headers)`` tuple to return from
         ``_poll_until_ready``, or ``_POLL_CONTINUE`` to keep looping.
         """
         nonlocal last_status, no_video_retries, near_complete_fast_repolls
+        nonlocal observation_error_started
         job_status, history, webdav_error = _resolver._poll_once(
             nzo_id,
             title,
@@ -237,6 +263,18 @@ def _poll_until_ready(
             _mark_dead_on_failed_history(history, nzo_id, _mark_dead)
             return None, None
 
+        if _poll_observation_unavailable(job_status, history, webdav_error):
+            if observation_error_started is None:
+                observation_error_started = elapsed
+            if (
+                elapsed - observation_error_started
+                >= _resolver._POLL_OBSERVABILITY_TIMEOUT_SECONDS
+            ):
+                _surface_poll_observation_timeout(nzo_id, poll_ctx.settings_getter)
+                return None, None
+        else:
+            observation_error_started = None
+
         if _resolver._handle_webdav_error(nzo_id, webdav_error):
             # Deliberately NOT calling cancel_job here. The WebDAV auth
             # failure is an addon-side observation problem (the addon
@@ -260,6 +298,6 @@ def _poll_until_ready(
             iteration, elapsed, download_timeout, dialog, nzo_id, title
         ):
             return None, None
-        result = _run_one_poll()
+        result = _run_one_poll(elapsed)
         if result is not _resolver._POLL_CONTINUE:
             return result

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_pollloop.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_pollloop.py
@@ -105,6 +105,35 @@ def _surface_poll_observation_timeout(nzo_id, settings_getter):
         _resolver._notify(_resolver._addon_name(), message, 5000)
 
 
+def _advance_observation_outage(
+    started, elapsed, job_status, history, webdav_error, nzo_id, settings_getter
+):
+    """Advance or reset the bounded total-observation outage."""
+    if not _poll_observation_unavailable(job_status, history, webdav_error):
+        return -1.0, False
+    if started < 0:
+        started = elapsed
+    if elapsed - started < _resolver._POLL_OBSERVABILITY_TIMEOUT_SECONDS:
+        return started, False
+    _surface_poll_observation_timeout(nzo_id, settings_getter)
+    return started, True
+
+
+def _poll_history_kwargs(poll_ctx, monitor):
+    """Build history-resolution options for one poll."""
+    kwargs = {
+        "monitor": monitor,
+        "settings_getter": poll_ctx.settings_getter,
+        "modal_failures": poll_ctx.settings_getter is None,
+        "download_size": poll_ctx.download_size,
+    }
+    if poll_ctx.episode_context is not None:
+        kwargs["episode_context"] = poll_ctx.episode_context
+    elif poll_ctx.requested_episode is not None:
+        kwargs["requested_episode"] = poll_ctx.requested_episode
+    return kwargs
+
+
 def _notify_primary_submitted(on_primary_submitted, nzo_id):
     """Fire the primary-submitted callback, never letting it break the poll loop."""
     if on_primary_submitted is None:
@@ -209,7 +238,7 @@ def _poll_until_ready(
     no_video_retries = 0
     max_no_video_retries = 5
     near_complete_fast_repolls = 0
-    observation_error_started = None
+    observation_error_started = -1.0
 
     def _mark_dead(nzo):
         if poll_ctx.dead is not None:
@@ -239,16 +268,7 @@ def _poll_until_ready(
             _mark_dead_on_terminal_job_status(job_status, nzo_id, _mark_dead)
             return None, None
 
-        history_kwargs = {
-            "monitor": monitor,
-            "settings_getter": poll_ctx.settings_getter,
-            "modal_failures": poll_ctx.settings_getter is None,
-            "download_size": poll_ctx.download_size,
-        }
-        if poll_ctx.episode_context is not None:
-            history_kwargs["episode_context"] = poll_ctx.episode_context
-        elif poll_ctx.requested_episode is not None:
-            history_kwargs["requested_episode"] = poll_ctx.requested_episode
+        history_kwargs = _poll_history_kwargs(poll_ctx, monitor)
         should_stop, stream_url, stream_headers, no_video_retries = (
             _resolver._handle_history_result(
                 history, title, no_video_retries, max_no_video_retries, **history_kwargs
@@ -263,17 +283,17 @@ def _poll_until_ready(
             _mark_dead_on_failed_history(history, nzo_id, _mark_dead)
             return None, None
 
-        if _poll_observation_unavailable(job_status, history, webdav_error):
-            if observation_error_started is None:
-                observation_error_started = elapsed
-            if (
-                elapsed - observation_error_started
-                >= _resolver._POLL_OBSERVABILITY_TIMEOUT_SECONDS
-            ):
-                _surface_poll_observation_timeout(nzo_id, poll_ctx.settings_getter)
-                return None, None
-        else:
-            observation_error_started = None
+        observation_error_started, observation_timed_out = _advance_observation_outage(
+            observation_error_started,
+            elapsed,
+            job_status,
+            history,
+            webdav_error,
+            nzo_id,
+            poll_ctx.settings_getter,
+        )
+        if observation_timed_out:
+            return None, None
 
         if _resolver._handle_webdav_error(nzo_id, webdav_error):
             # Deliberately NOT calling cancel_job here. The WebDAV auth

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_resume.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_resume.py
@@ -165,7 +165,7 @@ def _set_playback_monitor_properties(
 
 
 def _resolve_direct_no_proxy(
-    handle, stream_url, stream_headers, monitor_key, resume_seconds
+    handle, stream_url, stream_headers, monitor_key, resume_seconds, params=None
 ):
     """Resolve a direct (no service-proxy) stream and start handle playback."""
     bust_url = _resolver._cache_bust_url(stream_url)
@@ -185,7 +185,9 @@ def _resolve_direct_no_proxy(
     _resolver.xbmcplugin.setResolvedUrl(handle, True, li)
 
 
-def _finish_direct_playback(handle, prepared, resume_key="", resume_seconds=0.0):
+def _finish_direct_playback(
+    handle, prepared, resume_key="", resume_seconds=0.0, params=None
+):
     """Finish resolver playback on the Kodi thread.
 
     ``resume_seconds`` is the already-chosen offset (the resume lookup/prompt
@@ -223,6 +225,7 @@ def _finish_direct_playback(handle, prepared, resume_key="", resume_seconds=0.0)
             )
             bust_url = _resolver._cache_bust_url(stream_url)
             li = _resolver._make_playable_listitem(bust_url, stream_headers)
+            _resolver._apply_playback_identity(li, params)
             _apply_resume_start_offset(li, resume_seconds)
             play_url = _resolver._build_play_url(bust_url, stream_headers)
             _set_playback_monitor_properties(
@@ -234,6 +237,7 @@ def _finish_direct_playback(handle, prepared, resume_key="", resume_seconds=0.0)
         li = _resolver.xbmcgui.ListItem(path=proxy_url)
         li.setContentLookup(False)
         _resolver._apply_proxy_mime(li, stream_url, stream_info)
+        _resolver._apply_playback_identity(li, params)
         _apply_resume_start_offset(li, resume_seconds)
 
         _set_playback_monitor_properties(
@@ -243,11 +247,11 @@ def _finish_direct_playback(handle, prepared, resume_key="", resume_seconds=0.0)
         return
 
     _resolve_direct_no_proxy(
-        handle, stream_url, stream_headers, monitor_key, resume_seconds
+        handle, stream_url, stream_headers, monitor_key, resume_seconds, params
     )
 
 
-def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
+def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0, params=None):
     """Finish service-side playback on the Kodi thread.
 
     ``resume_seconds`` is the already-chosen offset (the resume lookup/prompt
@@ -276,6 +280,7 @@ def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
             )
             bust_url = _resolver._cache_bust_url(stream_url)
             li = _resolver._make_playable_listitem(bust_url, stream_headers)
+            _resolver._apply_playback_identity(li, params)
             _apply_resume_start_offset(li, resume_seconds)
             play_url = _resolver._build_play_url(bust_url, stream_headers)
             _set_playback_monitor_properties(
@@ -287,6 +292,7 @@ def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
         li = _resolver.xbmcgui.ListItem(path=proxy_url)
         li.setContentLookup(False)
         _resolver._apply_proxy_mime(li, stream_url, stream_info)
+        _resolver._apply_playback_identity(li, params)
         _apply_resume_start_offset(li, resume_seconds)
         _set_playback_monitor_properties(
             home, proxy_url, stream_url, monitor_key, resume_seconds
@@ -297,6 +303,8 @@ def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
 
     bust_url = _resolver._cache_bust_url(stream_url)
     li = _resolver._make_playable_listitem(bust_url, stream_headers)
+    _resolver._apply_playback_identity(li, params)
+    _resolver._apply_playback_identity(li, params)
     _apply_resume_start_offset(li, resume_seconds)
     play_url = _resolver._build_play_url(bust_url, stream_headers)
     _resolver.xbmc.log(

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_retry.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_retry.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+# pylint: disable=cyclic-import
+
+"""Sequential distinct-release retry orchestration."""
+
+import resources.lib.resolver as _resolver
+
+
+def _retry_attempts(nzb_url, title, candidates):
+    attempts = [{"link": nzb_url, "title": title, "primary": True}]
+    for candidate in candidates or []:
+        if not isinstance(candidate, dict):
+            continue
+        link = candidate.get("link")
+        candidate_title = candidate.get("title")
+        if link and candidate_title:
+            attempt = dict(candidate)
+            attempt["link"] = link
+            attempt["title"] = candidate_title
+            attempt["primary"] = False
+            attempts.append(attempt)
+    return attempts
+
+
+def _poll_with_release_retries(
+    nzb_url,
+    title,
+    retry_candidates,
+    dialog,
+    poll_interval,
+    download_timeout,
+    poll_ctx,
+):
+    """Try a new release only after the preceding release is provably dead."""
+    attempts = _retry_attempts(nzb_url, title, retry_candidates)
+    for index, attempt in enumerate(attempts):
+        if index:
+            _resolver.xbmc.log(
+                "NZB-DAV: Trying distinct release fallback {}/{}: '{}'".format(
+                    index, len(attempts) - 1, attempt["title"]
+                ),
+                _resolver.xbmc.LOGINFO,
+            )
+            _resolver._safe_dialog_update(
+                dialog,
+                0,
+                "Previous release was unavailable. Trying another posting...",
+            )
+        attempt_ctx = poll_ctx
+        if index:
+            attempt_ctx = poll_ctx._replace(
+                completed_job_hint=None,
+                completed_job_lookup_done=False,
+                selected_indexer=attempt.get("indexer", ""),
+                download_pubdate=attempt.get("pubdate"),
+                download_size=attempt.get("size"),
+            )
+        stream = _resolver._poll_until_ready(
+            attempt["link"],
+            attempt["title"],
+            dialog,
+            poll_interval,
+            download_timeout,
+            poll_ctx=attempt_ctx,
+        )
+        if stream[0]:
+            return stream
+        dead = attempt_ctx.dead
+        if dead is None or not dead.has_url(attempt["link"]):
+            break
+    return None, None

--- a/repo/plugin.video.nzbdav/resources/lib/router_play.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_play.py
@@ -477,6 +477,17 @@ def _release_retry_key(result):
     return " ".join(title.split())
 
 
+def _release_retry_identity(candidate):
+    """Return the usable link/release identity for a retry row."""
+    if not isinstance(candidate, dict):
+        return None
+    link = str(candidate.get("link", "") or "")
+    release_key = _release_retry_key(candidate)
+    if not link or not release_key:
+        return None
+    return link, release_key
+
+
 def _attach_retry_candidates(resolver_params, selected, results, max_candidates=5):
     """Attach distinct retry releases from the already-filtered picker pool."""
     selected_link = str(selected.get("link", "") or "")
@@ -484,16 +495,11 @@ def _attach_retry_candidates(resolver_params, selected, results, max_candidates=
     seen_releases = {_release_retry_key(selected)}
     retries = []
     for candidate in results or []:
-        if candidate is selected or not isinstance(candidate, dict):
+        identity = _release_retry_identity(candidate)
+        if candidate is selected or identity is None:
             continue
-        link = str(candidate.get("link", "") or "")
-        release_key = _release_retry_key(candidate)
-        if (
-            not link
-            or link in seen_links
-            or not release_key
-            or release_key in seen_releases
-        ):
+        link, release_key = identity
+        if link in seen_links or release_key in seen_releases:
             continue
         seen_links.add(link)
         seen_releases.add(release_key)

--- a/repo/plugin.video.nzbdav/resources/lib/router_play.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_play.py
@@ -328,10 +328,11 @@ def _available_filtered_rows(filtered, all_parsed, title, notify, pack_result):
     return [] if pack_result is not None else None
 
 
-def _prepare_picker_rows(results, title, notify, pack_result):
+def _prepare_picker_rows(results, title, notify, pack_result, identity=None):
     """Filter provider rows and prepend one exact local-pack row."""
-    from resources.lib.filter import filter_results
+    from resources.lib.filter import filter_requested_content, filter_results
 
+    results = filter_requested_content(results, identity) if identity else results
     filtered, all_parsed = filter_results(results)
     filtered = _available_filtered_rows(
         filtered, all_parsed, title, notify, pack_result
@@ -362,7 +363,9 @@ def _handle_play_filter_and_select(
         xbmc.LOGDEBUG,
     )
 
-    prepared = _prepare_picker_rows(results, title, notify, pack_result)
+    prepared = _prepare_picker_rows(
+        results, title, notify, pack_result, identity=identity
+    )
     if prepared is None:
         xbmcplugin.setResolvedUrl(handle, False, xbmcgui.ListItem())
         return
@@ -435,6 +438,7 @@ def _handle_play_auto_select(handle, best, filtered, identity=None):
         "_fallback_candidates": [],
         "_fallback_candidate_loader": _selection_fallback_loader(target, provider_rows),
     }
+    _attach_retry_candidates(resolver_params, target, provider_rows)
     _attach_episode_context(resolver_params, identity or {})
     _attach_nzbget_dupe(resolver_params, target, provider_rows, identity)
     _ensure_nzbget_completed_hint(target)
@@ -463,6 +467,43 @@ def _identity_from_params(params):
 def _normalize_release_name(title):
     """Case/whitespace-normalized release name for same-name matching (#372)."""
     return " ".join(str(title or "").split()).casefold()
+
+
+def _release_retry_key(result):
+    """Collapse cosmetic duplicate listings of one release."""
+    title = str((result or {}).get("title", "") or "").lower()
+    title = re.sub(r"\s*\[fallback-\d+-[0-9a-f]+\]\s*$", "", title)
+    title = re.sub(r"[\W_]+", " ", title)
+    return " ".join(title.split())
+
+
+def _attach_retry_candidates(resolver_params, selected, results, max_candidates=5):
+    """Attach distinct retry releases from the already-filtered picker pool."""
+    selected_link = str(selected.get("link", "") or "")
+    seen_links = {selected_link}
+    seen_releases = {_release_retry_key(selected)}
+    retries = []
+    for candidate in results or []:
+        if candidate is selected or not isinstance(candidate, dict):
+            continue
+        link = str(candidate.get("link", "") or "")
+        release_key = _release_retry_key(candidate)
+        if (
+            not link
+            or link in seen_links
+            or not release_key
+            or release_key in seen_releases
+        ):
+            continue
+        seen_links.add(link)
+        seen_releases.add(release_key)
+        retries.append(candidate)
+        if len(retries) >= max_candidates:
+            break
+    if retries:
+        resolver_params["_retry_candidates"] = retries
+    else:
+        resolver_params.pop("_retry_candidates", None)
 
 
 _IMDB_DIGITS_RE = re.compile(r"(\d+)")
@@ -777,6 +818,7 @@ def _handle_play_resolve_selection(
         "_fallback_candidates": [],
         "_fallback_candidate_loader": _selection_fallback_loader(target, provider_rows),
     }
+    _attach_retry_candidates(resolver_params, target, provider_rows)
     _attach_episode_context(resolver_params, identity or {})
     _attach_nzbget_dupe(resolver_params, target, provider_rows, identity)
     _apply_completed_job_hint(resolver_params, target, completed_jobs)
@@ -802,7 +844,10 @@ def _handle_search_filter_and_select(
         ),
         xbmc.LOGDEBUG,
     )
-    prepared = _prepare_picker_rows(results, title, notify, pack_result)
+    identity = _identity_from_params(params)
+    prepared = _prepare_picker_rows(
+        results, title, notify, pack_result, identity=identity
+    )
     if prepared is None:
         xbmcplugin.endOfDirectory(handle, succeeded=False)
         return
@@ -857,6 +902,7 @@ def _handle_search_auto_select(params, best, filtered):
     resolver_params["_fallback_candidate_loader"] = _selection_fallback_loader(
         target, provider_rows
     )
+    _attach_retry_candidates(resolver_params, target, provider_rows)
     _attach_nzbget_dupe(
         resolver_params, target, provider_rows, _identity_from_params(params)
     )
@@ -878,6 +924,7 @@ def _handle_search_resolve_selection(params, selected, filtered, completed_jobs)
     resolver_params["_fallback_candidate_loader"] = _selection_fallback_loader(
         target, provider_rows
     )
+    _attach_retry_candidates(resolver_params, target, provider_rows)
     _attach_nzbget_dupe(
         resolver_params, target, provider_rows, _identity_from_params(params)
     )

--- a/repo/plugin.video.nzbdav/resources/lib/router_play.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_play.py
@@ -488,6 +488,22 @@ def _release_retry_identity(candidate):
     return link, release_key
 
 
+def _append_unique_retry(retries, candidate, selected, seen_links, seen_releases):
+    """Append one usable, distinct retry row and return whether it was added."""
+    if candidate is selected:
+        return False
+    identity = _release_retry_identity(candidate)
+    if identity is None:
+        return False
+    link, release_key = identity
+    if link in seen_links or release_key in seen_releases:
+        return False
+    seen_links.add(link)
+    seen_releases.add(release_key)
+    retries.append(candidate)
+    return True
+
+
 def _attach_retry_candidates(resolver_params, selected, results, max_candidates=5):
     """Attach distinct retry releases from the already-filtered picker pool."""
     selected_link = str(selected.get("link", "") or "")
@@ -495,16 +511,10 @@ def _attach_retry_candidates(resolver_params, selected, results, max_candidates=
     seen_releases = {_release_retry_key(selected)}
     retries = []
     for candidate in results or []:
-        identity = _release_retry_identity(candidate)
-        if candidate is selected or identity is None:
-            continue
-        link, release_key = identity
-        if link in seen_links or release_key in seen_releases:
-            continue
-        seen_links.add(link)
-        seen_releases.add(release_key)
-        retries.append(candidate)
-        if len(retries) >= max_candidates:
+        added = _append_unique_retry(
+            retries, candidate, selected, seen_links, seen_releases
+        )
+        if added and len(retries) >= max_candidates:
             break
     if retries:
         resolver_params["_retry_candidates"] = retries

--- a/repo/plugin.video.nzbdav/resources/players/nzbdav.json
+++ b/repo/plugin.video.nzbdav/resources/players/nzbdav.json
@@ -3,7 +3,7 @@
     "plugin": "plugin.video.nzbdav",
     "priority": 100,
     "is_resolvable": "false",
-    "schema_version": 6,
+    "schema_version": 8,
     "play_movie": "executebuiltin://RunScript(special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,type=movie,title={title_url},year={year},imdb={imdb},tmdb_id={tmdb_id})",
-    "play_episode": "executebuiltin://RunScript(special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,type=episode,title={showname_url},year={showyear},season={season},episode={episode},imdb={imdb},tmdb_id={tmdb_id},ep_season={ep_showseason},ep_episode={ep_showepisode})"
+    "play_episode": "executebuiltin://RunScript(special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,type=episode,title={showname_url},year={showyear},season={season},episode={episode},imdb={imdb},tmdb_id={tmdb},show_tmdb_id={tmdb},episode_tmdb_id={eptmdb},tvdb={tvdb},ep_season={ep_showseason},ep_episode={ep_showepisode})"
 }

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from resources.lib.filter import (
     _has_filter_metadata_shape,
     _sort_results,
+    filter_requested_content,
     filter_results,
     matches_filters,
     parse_title_metadata,
@@ -32,6 +33,40 @@ def _make_result(title, size="5000000000", pubdate="", link="http://example.com/
         "pubdate": pubdate,
         "age": "1 day",
     }
+
+
+def test_strict_identity_filter_rejects_wrong_title_episode_and_extras():
+    identity = {
+        "type": "episode",
+        "title": "The Good the Bad and the Ugly",
+        "year": "2025",
+        "season": "1",
+        "episode": "3",
+    }
+    wanted = _make_result(
+        "The.Good.the.Bad.and.the.Ugly.2025.S01E03.1080p.WEB-DL-GROUP"
+    )
+    rows = [
+        wanted,
+        _make_result(
+            "The.Rookie.S01E03.The.Good.the.Bad.and.the.Ugly.1080p.WEB-DL-GROUP"
+        ),
+        _make_result("The.Good.the.Bad.and.the.Ugly.2025.S01E04.1080p.WEB-DL-GROUP"),
+        _make_result("The.Good.the.Bad.and.the.Ugly.2025.S01E03.Behind.the.Scenes"),
+    ]
+    assert filter_requested_content(rows, identity) == [wanted]
+
+
+def test_strict_identity_filter_rejects_episode_and_wrong_year_for_movie():
+    identity = {"type": "movie", "title": "Interstellar", "year": "2014"}
+    wanted = _make_result("Interstellar.2014.1080p.BluRay-GROUP")
+    rows = [
+        wanted,
+        _make_result("Doctor.Who.S01E02.The.Interstellar.Song.Contest.1080p"),
+        _make_result("Interstellar.2025.1080p.WEB-DL-GROUP"),
+        _make_result("Another.Movie.2014.1080p.WEB-DL-GROUP"),
+    ]
+    assert filter_requested_content(rows, identity) == [wanted]
 
 
 def test_filter_uses_module_scope_kodi_imports():

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -317,6 +317,21 @@ def test_redact_text_hides_getnzb_path_credentials():
     assert "&r=REDACTED" in result
 
 
+def test_redact_text_scopes_getnzb_path_credentials_to_url():
+    """Short Newznab credential names must not redact unrelated message data."""
+    msg = (
+        "fetch failed for "
+        "https://indexer.example/getnzb/id.nzb&i=12345&r=secretkey123 "
+        "while callback metadata remained &i=keep&r=visible"
+    )
+    result = redact_text(msg)
+
+    assert "12345" not in result
+    assert "secretkey123" not in result
+    assert "&i=REDACTED&r=REDACTED" in result
+    assert "metadata remained &i=keep&r=visible" in result
+
+
 def test_redact_text_redacts_digit_prefixed_values():
     """The ``\\1=REDACTED`` backreference must not misfire when the secret value
     begins with a digit — the literal ``=`` terminates the group, so there is no

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -229,6 +229,24 @@ def test_redact_url_preserves_url_without_apikey():
     assert result == url
 
 
+def test_redact_url_hides_getnzb_path_credentials():
+    """Newznab links may put account/API credentials in the path."""
+    url = "https://indexer.example/getnzb/id.nzb&i=12345&r=secretkey123"
+    result = redact_url(url)
+
+    assert "12345" not in result
+    assert "secretkey123" not in result
+    assert "&i=REDACTED" in result
+    assert "&r=REDACTED" in result
+
+
+def test_redact_url_preserves_short_params_outside_getnzb_paths():
+    """Short i/r parameters are not credentials in arbitrary URLs."""
+    url = "https://example.com/report&i=12345&r=summary"
+
+    assert redact_url(url) == url
+
+
 def test_redact_url_hides_extended_credential_keys():
     """TODO.md §H.2-H2c: the redaction set covers more than just apikey.
     `key`, `access_token`, `bearer`, `session`, `sessionid`, `password`,
@@ -283,6 +301,20 @@ def test_redact_text_redacts_multiple_credential_params():
     # Non-credential params are untouched.
     assert "imdbid=tt1" in result
     assert "t=movie" in result
+
+
+def test_redact_text_hides_getnzb_path_credentials():
+    """Free-form HTTP errors must scrub non-standard Newznab path secrets."""
+    msg = (
+        "fetch failed for "
+        "https://indexer.example/getnzb/id.nzb&i=12345&r=secretkey123"
+    )
+    result = redact_text(msg)
+
+    assert "12345" not in result
+    assert "secretkey123" not in result
+    assert "&i=REDACTED" in result
+    assert "&r=REDACTED" in result
 
 
 def test_redact_text_redacts_digit_prefixed_values():

--- a/tests/test_player_installer.py
+++ b/tests/test_player_installer.py
@@ -132,7 +132,9 @@ def test_player_json_uses_script_handoff_instead_of_plugin_media_url():
     assert "plugin.video.nzbdav" in PLAYER_JSON["play_episode"]
     assert "type=episode" in PLAYER_JSON["play_episode"]
     assert "title={showname_url}" in PLAYER_JSON["play_episode"]
-    assert "tmdb_id={tmdb_id}" in PLAYER_JSON["play_episode"]
+    assert "tmdb_id={tmdb}" in PLAYER_JSON["play_episode"]
+    assert "show_tmdb_id={tmdb}" in PLAYER_JSON["play_episode"]
+    assert "episode_tmdb_id={eptmdb}" in PLAYER_JSON["play_episode"]
     roundtripped = json.loads(json.dumps(PLAYER_JSON))
     assert roundtripped["name"] == PLAYER_JSON["name"]
 
@@ -153,6 +155,14 @@ def test_player_schema_version_bumped_for_tvdb_token():
 
     assert _PLAYER_SCHEMA_VERSION >= 7
     assert PLAYER_JSON["schema_version"] == _PLAYER_SCHEMA_VERSION
+
+
+def test_episode_player_distinguishes_show_and_episode_tmdb_ids():
+    action = PLAYER_JSON["play_episode"]
+    assert "show_tmdb_id={tmdb}" in action
+    assert "episode_tmdb_id={eptmdb}" in action
+    assert "tmdb_id={tmdb_id}" not in action
+    assert PLAYER_JSON["schema_version"] >= 8
 
 
 @patch("resources.lib.player_installer.xbmcaddon")

--- a/tests/test_poll_observability.py
+++ b/tests/test_poll_observability.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+from resources.lib.resolver import (
+    _POLL_CONTINUE,
+    PollContext,
+    _poll_observation_unavailable,
+    _poll_until_ready,
+)
+
+
+def _run_unobservable_poll(settings_getter=None):
+    dialog = MagicMock()
+    monitor = MagicMock()
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "resources.lib.resolver._existing_completed_stream",
+                return_value=None,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "resources.lib.resolver_pollloop._submit_and_announce",
+                return_value="job-1",
+            )
+        )
+        stack.enter_context(
+            patch("resources.lib.resolver.xbmc.Monitor", return_value=monitor)
+        )
+        stack.enter_context(
+            patch("resources.lib.resolver.time.time", return_value=1000)
+        )
+        stack.enter_context(
+            patch("resources.lib.resolver.time.monotonic", side_effect=[0, 0])
+        )
+        stack.enter_context(
+            patch("resources.lib.resolver._POLL_OBSERVABILITY_TIMEOUT_SECONDS", 0)
+        )
+        stack.enter_context(
+            patch("resources.lib.resolver._abort_poll_before_fetch", return_value=False)
+        )
+        stack.enter_context(
+            patch(
+                "resources.lib.resolver._poll_once",
+                return_value=(None, None, "server_error"),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "resources.lib.resolver_pollloop._poll_observation_unavailable",
+                return_value=True,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "resources.lib.resolver._handle_job_status",
+                return_value=(False, "Queued"),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "resources.lib.resolver._handle_history_result",
+                return_value=(False, None, None, 0),
+            )
+        )
+        stack.enter_context(
+            patch("resources.lib.resolver._handle_webdav_error", return_value=False)
+        )
+        stack.enter_context(
+            patch(
+                "resources.lib.resolver._poll_wait_after_status",
+                return_value=(1, 0),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "resources.lib.resolver_pollloop._wait_between_polls",
+                return_value=_POLL_CONTINUE,
+            )
+        )
+        notify = stack.enter_context(patch("resources.lib.resolver._notify"))
+        dialog_factory = stack.enter_context(
+            patch("resources.lib.resolver.xbmcgui.Dialog")
+        )
+        cancel_job = stack.enter_context(patch("resources.lib.resolver.cancel_job"))
+        result = _poll_until_ready(
+            "https://indexer.invalid/release",
+            "Release",
+            dialog,
+            1,
+            3600,
+            poll_ctx=PollContext(settings_getter=settings_getter),
+        )
+    return result, notify, dialog_factory, cancel_job
+
+
+def test_poll_observation_classifier_requires_total_backend_failure():
+    assert _poll_observation_unavailable(None, None, "server_error")
+    assert _poll_observation_unavailable(None, None, "connection_error")
+    assert not _poll_observation_unavailable({"status": "Queued"}, None, "server_error")
+    assert not _poll_observation_unavailable(None, {"status": "Failed"}, "server_error")
+    assert not _poll_observation_unavailable(None, None, None)
+
+
+def test_stuck_queued_backend_errors_stop_and_surface_final_notification():
+    result, notify, dialog_factory, cancel_job = _run_unobservable_poll(
+        settings_getter=MagicMock()
+    )
+    assert result == (None, None)
+    notify.assert_called_once()
+    dialog_factory.assert_not_called()
+    cancel_job.assert_not_called()
+
+
+def test_stuck_queued_handle_path_surfaces_final_modal_without_remote_cancel():
+    result, notify, dialog_factory, cancel_job = _run_unobservable_poll()
+    assert result == (None, None)
+    notify.assert_not_called()
+    dialog_factory.return_value.ok.assert_called_once()
+    cancel_job.assert_not_called()

--- a/tests/test_release_retry.py
+++ b/tests/test_release_retry.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+from unittest.mock import MagicMock, patch
+
+from resources.lib.dead_candidates import DeadCandidates
+from resources.lib.resolver import PollContext, _poll_with_release_retries
+from resources.lib.router_play import _attach_retry_candidates
+
+
+def _row(title, link, **extra):
+    row = {"title": title, "link": link}
+    row.update(extra)
+    return row
+
+
+def test_retry_candidates_are_distinct_and_capped():
+    selected = _row("Movie.2026.1080p-GROUP", "https://indexer/primary")
+    duplicate = _row(
+        "Movie 2026 1080p GROUP [fallback-2-deadbeef]",
+        "https://indexer/duplicate",
+    )
+    distinct = [
+        _row(
+            "Movie.2026.{}p-GROUP{}".format(720 + index, index),
+            "https://i/{}".format(index),
+        )
+        for index in range(7)
+    ]
+    params = {}
+    _attach_retry_candidates(params, selected, [selected, duplicate] + distinct)
+    assert params["_retry_candidates"] == distinct[:5]
+
+
+def test_release_retry_runs_only_after_provably_dead_attempt():
+    dead = DeadCandidates()
+    context = PollContext(dead=dead)
+    dialog = MagicMock()
+
+    def poll(url, _title, _dialog, _interval, _timeout, poll_ctx=None):
+        if url.endswith("primary"):
+            poll_ctx.dead.add(nzb_url=url)
+            return None, None
+        return "https://webdav/movie.mkv", {"Authorization": "Basic x"}
+
+    with patch("resources.lib.resolver._poll_until_ready", side_effect=poll) as mocked:
+        result = _poll_with_release_retries(
+            "https://indexer/primary",
+            "Movie.2026.1080p-GROUP",
+            [_row("Movie.2026.2160p-GROUP", "https://indexer/retry")],
+            dialog,
+            2,
+            600,
+            context,
+        )
+
+    assert result[0] == "https://webdav/movie.mkv"
+    assert [item.args[0] for item in mocked.call_args_list] == [
+        "https://indexer/primary",
+        "https://indexer/retry",
+    ]
+
+
+def test_release_retry_stops_after_nonterminal_failure():
+    context = PollContext(dead=DeadCandidates())
+    dialog = MagicMock()
+    with patch(
+        "resources.lib.resolver._poll_until_ready", return_value=(None, None)
+    ) as mocked:
+        result = _poll_with_release_retries(
+            "https://indexer/primary",
+            "Movie.2026.1080p-GROUP",
+            [_row("Movie.2026.2160p-GROUP", "https://indexer/retry")],
+            dialog,
+            2,
+            600,
+            context,
+        )
+    assert result == (None, None)
+    assert mocked.call_count == 1

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2647,7 +2647,11 @@ def test_resolve_starts_fallback_worker_after_primary_submit_and_uses_snapshot(
         legacy_key="http://webdav/content/primary/movie.mp4",
     )
     mock_finish_playback.assert_called_once_with(
-        1, prepared_playback, resume_key="rel-id", resume_seconds=321.0
+        1,
+        prepared_playback,
+        resume_key="rel-id",
+        resume_seconds=321.0,
+        params=ANY,
     )
     mock_stop_fallback.assert_not_called()
 
@@ -2729,7 +2733,7 @@ def test_resolve_attaches_fallback_handoff_for_mkv_streams(
     )
     mock_wait_prepare.assert_called_once_with({"state": "prepare"})
     mock_finish_playback.assert_called_once_with(
-        1, {"state": "prepared"}, resume_key="", resume_seconds=0.0
+        1, {"state": "prepared"}, resume_key="", resume_seconds=0.0, params=ANY
     )
 
 
@@ -2787,7 +2791,7 @@ def test_resolve_routes_plain_mkv_through_proxy_without_fallbacks(
     )
     mock_wait_prepare.assert_called_once_with({"state": "prepare"})
     mock_finish_playback.assert_called_once_with(
-        1, {"state": "prepared"}, resume_key="", resume_seconds=0.0
+        1, {"state": "prepared"}, resume_key="", resume_seconds=0.0, params=ANY
     )
 
 
@@ -3267,7 +3271,7 @@ def test_resolve_keeps_service_config_lookup_on_resolver_thread(
     )
     mock_wait_prepare.assert_called_once_with({"state": "prepare"})
     mock_finish_playback.assert_called_once_with(
-        1, {"state": "prepared"}, resume_key="", resume_seconds=0.0
+        1, {"state": "prepared"}, resume_key="", resume_seconds=0.0, params=ANY
     )
     mock_clear_state.assert_called_once()
 
@@ -3541,7 +3545,7 @@ def test_resolve_and_play_does_not_wait_forever_for_stuck_bookmark_cleanup(
     mock_start_prepare.assert_called_once()
     mock_wait_prepare.assert_called_once_with({"state": "prepare"})
     mock_finish_playback.assert_called_once_with(
-        {"state": "prepared"}, resume_key="", resume_seconds=0.0
+        {"state": "prepared"}, resume_key="", resume_seconds=0.0, params=ANY
     )
     cleanup_can_finish.set()
 
@@ -3607,7 +3611,10 @@ def test_resolve_and_play_routes_plain_mkv_through_proxy_without_fallbacks(
         legacy_key="http://webdav/content/primary/movie.mkv",
     )
     mock_finish_playback.assert_called_once_with(
-        {"state": "prepared"}, resume_key="rel-id", resume_seconds=456.0
+        {"state": "prepared"},
+        resume_key="rel-id",
+        resume_seconds=456.0,
+        params=ANY,
     )
 
 
@@ -3683,7 +3690,7 @@ def test_resolve_and_play_attaches_fallback_handoff_for_mkv_streams(
     )
     mock_wait_prepare.assert_called_once_with({"state": "prepare"})
     mock_finish_playback.assert_called_once_with(
-        {"state": "prepared"}, resume_key="", resume_seconds=0.0
+        {"state": "prepared"}, resume_key="", resume_seconds=0.0, params=ANY
     )
 
 

--- a/tests/test_resolver_metadata.py
+++ b/tests/test_resolver_metadata.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+import json
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
+
+from resources.lib.resolver import (
+    _apply_playback_identity,
+    _tmdb_helper_metadata,
+)
+
+HOD_S02E01 = {
+    "type": "episode",
+    "title": "House of the Dragon",
+    "year": "2022",
+    "season": "2",
+    "episode": "1",
+    "imdb": "tt11198330",
+    "tmdb_id": "94997",
+    "show_tmdb_id": "94997",
+    "episode_tmdb_id": "10396624",
+}
+
+
+@patch("resources.lib.resolver.xbmc")
+def test_hod_episode_metadata_lookup_uses_show_tmdb_id(mock_xbmc):
+    mock_xbmc.executeJSONRPC.return_value = json.dumps({"result": {"files": []}})
+
+    assert _tmdb_helper_metadata(HOD_S02E01) == {}
+
+    request = json.loads(mock_xbmc.executeJSONRPC.call_args[0][0])
+    directory = request["params"]["directory"]
+    query = parse_qs(urlsplit(directory).query)
+    assert query["tmdb_type"] == ["tv"]
+    assert query["tmdb_id"] == ["94997"]
+    assert query["season"] == ["2"]
+    assert query["episode"] == ["1"]
+    assert "10396624" not in directory
+
+
+@patch("resources.lib.resolver_metadata._tmdb_helper_metadata", return_value={})
+def test_hod_episode_fallback_preserves_complete_listitem_identity(_metadata):
+    listitem = MagicMock()
+
+    _apply_playback_identity(listitem, HOD_S02E01)
+
+    listitem.setInfo.assert_called_once_with(
+        "video",
+        {
+            "title": "House of the Dragon",
+            "tvshowtitle": "House of the Dragon",
+            "year": "2022",
+            "season": "2",
+            "episode": "1",
+            "mediatype": "episode",
+        },
+    )
+    listitem.setUniqueIDs.assert_called_once_with(
+        {
+            "tvshow.tmdb": "94997",
+            "tmdb": "10396624",
+            "tvshow.imdb": "tt11198330",
+        },
+        "tmdb",
+    )
+
+
+@patch("resources.lib.resolver_metadata._tmdb_helper_metadata")
+def test_hod_episode_identity_overrides_incomplete_rich_metadata(metadata):
+    metadata.return_value = {
+        "title": "A Son for a Son",
+        "showtitle": "House of the Dragon",
+        "season": 2,
+        "episode": 1,
+        "type": "episode",
+        "uniqueid": {"tmdb": "10396624"},
+    }
+    listitem = MagicMock()
+
+    _apply_playback_identity(listitem, HOD_S02E01)
+
+    info = listitem.setInfo.call_args[0][1]
+    assert info["title"] == "A Son for a Son"
+    assert info["tvshowtitle"] == "House of the Dragon"
+    assert info["season"] == 2
+    assert info["episode"] == 1
+    assert info["mediatype"] == "episode"
+    unique_ids = listitem.setUniqueIDs.call_args[0][0]
+    assert unique_ids["tvshow.tmdb"] == "94997"
+    assert unique_ids["tmdb"] == "10396624"


### PR DESCRIPTION
## Summary
- retain strict content identity filtering and sequential distinct-release retries from superseded draft #469
- stop local polling after 60 seconds when job status, history, and WebDAV are all unobservable
- surface a final connection error instead of leaving Kodi on the last-known `Queued` state
- deliberately avoid cancelling the remote job because it may still be active and complete
- redact nonstandard Newznab credentials embedded in GetNZB URL paths, scoped to URL spans

## Evidence
A real S02E01 request had one terminal missing-article failure followed by a second job whose status/history/WebDAV calls all returned HTTP 500. Kodi retained `Queued`; the remote second job later completed. The configured one-hour download timeout did not bound this observation outage, and cancellation also returned HTTP 500.

Service-log follow-up identified the shared HTTP 500 source as intermittent NZBDav SQLite Error 14 (`unable to open database file`) affecting its API and WebDAV layers. That service-storage issue is operationally separate from this add-on-side bounded failure handling.

## Codacy remediation
The original check reported six exact annotations: one ErrorProne observation-state comparison warning, four cyclomatic-complexity findings, and one method-length finding. The observation tracker now uses an explicit numeric sentinel and helper; new identity, retry-selection, and poll-state logic was decomposed below Codacy's thresholds without changing behavior.

## Validation
- focused identity/retry/observability tests: 71 passed
- complete local suite: 2,596 passed, 2 skipped, 3 environment/platform failures
  - two pre-existing Windows timing-baseline failures, reproducible on untouched upstream
  - one Windows environment failure because WSL has no default `/bin/bash`
- ruff and black: passed
- pylint: 10.00/10
- vermin: runtime floor remains Python 3.7
- credential redaction coverage includes direct URLs, free-form errors, and non-URL short-parameter preservation

This draft is the canonical review target and supersedes #469.