### PR TITLE
fix: convert onPlayBackSeek times from milliseconds to seconds

### DIFF
--- a/repo/plugin.video.nzbdav/service.py
+++ b/repo/plugin.video.nzbdav/service.py
@@ -415,12 +415,19 @@ class NzbdavPlayer(xbmc.Player):
         ``_last_position`` via ``getTime()``. Without this callback the retry
         path falls back to the older saved position and appears to "jump
         backwards" after a failed seek.
+
+        Kodi passes ``time`` and ``seek_offset`` in **milliseconds**, while
+        every other position in this class (``getTime()``, ``_last_position``,
+        ``_save_position``, the ``StartOffset`` handed to a retry) is in
+        seconds. Converting here keeps a single unit throughout; without it a
+        seek stored a value 1000x too large and the retry then tried to resume
+        far past the end of the file, which failed instantly and looped.
         """
         with self._state_lock:
             if self._state not in (PlaybackState.MONITORING, PlaybackState.ERROR):
                 return
             try:
-                self._last_position = max(0.0, float(time))
+                self._last_position = max(0.0, float(time) / 1000.0)
             except (TypeError, ValueError):
                 pos_failed = True
             else:
@@ -434,7 +441,7 @@ class NzbdavPlayer(xbmc.Player):
             "NZB-DAV: Playback seek for '{}' -> {:.0f}s (offset={:.0f}s)".format(
                 title,
                 position,
-                float(seek_offset),
+                float(seek_offset) / 1000.0,
             ),
             xbmc.LOGINFO,
         )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -207,14 +207,32 @@ def test_on_playback_seek_updates_retry_resume_position():
     Real repro from CoreELEC: seeking ~30 minutes into a movie failed
     before the 1 Hz service tick refreshed ``_last_position``, so the
     auto-retry jumped back to an older saved point (~1 minute).
+
+    Kodi reports the seek target in milliseconds, so 30 minutes arrives as
+    1_800_000 and must be stored as 1800.0 seconds.
     """
     player = NzbdavPlayer()
     player._state = PlaybackState.MONITORING
     player._last_position = 60.0
 
-    player.onPlayBackSeek(1800, 1740)
+    player.onPlayBackSeek(1_800_000, 1_740_000)
 
     assert player._last_position == 1800.0
+
+
+def test_on_playback_seek_converts_milliseconds_to_seconds():
+    """Guard the unit boundary: ms in, seconds out.
+
+    Observed on Windows/Kodi 21: a seek to ~23 minutes of a 70 minute
+    episode arrived as 1379045 and was stored verbatim, so the retry path
+    tried to resume 1379045 seconds in — far past the end of the file.
+    """
+    player = NzbdavPlayer()
+    player._state = PlaybackState.MONITORING
+
+    player.onPlayBackSeek(1_379_045, 199_347)
+
+    assert player._last_position == pytest.approx(1379.045)
 
 
 @patch("service.xbmcgui")
@@ -230,7 +248,7 @@ def test_retry_playback_uses_latest_seek_position(mock_gui):
     player.play = MagicMock()
     player.isPlaying = MagicMock(return_value=True)
 
-    player.onPlayBackSeek(1800, 1740)
+    player.onPlayBackSeek(1_800_000, 1_740_000)
     ok = player._retry_playback(max_retries=3, retry_delay=0)
 
     assert ok is True


### PR DESCRIPTION
## Problem

`onPlayBackSeek(time, seek_offset)` receives **milliseconds** from Kodi, but
`NzbdavPlayer` stored `time` verbatim into `_last_position`, which every other
position in the class treats as seconds (`getTime()`, `_save_position()`, and
the `StartOffset` handed to `_retry_playback`).

## Evidence

Observed on Windows / Kodi 21 with a 70 minute episode (4238 s). Seeking to
~23 minutes logged:

```
NZB-DAV: Playback seek for '...' -> 1379045s (offset=199347s)
```

`1379045` is impossible as seconds for a 4238 s file; as milliseconds it is
exactly 22:59, where the seek actually landed. The retry ladder then attempted
to resume 1379045 seconds in, failed immediately, and re-entered retries — which
surfaced as a burst of `client_disconnected` reconnects during ordinary seeking.

After the conversion the same seeks log sane, monotonic values: `822s`, `1049s`,
`1226s`, `1404s`.

## Tests

Two existing tests asserted the pre-conversion behaviour (`1800` in → `1800.0`
stored), so they encoded the wrong unit; they now pass the value Kodi actually
sends. A focused regression test pins the unit boundary using the observed
value.

Full suite: 2586 passed, 2 failed, 2 skipped. Both failures are pre-existing
timing assertions in `test_resolver.py`
(`completed hint path stalled for 2.68s, assert < 0.5`) that reproduce on a
clean checkout and are unrelated to this change. `ruff` and `black` clean.