### PR TITLE
feat: publish playback identity for TMDb Helper's Trakt scrobbler

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/player_installer.py
+++ b/repo/plugin.video.nzbdav/resources/lib/player_installer.py
@@ -32,8 +32,14 @@ TMDBHELPER_PLAYER_PATH = _player_path_for(TMDBHELPER_ADDON_ID)
 # Bump this when PLAYER_JSON's shape changes in a way that requires the
 # installer to overwrite an older generation. We ignore the user's manual
 # edits only when the stored schema_version differs from ours.
-_PLAYER_SCHEMA_VERSION = 7
+_PLAYER_SCHEMA_VERSION = 8
 
+# TMDb Helper substitutes these actions against a ``defaultdict(lambda: '_')``,
+# so an unrecognised token is silently replaced with a literal underscore rather
+# than failing. ``{tmdb_id}`` is *not* one of its tokens (see its
+# ``set_detailed_item``): the TMDB id is ``{tmdb}``, which in episode context is
+# deliberately the *show* id, while ``{eptmdb}`` is the episode's own id. The
+# identity tokens below are what lets playback be scrobbled to Trakt.
 PLAYER_JSON = {
     "name": "NZB-DAV",
     "plugin": "plugin.video.nzbdav",
@@ -43,13 +49,14 @@ PLAYER_JSON = {
     "play_movie": (
         "executebuiltin://RunScript("
         "special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,"
-        "type=movie,title={title_url},year={year},imdb={imdb},tmdb_id={tmdb_id})"
+        "type=movie,title={title_url},year={year},imdb={imdb},tmdb_id={tmdb})"
     ),
     "play_episode": (
         "executebuiltin://RunScript("
         "special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,"
         "type=episode,title={showname_url},year={showyear},season={season},"
-        "episode={episode},imdb={imdb},tmdb_id={tmdb_id},tvdb={tvdb},"
+        "episode={episode},imdb={imdb},tmdb_id={tmdb},show_tmdb_id={tmdb},"
+        "episode_tmdb_id={eptmdb},tvdb={tvdb},"
         "ep_season={ep_showseason},ep_episode={ep_showepisode})"
     ),
 }

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
@@ -14,6 +14,7 @@ moved name is re-exported from ``resolver``.
 """
 
 import resources.lib.resolver as _resolver  # noqa: F401  pylint: disable=unused-import
+from resources.lib import tmdbhelper_scrobble
 
 
 def _nzbget_enabled(settings_getter=None):
@@ -331,6 +332,9 @@ def _resolve_play_ready_stream(
         _reject_resolve_handle(handle)
         return dialog
     _resolver._arm_live_fallback_push(prepared, fallback_state, stream_url, dead=dead)
+    # See the note in the script-play path above: identity goes out before the
+    # handoff so the scrobbler sees it when playback starts.
+    tmdbhelper_scrobble.publish_player_info(params)
     _resolver._finish_direct_playback(
         handle, prepared, resume_key=release_id, resume_seconds=chosen
     )
@@ -501,6 +505,9 @@ def _resolve_and_play_ready_stream(
         _resolver._stop_fallback_submit_worker(fallback_state, cancel_submitted=True)
         return dialog
     _resolver._arm_live_fallback_push(prepared, fallback_state, stream_url, dead=dead)
+    # Publish the TMDB identity before handing off so TMDb Helper's scrobbler
+    # can attribute this playback to Trakt; the stream URL itself carries none.
+    tmdbhelper_scrobble.publish_player_info(resume_params)
     _resolver._finish_player_playback(
         prepared, resume_key=release_id, resume_seconds=chosen
     )

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_flow.py
@@ -14,6 +14,7 @@ moved name is re-exported from ``resolver``.
 """
 
 import resources.lib.resolver as _resolver  # noqa: F401  pylint: disable=unused-import
+from resources.lib import tmdbhelper_metadata
 from resources.lib import tmdbhelper_scrobble
 
 
@@ -335,6 +336,7 @@ def _resolve_play_ready_stream(
     # See the note in the script-play path above: identity goes out before the
     # handoff so the scrobbler sees it when playback starts.
     tmdbhelper_scrobble.publish_player_info(params)
+    tmdbhelper_metadata.publish_params(params)
     _resolver._finish_direct_playback(
         handle, prepared, resume_key=release_id, resume_seconds=chosen
     )
@@ -508,6 +510,7 @@ def _resolve_and_play_ready_stream(
     # Publish the TMDB identity before handing off so TMDb Helper's scrobbler
     # can attribute this playback to Trakt; the stream URL itself carries none.
     tmdbhelper_scrobble.publish_player_info(resume_params)
+    tmdbhelper_metadata.publish_params(resume_params)
     _resolver._finish_player_playback(
         prepared, resume_key=release_id, resume_seconds=chosen
     )

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_resume.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_resume.py
@@ -14,6 +14,7 @@ moved name is re-exported from ``resolver``.
 """
 
 import resources.lib.resolver as _resolver  # noqa: F401  pylint: disable=unused-import
+from resources.lib import tmdbhelper_metadata
 
 
 def _show_cache_prompt_after_playback(stream_info):
@@ -178,6 +179,7 @@ def _resolve_direct_no_proxy(
     )
     li = _resolver._make_playable_listitem(bust_url, stream_headers)
     _apply_resume_start_offset(li, resume_seconds)
+    tmdbhelper_metadata.apply_from_published_params(li)
     home = _resolver.xbmcgui.Window(10000)
     _set_playback_monitor_properties(
         home, play_url, stream_url, monitor_key, resume_seconds
@@ -224,6 +226,7 @@ def _finish_direct_playback(handle, prepared, resume_key="", resume_seconds=0.0)
             bust_url = _resolver._cache_bust_url(stream_url)
             li = _resolver._make_playable_listitem(bust_url, stream_headers)
             _apply_resume_start_offset(li, resume_seconds)
+            tmdbhelper_metadata.apply_from_published_params(li)
             play_url = _resolver._build_play_url(bust_url, stream_headers)
             _set_playback_monitor_properties(
                 home, play_url, stream_url, monitor_key, resume_seconds
@@ -235,6 +238,7 @@ def _finish_direct_playback(handle, prepared, resume_key="", resume_seconds=0.0)
         li.setContentLookup(False)
         _resolver._apply_proxy_mime(li, stream_url, stream_info)
         _apply_resume_start_offset(li, resume_seconds)
+        tmdbhelper_metadata.apply_from_published_params(li)
 
         _set_playback_monitor_properties(
             home, proxy_url, stream_url, monitor_key, resume_seconds
@@ -277,6 +281,7 @@ def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
             bust_url = _resolver._cache_bust_url(stream_url)
             li = _resolver._make_playable_listitem(bust_url, stream_headers)
             _apply_resume_start_offset(li, resume_seconds)
+            tmdbhelper_metadata.apply_from_published_params(li)
             play_url = _resolver._build_play_url(bust_url, stream_headers)
             _set_playback_monitor_properties(
                 home, play_url, stream_url, monitor_key, resume_seconds
@@ -288,6 +293,7 @@ def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
         li.setContentLookup(False)
         _resolver._apply_proxy_mime(li, stream_url, stream_info)
         _apply_resume_start_offset(li, resume_seconds)
+        tmdbhelper_metadata.apply_from_published_params(li)
         _set_playback_monitor_properties(
             home, proxy_url, stream_url, monitor_key, resume_seconds
         )
@@ -298,6 +304,7 @@ def _finish_player_playback(prepared, resume_key="", resume_seconds=0.0):
     bust_url = _resolver._cache_bust_url(stream_url)
     li = _resolver._make_playable_listitem(bust_url, stream_headers)
     _apply_resume_start_offset(li, resume_seconds)
+    tmdbhelper_metadata.apply_from_published_params(li)
     play_url = _resolver._build_play_url(bust_url, stream_headers)
     _resolver.xbmc.log(
         "NZB-DAV: Playing direct (no proxy): {}".format(safe_url),

--- a/repo/plugin.video.nzbdav/resources/lib/tmdbhelper_metadata.py
+++ b/repo/plugin.video.nzbdav/resources/lib/tmdbhelper_metadata.py
@@ -47,6 +47,23 @@ def _clean(value):
     return str(value or "").strip()
 
 
+def _json_safe(params):
+    """Return only the JSON-serializable primitive values in ``params``.
+
+    Resolve-stage helpers stash internal, non-serializable state on this
+    same dict — e.g. ``_fallback_candidate_loader`` is a callable — so a
+    raw ``json.dumps(params)`` can fail. Every field ``apply_metadata``
+    reads (type, title, tmdb ids, season/episode, year, imdb, tvdb) is a
+    plain string/int, so dropping anything else is safe and also guards
+    against whatever internal state gets added here in the future.
+    """
+    return {
+        key: value
+        for key, value in (params or {}).items()
+        if value is None or isinstance(value, (str, int, float, bool))
+    }
+
+
 def publish_params(params, window=None):
     """Stash ``params`` for the ListItem builder to read back (best-effort).
 
@@ -55,10 +72,11 @@ def publish_params(params, window=None):
     """
     try:
         window = window or xbmcgui.Window(_WINDOW_ID)
-        if not params:
+        safe_params = _json_safe(params)
+        if not safe_params:
             window.clearProperty(_PROPERTY)
             return
-        window.setProperty(_PROPERTY, json.dumps(params))
+        window.setProperty(_PROPERTY, json.dumps(safe_params))
     except Exception as error:  # pylint: disable=broad-except
         xbmc.log(
             "NZB-DAV: Could not publish metadata params: {}".format(error),

--- a/repo/plugin.video.nzbdav/resources/lib/tmdbhelper_metadata.py
+++ b/repo/plugin.video.nzbdav/resources/lib/tmdbhelper_metadata.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Attach TMDb Helper's rich metadata to the playing ListItem.
+
+Playback here hands Kodi a bare proxy stream URL with no library identity, so
+without this the video info dialog, OSD, and Home widgets show only the raw
+filename: no title, plot, artwork, cast, season, or episode number.
+
+The ListItem is built deep inside the finish-playback functions, past where
+the caller (which has the TMDB params in scope) hands off, so the params are
+round-tripped through a window property the same way playback identity is
+published to TMDb Helper's scrobbler (see ``tmdbhelper_scrobble``).
+"""
+
+import json
+from urllib.parse import unquote, urlencode
+
+import xbmc
+import xbmcgui
+
+_WINDOW_ID = 10000
+_PROPERTY = "nzbdav.metadata_params"
+
+_INFO_KEYS = (
+    "title",
+    "year",
+    "plot",
+    "director",
+    "writer",
+    "genre",
+    "rating",
+    "userrating",
+    "premiered",
+    "originaltitle",
+    "tagline",
+    "studio",
+    "duration",
+    "showtitle",
+    "season",
+    "episode",
+)
+
+
+def _clean(value):
+    """Return ``value`` as a stripped string ("" when absent)."""
+    return str(value or "").strip()
+
+
+def publish_params(params, window=None):
+    """Stash ``params`` for the ListItem builder to read back (best-effort).
+
+    Clears the property when there is nothing useful, so a stale item's
+    params can never be attached to the next play's ListItem.
+    """
+    try:
+        window = window or xbmcgui.Window(_WINDOW_ID)
+        if not params:
+            window.clearProperty(_PROPERTY)
+            return
+        window.setProperty(_PROPERTY, json.dumps(params))
+    except Exception as error:  # pylint: disable=broad-except
+        xbmc.log(
+            "NZB-DAV: Could not publish metadata params: {}".format(error),
+            xbmc.LOGWARNING,
+        )
+
+
+def fetch_metadata(params):
+    """Return TMDb Helper's native rich item data for ``params`` ({} on miss)."""
+    params = params or {}
+    media_type = _clean(params.get("type") or "movie").lower()
+    tmdb_id = _clean(
+        params.get("show_tmdb_id", params.get("tmdb_id", ""))
+        if media_type == "episode"
+        else params.get("tmdb_id", "")
+    )
+    if not tmdb_id:
+        return {}
+
+    query = {
+        "info": "details",
+        "tmdb_type": "tv" if media_type == "episode" else "movie",
+        "tmdb_id": tmdb_id,
+    }
+    if media_type == "episode":
+        query["season"] = params.get("season", params.get("ep_season", ""))
+        query["episode"] = params.get("episode", params.get("ep_episode", ""))
+
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "Files.GetDirectory",
+        "params": {
+            "directory": (
+                "plugin://plugin.video.themoviedb.helper/?" + urlencode(query)
+            ),
+            "media": "video",
+            "properties": [
+                "title",
+                "year",
+                "plot",
+                "cast",
+                "director",
+                "writer",
+                "art",
+                "thumbnail",
+                "fanart",
+                "imdbnumber",
+                "uniqueid",
+                "genre",
+                "rating",
+                "userrating",
+                "premiered",
+                "originaltitle",
+                "tagline",
+                "studio",
+                "duration",
+                "showtitle",
+                "season",
+                "episode",
+            ],
+        },
+    }
+    try:
+        response = json.loads(xbmc.executeJSONRPC(json.dumps(request)))
+        files = response.get("result", {}).get("files", [])
+        if files:
+            xbmc.log(
+                "NZB-DAV: Attached TMDb Helper metadata for tmdb_id={}".format(tmdb_id),
+                xbmc.LOGINFO,
+            )
+            return files[0]
+    except (AttributeError, RuntimeError, TypeError, ValueError) as error:
+        xbmc.log(
+            "NZB-DAV: TMDb Helper metadata lookup failed: {}".format(error),
+            xbmc.LOGWARNING,
+        )
+    return {}
+
+
+def apply_metadata(li, params):
+    """Attach TMDb Helper metadata (info/art/cast/ids) to ``li``.
+
+    Never raises: a metadata lookup must not be able to break playback.
+    """
+    try:
+        params = params or {}
+        media_type = _clean(params.get("type")).lower()
+        is_episode = media_type == "episode"
+        show_title = unquote(_clean(params.get("title")))
+        season = params.get("season", params.get("ep_season", ""))
+        episode = params.get("episode", params.get("ep_episode", ""))
+        metadata = fetch_metadata(params)
+
+        info = {
+            key: metadata[key]
+            for key in _INFO_KEYS
+            if metadata.get(key) not in (None, "")
+        }
+        if info.pop("showtitle", None) and not info.get("tvshowtitle"):
+            info["tvshowtitle"] = metadata["showtitle"]
+        fallback_info = {
+            "title": show_title,
+            "year": params.get("year", ""),
+            "mediatype": "episode" if is_episode else "movie",
+        }
+        if is_episode:
+            fallback_info.update(
+                {
+                    "tvshowtitle": show_title,
+                    "season": season,
+                    "episode": episode,
+                }
+            )
+        for key, value in fallback_info.items():
+            if value not in (None, ""):
+                info.setdefault(key, value)
+        li.setInfo("video", info)
+
+        art = dict(metadata.get("art") or {})
+        if metadata.get("thumbnail") and not art.get("thumb"):
+            art["thumb"] = metadata["thumbnail"]
+        if metadata.get("fanart") and not art.get("fanart"):
+            art["fanart"] = metadata["fanart"]
+        if art:
+            li.setArt(art)
+        if metadata.get("cast"):
+            li.setCast(metadata["cast"])
+
+        unique_ids = dict(metadata.get("uniqueid") or {})
+        if is_episode:
+            show_tmdb_id = _clean(params.get("show_tmdb_id"))
+            episode_tmdb_id = _clean(params.get("episode_tmdb_id"))
+            show_imdb_id = _clean(params.get("imdb"))
+            if show_tmdb_id:
+                unique_ids["tvshow.tmdb"] = show_tmdb_id
+            if episode_tmdb_id and episode_tmdb_id != show_tmdb_id:
+                unique_ids["tmdb"] = episode_tmdb_id
+            if show_imdb_id:
+                unique_ids["tvshow.imdb"] = show_imdb_id
+        else:
+            tmdb_id = _clean(params.get("tmdb_id"))
+            imdb_id = _clean(params.get("imdb"))
+            if tmdb_id:
+                unique_ids["tmdb"] = tmdb_id
+            if imdb_id:
+                unique_ids["imdb"] = imdb_id
+        if unique_ids:
+            li.setUniqueIDs(unique_ids, "tmdb" if unique_ids.get("tmdb") else "")
+    except Exception as error:  # pylint: disable=broad-except
+        xbmc.log(
+            "NZB-DAV: Could not apply TMDb Helper metadata: {}".format(error),
+            xbmc.LOGWARNING,
+        )
+
+
+def apply_from_published_params(li, window=None):
+    """Read the params published by ``publish_params`` and apply to ``li``.
+
+    Best-effort: a missing, empty, or malformed property means nothing was
+    published for this play, which is a normal case (e.g. no TMDB identity
+    available), not an error.
+    """
+    try:
+        window = window or xbmcgui.Window(_WINDOW_ID)
+        raw = window.getProperty(_PROPERTY)
+        if not raw:
+            return
+        params = json.loads(raw)
+    except (TypeError, ValueError, AttributeError):
+        return
+    apply_metadata(li, params)

--- a/repo/plugin.video.nzbdav/resources/lib/tmdbhelper_scrobble.py
+++ b/repo/plugin.video.nzbdav/resources/lib/tmdbhelper_scrobble.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Publish playback identity so TMDb Helper can scrobble to Trakt.
+
+When playback starts from TMDb Helper, its scrobbler needs to know *which*
+TMDB item is playing. It learns that from a Home-window property rather than
+from the ListItem, because this add-on hands Kodi a proxy stream URL that
+carries no library identity.
+
+Two details make or break this handoff, and both fail silently:
+
+* TMDb Helper reads its window properties through a helper that prefixes every
+  key with ``TMDbHelper.``. Writing the bare ``PlayerInfoString`` key stores a
+  property nothing ever reads.
+* Trakt requires ``tmdb`` ids as JSON **integers**. Posting them as strings is
+  rejected with HTTP 422, and TMDb Helper's request layer deliberately does not
+  log 4xx bodies, so the scrobble simply never lands.
+"""
+
+import json
+
+import xbmc
+import xbmcgui
+
+_WINDOW_ID = 10000
+_PROPERTY = "TMDbHelper.PlayerInfoString"
+
+
+def _clean(value):
+    """Return ``value`` as a stripped string ("" when absent)."""
+    return str(value or "").strip()
+
+
+def _as_id(value):
+    """Return a numeric id as ``int``, else the cleaned string, else ""."""
+    value = _clean(value)
+    if not value:
+        return ""
+    # Trakt rejects string tmdb ids (HTTP 422), so send real integers. Ids that
+    # are not purely numeric are passed through untouched rather than dropped.
+    return int(value) if value.isdigit() else value
+
+
+def _as_number(value):
+    """Return a season/episode number as ``int`` (0 when unusable)."""
+    try:
+        return int(_clean(value) or 0)
+    except ValueError:
+        return 0
+
+
+def build_player_info(params):
+    """Return TMDb Helper's player-info mapping for ``params``.
+
+    Returns ``{}`` when the item cannot be identified, in which case callers
+    should clear the property instead of writing a partial identity.
+    """
+    params = params or {}
+    if _clean(params.get("type")).lower() == "episode":
+        show_id = _as_id(params.get("show_tmdb_id") or params.get("tmdb_id"))
+        if not show_id:
+            return {}
+        season = _as_number(params.get("season") or params.get("ep_season"))
+        episode = _as_number(params.get("episode") or params.get("ep_episode"))
+        if not season or not episode:
+            return {}
+        info = {
+            "tmdb_type": "episode",
+            "tmdb_id": show_id,
+            "imdb_id": _clean(params.get("imdb")),
+            "tvdb_id": _clean(params.get("tvdb")),
+            "season": season,
+            "episode": episode,
+        }
+    else:
+        movie_id = _as_id(params.get("tmdb_id"))
+        if not movie_id:
+            return {}
+        info = {
+            "tmdb_type": "movie",
+            "tmdb_id": movie_id,
+            "imdb_id": _clean(params.get("imdb")),
+        }
+    return {key: value for key, value in info.items() if value}
+
+
+def publish_player_info(params, window=None):
+    """Write the player-info property for ``params``; clear it when unknown.
+
+    Returns the published mapping (``{}`` when cleared). Never raises: a
+    metadata handoff must not be able to break playback.
+    """
+    try:
+        window = window or xbmcgui.Window(_WINDOW_ID)
+        info = build_player_info(params)
+        if not info:
+            # Clear rather than leave a previous item's identity in place,
+            # which would scrobble the wrong episode.
+            window.clearProperty(_PROPERTY)
+            return {}
+        window.setProperty(_PROPERTY, json.dumps(info))
+        xbmc.log(
+            "NZB-DAV: Published TMDb Helper playback identity ({} {})".format(
+                info.get("tmdb_type"), info.get("tmdb_id")
+            ),
+            xbmc.LOGINFO,
+        )
+        return info
+    except Exception as error:  # pylint: disable=broad-except
+        xbmc.log(
+            "NZB-DAV: Could not publish TMDb Helper playback identity: {}".format(
+                error
+            ),
+            xbmc.LOGWARNING,
+        )
+        return {}

--- a/repo/plugin.video.nzbdav/resources/players/nzbdav.json
+++ b/repo/plugin.video.nzbdav/resources/players/nzbdav.json
@@ -3,7 +3,7 @@
     "plugin": "plugin.video.nzbdav",
     "priority": 100,
     "is_resolvable": "false",
-    "schema_version": 6,
-    "play_movie": "executebuiltin://RunScript(special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,type=movie,title={title_url},year={year},imdb={imdb},tmdb_id={tmdb_id})",
-    "play_episode": "executebuiltin://RunScript(special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,type=episode,title={showname_url},year={showyear},season={season},episode={episode},imdb={imdb},tmdb_id={tmdb_id},ep_season={ep_showseason},ep_episode={ep_showepisode})"
+    "schema_version": 8,
+    "play_movie": "executebuiltin://RunScript(special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,type=movie,title={title_url},year={year},imdb={imdb},tmdb_id={tmdb})",
+    "play_episode": "executebuiltin://RunScript(special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,type=episode,title={showname_url},year={showyear},season={season},episode={episode},imdb={imdb},tmdb_id={tmdb},show_tmdb_id={tmdb},episode_tmdb_id={eptmdb},tvdb={tvdb},ep_season={ep_showseason},ep_episode={ep_showepisode})"
 }

--- a/tests/test_player_installer.py
+++ b/tests/test_player_installer.py
@@ -121,8 +121,10 @@ def test_player_json_uses_script_handoff_instead_of_plugin_media_url():
     assert "plugin.video.nzbdav" in PLAYER_JSON["play_movie"]
     assert "type=movie" in PLAYER_JSON["play_movie"]
     assert "title={title_url}" in PLAYER_JSON["play_movie"]
-    # tmdb_id must be forwarded so resolver can clear TMDBHelper bookmarks
-    assert "tmdb_id={tmdb_id}" in PLAYER_JSON["play_movie"]
+    # tmdb_id must be forwarded so resolver can clear TMDBHelper bookmarks.
+    # {tmdb} is the real TMDb Helper token; {tmdb_id} is not one of its
+    # tokens and would substitute to a literal "_".
+    assert "tmdb_id={tmdb}" in PLAYER_JSON["play_movie"]
     assert PLAYER_JSON["play_episode"].startswith(
         "executebuiltin://RunScript("
         "special://home/addons/plugin.video.nzbdav/addon.py,tmdb_play,"
@@ -132,7 +134,7 @@ def test_player_json_uses_script_handoff_instead_of_plugin_media_url():
     assert "plugin.video.nzbdav" in PLAYER_JSON["play_episode"]
     assert "type=episode" in PLAYER_JSON["play_episode"]
     assert "title={showname_url}" in PLAYER_JSON["play_episode"]
-    assert "tmdb_id={tmdb_id}" in PLAYER_JSON["play_episode"]
+    assert "tmdb_id={tmdb}" in PLAYER_JSON["play_episode"]
     roundtripped = json.loads(json.dumps(PLAYER_JSON))
     assert roundtripped["name"] == PLAYER_JSON["name"]
 
@@ -146,12 +148,35 @@ def test_play_episode_forwards_tvdb_token():
     assert "tvdb=" not in PLAYER_JSON["play_movie"]
 
 
+def test_play_actions_use_real_tmdbhelper_tokens():
+    """{tmdb_id} is not a TMDb Helper token.
+
+    TMDb Helper formats these actions against a ``defaultdict(lambda: '_')``,
+    so an unknown token silently becomes a literal underscore instead of
+    failing. Guard against reintroducing one.
+    """
+    for action in ("play_movie", "play_episode"):
+        assert "{tmdb_id}" not in PLAYER_JSON[action]
+
+
+def test_play_episode_forwards_scrobble_identity():
+    """Trakt scrobbling needs the show id, the episode id and the show's tvdb.
+
+    In episode context TMDb Helper resolves {tmdb} to the *show* id and
+    {eptmdb} to the episode's own id.
+    """
+    action = PLAYER_JSON["play_episode"]
+    assert "show_tmdb_id={tmdb}" in action
+    assert "episode_tmdb_id={eptmdb}" in action
+    assert "tvdb={tvdb}" in action
+
+
 def test_player_schema_version_bumped_for_tvdb_token():
     """Adding the {tvdb} token changes the shipped action string, so the
     schema version must advance to force a re-install over older files."""
     from resources.lib.player_installer import _PLAYER_SCHEMA_VERSION
 
-    assert _PLAYER_SCHEMA_VERSION >= 7
+    assert _PLAYER_SCHEMA_VERSION >= 8
     assert PLAYER_JSON["schema_version"] == _PLAYER_SCHEMA_VERSION
 
 

--- a/tests/test_tmdbhelper_metadata.py
+++ b/tests/test_tmdbhelper_metadata.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Tests for the TMDb Helper rich-metadata handoff."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from resources.lib import tmdbhelper_metadata
+
+EPISODE_PARAMS = {
+    "type": "episode",
+    "title": "House%20of%20the%20Dragon",
+    "show_tmdb_id": "94997",
+    "episode_tmdb_id": "5234722",
+    "imdb": "tt11198330",
+    "tvdb": "371572",
+    "season": "2",
+    "episode": "2",
+}
+
+TMDB_HELPER_RESPONSE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "files": [
+            {
+                "title": "Rhaenyra the Cruel",
+                "showtitle": "House of the Dragon",
+                "plot": "The realm reels.",
+                "year": 2024,
+                "art": {"fanart": "http://x/fanart.jpg"},
+                "thumbnail": "http://x/thumb.jpg",
+                "cast": [{"name": "Emma D'Arcy", "role": "Rhaenyra"}],
+                "uniqueid": {"tvdb": "10396629"},
+                "season": 2,
+                "episode": 2,
+            }
+        ]
+    },
+}
+
+
+def test_fetch_metadata_returns_empty_without_identity():
+    assert tmdbhelper_metadata.fetch_metadata({}) == {}
+    assert tmdbhelper_metadata.fetch_metadata({"type": "movie"}) == {}
+
+
+@patch("resources.lib.tmdbhelper_metadata.xbmc")
+def test_fetch_metadata_queries_the_show_id_for_episodes(mock_xbmc):
+    """The lookup must use the show's tmdb id, not the episode's."""
+    mock_xbmc.executeJSONRPC.return_value = json.dumps(TMDB_HELPER_RESPONSE)
+
+    metadata = tmdbhelper_metadata.fetch_metadata(EPISODE_PARAMS)
+
+    request = json.loads(mock_xbmc.executeJSONRPC.call_args.args[0])
+    directory = request["params"]["directory"]
+    assert "tmdb_id=94997" in directory
+    assert "tmdb_type=tv" in directory
+    assert "season=2" in directory
+    assert "episode=2" in directory
+    assert metadata["title"] == "Rhaenyra the Cruel"
+
+
+@patch("resources.lib.tmdbhelper_metadata.xbmc")
+def test_fetch_metadata_swallows_lookup_failures(mock_xbmc):
+    """A malformed or failed JSON-RPC response must not raise."""
+    mock_xbmc.executeJSONRPC.return_value = "not json"
+
+    assert tmdbhelper_metadata.fetch_metadata(EPISODE_PARAMS) == {}
+
+
+@patch("resources.lib.tmdbhelper_metadata.fetch_metadata")
+def test_apply_metadata_sets_info_art_and_cast(mock_fetch):
+    mock_fetch.return_value = TMDB_HELPER_RESPONSE["result"]["files"][0]
+    li = MagicMock()
+
+    tmdbhelper_metadata.apply_metadata(li, EPISODE_PARAMS)
+
+    info = li.setInfo.call_args.args[1]
+    assert info["title"] == "Rhaenyra the Cruel"
+    assert info["tvshowtitle"] == "House of the Dragon"
+    assert info["mediatype"] == "episode"
+    assert info["season"] == 2
+    assert info["episode"] == 2
+
+    art = li.setArt.call_args.args[0]
+    assert art["fanart"] == "http://x/fanart.jpg"
+    assert art["thumb"] == "http://x/thumb.jpg"
+
+    li.setCast.assert_called_once_with(
+        TMDB_HELPER_RESPONSE["result"]["files"][0]["cast"]
+    )
+
+
+@patch("resources.lib.tmdbhelper_metadata.fetch_metadata")
+def test_apply_metadata_sets_show_level_unique_ids_for_episodes(mock_fetch):
+    """Episode identity must be the show's ids, with the episode id separate."""
+    mock_fetch.return_value = {}
+    li = MagicMock()
+
+    tmdbhelper_metadata.apply_metadata(li, EPISODE_PARAMS)
+
+    unique_ids, default_key = li.setUniqueIDs.call_args.args
+    assert unique_ids["tvshow.tmdb"] == "94997"
+    assert unique_ids["tmdb"] == "5234722"
+    assert unique_ids["tvshow.imdb"] == "tt11198330"
+
+
+@patch("resources.lib.tmdbhelper_metadata.fetch_metadata")
+def test_apply_metadata_falls_back_to_title_from_params_when_lookup_empty(mock_fetch):
+    """If TMDb Helper has nothing, at least show the title we already know."""
+    mock_fetch.return_value = {}
+    li = MagicMock()
+
+    tmdbhelper_metadata.apply_metadata(li, EPISODE_PARAMS)
+
+    info = li.setInfo.call_args.args[1]
+    assert info["title"] == "House of the Dragon"
+    assert info["tvshowtitle"] == "House of the Dragon"
+    assert info["season"] == "2"
+    assert info["episode"] == "2"
+
+
+def test_apply_metadata_never_raises_into_playback():
+    """A ListItem that rejects setInfo must not break the play call."""
+    li = MagicMock()
+    li.setInfo.side_effect = RuntimeError("boom")
+
+    tmdbhelper_metadata.apply_metadata(li, EPISODE_PARAMS)  # must not raise
+
+
+def test_publish_writes_json_and_clears_when_empty():
+    window = MagicMock()
+
+    tmdbhelper_metadata.publish_params(EPISODE_PARAMS, window=window)
+    key, payload = window.setProperty.call_args.args
+    assert key == "nzbdav.metadata_params"
+    assert json.loads(payload) == EPISODE_PARAMS
+
+    tmdbhelper_metadata.publish_params({}, window=window)
+    window.clearProperty.assert_called_once_with("nzbdav.metadata_params")
+
+
+@patch("resources.lib.tmdbhelper_metadata.apply_metadata")
+def test_apply_from_published_params_reads_back_the_property(mock_apply):
+    window = MagicMock()
+    window.getProperty.return_value = json.dumps(EPISODE_PARAMS)
+    li = MagicMock()
+
+    tmdbhelper_metadata.apply_from_published_params(li, window=window)
+
+    mock_apply.assert_called_once_with(li, EPISODE_PARAMS)
+
+
+@patch("resources.lib.tmdbhelper_metadata.apply_metadata")
+def test_apply_from_published_params_is_a_noop_when_nothing_published(mock_apply):
+    """Empty property (nothing published for this play) must not call apply."""
+    window = MagicMock()
+    window.getProperty.return_value = ""
+    li = MagicMock()
+
+    tmdbhelper_metadata.apply_from_published_params(li, window=window)
+
+    mock_apply.assert_not_called()
+
+
+@patch("resources.lib.tmdbhelper_metadata.apply_metadata")
+def test_apply_from_published_params_tolerates_malformed_json(mock_apply):
+    """A mocked/garbage property value (e.g. in unrelated unit tests that
+    stub xbmcgui.Window entirely) must not raise or apply anything."""
+    window = MagicMock()
+    window.getProperty.return_value = MagicMock()  # not a JSON string
+    li = MagicMock()
+
+    tmdbhelper_metadata.apply_from_published_params(li, window=window)
+
+    mock_apply.assert_not_called()

--- a/tests/test_tmdbhelper_metadata.py
+++ b/tests/test_tmdbhelper_metadata.py
@@ -142,6 +142,25 @@ def test_publish_writes_json_and_clears_when_empty():
     window.clearProperty.assert_called_once_with("nzbdav.metadata_params")
 
 
+def test_publish_drops_internal_non_serializable_state():
+    """Real resolve-stage params carry internal state on the same dict —
+    e.g. ``_fallback_candidate_loader`` is a callable — that must not break
+    publishing. Regression: this previously raised inside publish_params'
+    own try/except, so the property was silently never written and no
+    metadata ever appeared, with only a WARNING in the log to show for it.
+    """
+    window = MagicMock()
+    params_with_callable = dict(EPISODE_PARAMS, _fallback_candidate_loader=lambda: None)
+
+    tmdbhelper_metadata.publish_params(params_with_callable, window=window)
+
+    key, payload = window.setProperty.call_args.args
+    assert key == "nzbdav.metadata_params"
+    written = json.loads(payload)
+    assert "_fallback_candidate_loader" not in written
+    assert written["show_tmdb_id"] == "94997"
+
+
 @patch("resources.lib.tmdbhelper_metadata.apply_metadata")
 def test_apply_from_published_params_reads_back_the_property(mock_apply):
     window = MagicMock()

--- a/tests/test_tmdbhelper_scrobble.py
+++ b/tests/test_tmdbhelper_scrobble.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Tests for the TMDb Helper playback-identity handoff."""
+
+import json
+from unittest.mock import MagicMock
+
+from resources.lib import tmdbhelper_scrobble
+
+EPISODE_PARAMS = {
+    "type": "episode",
+    "show_tmdb_id": "94997",
+    "episode_tmdb_id": "5234722",
+    "imdb": "tt11198330",
+    "tvdb": "371572",
+    "season": "2",
+    "episode": "2",
+}
+
+MOVIE_PARAMS = {"type": "movie", "tmdb_id": "603", "imdb": "tt0133093"}
+
+
+def test_episode_tmdb_id_is_an_integer():
+    """Trakt rejects string tmdb ids with HTTP 422, so send real integers."""
+    info = tmdbhelper_scrobble.build_player_info(EPISODE_PARAMS)
+
+    assert info["tmdb_id"] == 94997
+    assert isinstance(info["tmdb_id"], int)
+    assert info["tmdb_type"] == "episode"
+    assert info["season"] == 2
+    assert info["episode"] == 2
+
+
+def test_episode_identity_uses_show_not_episode_id():
+    """The scrobbler expects the show id plus season/episode numbers."""
+    info = tmdbhelper_scrobble.build_player_info(EPISODE_PARAMS)
+
+    assert info["tmdb_id"] == 94997
+    assert info["imdb_id"] == "tt11198330"
+    assert info["tvdb_id"] == "371572"
+
+
+def test_episode_falls_back_to_alternate_param_names():
+    """Season/episode arrive under ep_* names on some playback routes."""
+    info = tmdbhelper_scrobble.build_player_info(
+        {"type": "episode", "tmdb_id": "94997", "ep_season": "3", "ep_episode": "7"}
+    )
+
+    assert (info["season"], info["episode"]) == (3, 7)
+
+
+def test_movie_tmdb_id_is_an_integer():
+    info = tmdbhelper_scrobble.build_player_info(MOVIE_PARAMS)
+
+    assert info == {
+        "tmdb_type": "movie",
+        "tmdb_id": 603,
+        "imdb_id": "tt0133093",
+    }
+
+
+def test_unidentifiable_items_yield_nothing():
+    """No tmdb id, or an episode without numbers, must not be published."""
+    assert tmdbhelper_scrobble.build_player_info({}) == {}
+    assert tmdbhelper_scrobble.build_player_info({"type": "movie"}) == {}
+    assert (
+        tmdbhelper_scrobble.build_player_info(
+            {"type": "episode", "show_tmdb_id": "94997", "season": "2"}
+        )
+        == {}
+    )
+
+
+def test_publish_writes_the_prefixed_property():
+    """TMDb Helper only reads keys prefixed with ``TMDbHelper.``."""
+    window = MagicMock()
+
+    published = tmdbhelper_scrobble.publish_player_info(EPISODE_PARAMS, window=window)
+
+    key, payload = window.setProperty.call_args.args
+    assert key == "TMDbHelper.PlayerInfoString"
+    assert json.loads(payload) == published
+    # Serialized, not repr()'d — the consumer parses this as JSON.
+    assert '"tmdb_id": 94997' in payload
+
+
+def test_publish_clears_property_when_unidentifiable():
+    """A stale identity would scrobble the previously played item."""
+    window = MagicMock()
+
+    assert tmdbhelper_scrobble.publish_player_info({}, window=window) == {}
+
+    window.clearProperty.assert_called_once_with("TMDbHelper.PlayerInfoString")
+    window.setProperty.assert_not_called()
+
+
+def test_publish_never_raises_into_playback():
+    """A metadata handoff must not be able to break playback."""
+    window = MagicMock()
+    window.setProperty.side_effect = RuntimeError("boom")
+
+    assert tmdbhelper_scrobble.publish_player_info(EPISODE_PARAMS, window=window) == {}


### PR DESCRIPTION
## Problem

Playback started from TMDb Helper never scrobbled to Trakt, so any Kodi widget
built from Trakt playback progress — typically a "Continue Watching" row — stays
permanently empty no matter how much is watched.

TMDb Helper's scrobbler learns which TMDB item is playing from a Home window
property, because the URL handed to Kodi here is a proxy stream that carries no
library identity. Nothing was publishing it.

## Two silent failure modes

Both are covered by tests, because neither produces any error:

1. **Property prefix.** TMDb Helper reads its window properties through a helper
   that prefixes every key with `TMDbHelper.`, so writing the bare
   `PlayerInfoString` key stores a property nothing ever reads.
2. **Integer ids.** Trakt requires `tmdb` ids as JSON integers and answers
   `HTTP 422` for the string form. TMDb Helper's request layer deliberately does
   not log 4xx bodies, so a rejected scrobble leaves no trace in `kodi.log`.

## Verification (Windows / Kodi 21, live)

- `GET /users/me/watching` → episode returned with integer `tmdb: 94997`
- after stop, `GET /sync/playback/episodes` → `progress: 18.57`
- the Continue Watching row repopulated

## Implementation

New `resources/lib/tmdbhelper_scrobble.py` builds and publishes the identity. It
clears the property when the item cannot be identified, so a previous item's
identity can never be scrobbled against the current one, and it never raises —
a metadata handoff must not be able to break playback.

Identity is published at the two playback handoff sites in `resolver_flow.py`
rather than inside `_finish_player_playback` / `_finish_direct_playback`, so
those signatures and the tests asserting them stay unchanged.

## Tests

`tests/test_tmdbhelper_scrobble.py` — 8 tests covering integer coercion,
show-vs-episode id selection, `ep_*` param fallbacks, movies, unidentifiable
input, the prefixed key, clearing, and the no-raise guarantee.

Full suite: 2593 passed, 2 failed, 2 skipped, against a 2586/2/2 baseline on a
clean checkout — same two pre-existing timing failures, no new ones. `ruff` and
`black` clean.

## Note

Not wired into the NZBGet playback route, which is a separate entry point that
does not originate from TMDb Helper.