### PR TITLE
🎨 Palette: Add empty state message to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -62,6 +62,17 @@
       <texture>white.png</texture>
     </control>
 
+    <!-- Empty state label -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font14</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Results list — 2 lines per item, 66px each -->
     <control type="list" id="50">
       <left>0</left><top>60</top><width>1910</width><height>975</height>


### PR DESCRIPTION
**What:**
Added a centralized `<label>` outside the search results list (`id="50"`) in `results-dialog.xml`. The label displays "No results found" and is only visible when the list container is empty (`Integer.IsEqual(Container(50).NumItems,0)`).

**Why:**
Custom lists in Kodi XML skins do not automatically handle empty states. Previously, this resulted in a confusing blank screen when no items were present, leaving users unsure if a search was successful, loading, or had no results.

**Before/After:**
- **Before:** Blank list area when a search yields 0 results.
- **After:** Centered text "No results found" explicitly communicating the empty state.

**Accessibility:**
Provides clear, immediate textual feedback to users regarding the state of the interface, preventing confusion for all users and improving cognitive accessibility.

---
*PR created automatically by Jules for task [13545112119611976475](https://jules.google.com/task/13545112119611976475) started by @xbmc4lyfe*