### PR TITLE
fix: stop the search loading dialog from always saying NZBHydra

### DIFF
--- a/repo/plugin.video.nzbdav/resources/language/resource.language.en_gb/strings.po
+++ b/repo/plugin.video.nzbdav/resources/language/resource.language.en_gb/strings.po
@@ -1429,3 +1429,7 @@ msgstr "The downloaded season pack is no longer available. Choose another result
 msgctxt "#30366"
 msgid "Video file is listed but not readable. If this persists, check the share or mount and restart Kodi."
 msgstr "Video file is listed but not readable. If this persists, check the share or mount and restart Kodi."
+
+msgctxt "#30367"
+msgid "Searching for {}..."
+msgstr "Searching for {}..."

--- a/repo/plugin.video.nzbdav/resources/lib/i18n.py
+++ b/repo/plugin.video.nzbdav/resources/lib/i18n.py
@@ -16,6 +16,7 @@ _FALLBACK_STRINGS = {
     30087: "No results found for {}",
     30088: "Filtering results...",
     30089: "No results after filtering for {}",
+    30367: "Searching for {}...",
     30091: "Clear Cache",
     30092: "Settings",
     30093: "Install NZB-DAV Player To",

--- a/repo/plugin.video.nzbdav/resources/lib/router_settings.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_settings.py
@@ -47,7 +47,11 @@ def _open_loading_dialog(title):
 
     try:
         dialog = xbmcgui.DialogProgressBG()
-        dialog.create(_router._addon_name(), _router._fmt(30083, title or ""))
+        # Provider-agnostic: this fires for every search regardless of which
+        # provider(s) are actually configured (NZBHydra2, Prowlarr, direct
+        # indexers, any combination). #30083 hardcoded "NZBHydra" here even
+        # when NZBHydra2 was disabled and only direct indexers ran.
+        dialog.create(_router._addon_name(), _router._fmt(30367, title or ""))
         return dialog
     except Exception:  # pylint: disable=broad-except
         return None


### PR DESCRIPTION
## Problem

\`_open_loading_dialog()\` (\`router_settings.py\`) hardcodes the loading indicator to string #30083, "Searching NZBHydra for {}...", for every search — regardless of which provider(s) are actually configured.

Observed live: NZBHydra2 disabled, only direct indexers enabled (confirmed via log: \`providers settings nzbhydra=False prowlarr=False direct=True\`), yet the on-screen dialog still read "Searching NZBHydra for House of the Dragon...".

## Fix

Adds #30367, a provider-agnostic "Searching for {}..." string, and points the one call site at it instead. #30083 is left untouched — still used by \`test_i18n.py\` as a generic \`fmt()\` example, and remains a legitimate string for any actual NZBHydra-specific context.

## Tests

\`test_i18n.py\` (18 tests) and the full search-related suite (121 tests) pass unchanged; no existing test asserted the old call site's string id.