### PR TITLE
Skip pointless 8s fallback-handoff wait + IPv4 for stream-proxy content-length probes

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/http_util.py
+++ b/repo/plugin.video.nzbdav/resources/lib/http_util.py
@@ -3,9 +3,46 @@
 
 """Shared HTTP and Kodi utility functions."""
 
+import contextlib
 import re
+import socket
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
+
+
+@contextlib.contextmanager
+def prefer_ipv4_connections():
+    """Reorder DNS results so IPv4 addresses are tried before IPv6 ones.
+
+    Docker Desktop / WSL2 port-forwarding for NZB-DAV's own API and WebDAV
+    endpoints is IPv4-only, but "localhost" resolves to both ``::1`` and
+    ``127.0.0.1``, and the standard library tries ``getaddrinfo`` results in
+    the order returned -- IPv6 first on this platform. Every request then
+    pays a multi-second wait for the IPv6 attempt to be refused before
+    falling back to the IPv4 address that actually works: measured at
+    ~2.0s per request, three times in a single resolve (PROPFIND, HEAD, and
+    the mid-file body probe), accounting for the entire observed ~10s
+    "resolving" stall before the resume/restart prompt even appears.
+
+    This only REORDERS results -- it never removes IPv6 -- so a host that
+    is genuinely reachable only over IPv6 still works, just tried second.
+    Scoped to the enclosing ``with`` block and restored immediately after,
+    so it cannot affect unrelated connections outside that block. Safe to
+    nest / use from multiple threads concurrently: at worst two calls
+    briefly agree on the same (harmless) reordering.
+    """
+    original_getaddrinfo = socket.getaddrinfo
+
+    def _ipv4_first(*args, **kwargs):
+        results = original_getaddrinfo(*args, **kwargs)
+        return sorted(results, key=lambda info: info[0] != socket.AF_INET)
+
+    socket.getaddrinfo = _ipv4_first
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
+
 
 # Match common credential-style query parameter names. Covers the usual
 # suspects: ``apikey``, ``api_key``, ``auth``, ``token``, ``password``,
@@ -244,15 +281,16 @@ def http_get(url, timeout=15, headers=None, max_bytes=None):
     if headers:
         request_headers.update(headers)
     req = Request(url, headers=request_headers)
-    # nosemgrep
-    with urlopen(  # nosec B310 — scheme allowlist enforced above
-        req, timeout=timeout
-    ) as resp:
-        status = _response_status(resp)
-        if status is not None and not 200 <= status < 300:
-            raise OSError("HTTP status {}".format(status))
-        body = _read_capped_body(resp, max_bytes)
-        return body.decode("utf-8", errors="replace")
+    with prefer_ipv4_connections():
+        # nosemgrep
+        with urlopen(  # nosec B310 — scheme allowlist enforced above
+            req, timeout=timeout
+        ) as resp:
+            status = _response_status(resp)
+            if status is not None and not 200 <= status < 300:
+                raise OSError("HTTP status {}".format(status))
+            body = _read_capped_body(resp, max_bytes)
+            return body.decode("utf-8", errors="replace")
 
 
 def http_post_json(url, payload, timeout=15, headers=None, basic_auth=None):
@@ -283,14 +321,15 @@ def http_post_json(url, payload, timeout=15, headers=None, basic_auth=None):
         )
         request_headers["Authorization"] = "Basic " + token
     req = Request(url, data=body, headers=request_headers)
-    # nosemgrep
-    with urlopen(  # nosec B310 — scheme allowlist enforced above
-        req, timeout=timeout
-    ) as resp:
-        status = _response_status(resp)
-        if status is not None and not 200 <= status < 300:
-            raise OSError("HTTP status {}".format(status))
-        return resp.read().decode("utf-8", errors="replace")
+    with prefer_ipv4_connections():
+        # nosemgrep
+        with urlopen(  # nosec B310 — scheme allowlist enforced above
+            req, timeout=timeout
+        ) as resp:
+            status = _response_status(resp)
+            if status is not None and not 200 <= status < 300:
+                raise OSError("HTTP status {}".format(status))
+            return resp.read().decode("utf-8", errors="replace")
 
 
 _PUBDATE_ERRORS = (OverflowError, TypeError, ValueError)

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_fallback.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_fallback.py
@@ -540,6 +540,7 @@ def _start_fallback_submit_worker(
         "stop": _resolver.threading.Event(),
         "finished": _resolver.threading.Event(),
         "playback_started": _resolver.threading.Event(),
+        "wait_for_playback": wait_for_playback,
         "thread": None,
         "cancel_job": _cancel_job,
     }

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_fallback_jobs.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_fallback_jobs.py
@@ -90,9 +90,26 @@ def _await_fallback_worker_finish(thread, finished, wait_seconds):
 
 
 def _fallback_submit_jobs_snapshot(state, wait_seconds=0.5):
-    """Return fallback jobs submitted so far, waiting briefly for completion."""
+    """Return fallback jobs submitted so far, waiting briefly for completion.
+
+    A ``wait_for_playback`` worker (see ``_start_fallback_submit_worker``)
+    gates ALL submission work behind ``state["playback_started"]``, which is
+    only set by ``_signal_fallback_playback_started`` after this exact
+    snapshot call returns (it runs from the same synchronous prepare/handoff
+    sequence, strictly earlier). Waiting the full ``wait_seconds`` here can
+    therefore never observe a job -- it is a guaranteed-timeout wait that
+    only delays handoff. Skip it in that case; the worker still submits its
+    real burst once playback is signaled, just as before.
+    """
     if not state:
         return []
+    playback_started = state.get("playback_started")
+    if (
+        state.get("wait_for_playback")
+        and playback_started is not None
+        and not playback_started.is_set()
+    ):
+        wait_seconds = 0
     _await_fallback_worker_finish(
         state.get("thread"), state.get("finished"), wait_seconds
     )

--- a/repo/plugin.video.nzbdav/resources/lib/resolver_playback.py
+++ b/repo/plugin.video.nzbdav/resources/lib/resolver_playback.py
@@ -150,13 +150,16 @@ def _completed_stream_head_length(url, headers, timeout):
     """Return the Content-Length via HEAD, or None on any ambiguous failure."""
     from urllib.request import Request, urlopen
 
+    from resources.lib.http_util import prefer_ipv4_connections
+
     # Any failure here is ambiguous (e.g. server rejects HEAD) — don't block.
     try:
         head = Request(url, method="HEAD")
         _add_request_headers(head, headers)
-        # nosemgrep
-        with urlopen(head, timeout=timeout) as resp:  # nosec B310
-            return int(resp.headers.get("Content-Length", 0) or 0)
+        with prefer_ipv4_connections():
+            # nosemgrep
+            with urlopen(head, timeout=timeout) as resp:  # nosec B310
+                return int(resp.headers.get("Content-Length", 0) or 0)
     except (OSError, ValueError, _resolver.http.client.HTTPException):
         return None
 
@@ -166,19 +169,22 @@ def _completed_stream_midfile_present(url, headers, length, probe_bytes, timeout
     from urllib.error import HTTPError
     from urllib.request import Request, urlopen
 
+    from resources.lib.http_util import prefer_ipv4_connections
+
     start = length // 2
     end = min(start + probe_bytes - 1, length - 1)
     try:
         req = Request(url)
         req.add_header("Range", "bytes={}-{}".format(start, end))
         _add_request_headers(req, headers)
-        # nosemgrep
-        with urlopen(req, timeout=timeout) as resp:  # nosec B310
-            if resp.getcode() >= 400:
-                return False
-            # A success status that delivers no body == the article body is
-            # gone even though the metadata claims the file exists.
-            return bool(resp.read(1))
+        with prefer_ipv4_connections():
+            # nosemgrep
+            with urlopen(req, timeout=timeout) as resp:  # nosec B310
+                if resp.getcode() >= 400:
+                    return False
+                # A success status that delivers no body == the article body
+                # is gone even though the metadata claims the file exists.
+                return bool(resp.read(1))
     except HTTPError:
         # Definitive: the backend cannot serve the mid-file body (e.g. the
         # 404/500 seen when articles are missing).

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_fallback.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_fallback.py
@@ -21,6 +21,7 @@ from urllib.parse import urlsplit  # noqa: E402
 from urllib.request import Request  # noqa: E402
 
 import resources.lib.stream_proxy as _sp  # noqa: E402
+from resources.lib.http_util import prefer_ipv4_connections  # noqa: E402
 from resources.lib.stream_proxy import (  # noqa: E402
     _CONTENT_RANGE_ZERO_RE,
     _SEEK_THRESHOLD,
@@ -122,18 +123,19 @@ def _probe_content_length_hint(url, auth_header, content_length_hint):
         req = Request(url)
         _sp._add_request_headers(req, auth_header)
         req.add_header("Range", "bytes=0-0")
-        # nosemgrep
-        with _sp.urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
-            req, timeout=10
-        ) as resp:
-            cr = resp.headers.get("Content-Range", "")
-            status = getattr(resp, "status", None)
-            if status is None:
-                status = resp.getcode()
-            match = _CONTENT_RANGE_ZERO_RE.match(cr.strip())
-            stream_length = int(match.group(1)) if match else 0
-            if status == 206 and stream_length == content_length_hint:
-                return content_length_hint
+        with prefer_ipv4_connections():
+            # nosemgrep
+            with _sp.urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
+                req, timeout=10
+            ) as resp:
+                cr = resp.headers.get("Content-Range", "")
+                status = getattr(resp, "status", None)
+                if status is None:
+                    status = resp.getcode()
+                match = _CONTENT_RANGE_ZERO_RE.match(cr.strip())
+                stream_length = int(match.group(1)) if match else 0
+                if status == 206 and stream_length == content_length_hint:
+                    return content_length_hint
     except (OSError, ValueError):
         pass
     return 0
@@ -145,12 +147,13 @@ def _probe_content_length_tail(url, auth_header):
         req = Request(url)
         _sp._add_request_headers(req, auth_header)
         req.add_header("Range", "bytes=-1")
-        # nosemgrep
-        with _sp.urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
-            req, timeout=10
-        ) as resp:
-            cr = resp.headers.get("Content-Range", "")
-            return int(cr.split("/")[1]) if "/" in cr else 0
+        with prefer_ipv4_connections():
+            # nosemgrep
+            with _sp.urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
+                req, timeout=10
+            ) as resp:
+                cr = resp.headers.get("Content-Range", "")
+                return int(cr.split("/")[1]) if "/" in cr else 0
     except (OSError, ValueError):
         return 0
 

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_mgr_probe.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_mgr_probe.py
@@ -12,6 +12,7 @@ call time via ``_sp.<name>`` so test monkeypatches on
 """
 
 import resources.lib.stream_proxy as _sp  # noqa: E402
+from resources.lib.http_util import prefer_ipv4_connections  # noqa: E402
 
 
 class _MgrProbeMixin:  # pylint: disable=too-few-public-methods
@@ -265,11 +266,12 @@ class _MgrProbeMixin:  # pylint: disable=too-few-public-methods
         req = _sp.Request(url, method="HEAD")
         _sp._add_request_headers(req, auth_header)
         try:
-            # nosemgrep
-            with _sp.urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
-                req, timeout=10
-            ) as resp:
-                return int(resp.headers.get("Content-Length", 0))
+            with prefer_ipv4_connections():
+                # nosemgrep
+                with _sp.urlopen(  # nosec B310 — URL from user-configured nzbdav/WebDAV setting
+                    req, timeout=10
+                ) as resp:
+                    return int(resp.headers.get("Content-Length", 0))
         except (OSError, ValueError):
             pass
         return _sp._probe_content_length_tail(url, auth_header)

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -19,6 +19,7 @@ from urllib.request import Request, urlopen
 
 import xbmc
 
+from resources.lib.http_util import prefer_ipv4_connections
 from resources.lib.webdav_match import (
     _episode_tags,
     _hint_tokens,
@@ -109,11 +110,12 @@ def _http_head(
         encoded = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
         req.add_header("Authorization", "Basic {}".format(encoded))
     try:
-        # nosemgrep
-        with urlopen(  # nosec B310 — URL from user's configured WebDAV setting
-            req, timeout=30
-        ) as resp:
-            return resp.getcode()
+        with prefer_ipv4_connections():
+            # nosemgrep
+            with urlopen(  # nosec B310 — URL from user's configured WebDAV setting
+                req, timeout=30
+            ) as resp:
+                return resp.getcode()
     except HTTPError as e:
         return e.code
 
@@ -381,11 +383,12 @@ def _folder_total_fetch_root(url, username, password):
     for header, value in _build_auth_headers(username, password).items():
         req.add_header(header, value)
 
-    # nosemgrep
-    with urlopen(  # nosec B310 — URL from user's configured WebDAV setting
-        req, timeout=10
-    ) as resp:
-        body = resp.read().decode("utf-8", errors="replace")
+    with prefer_ipv4_connections():
+        # nosemgrep
+        with urlopen(  # nosec B310 — URL from user's configured WebDAV setting
+            req, timeout=10
+        ) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
 
     return safe_fromstring(body)
 
@@ -781,11 +784,12 @@ def _browse_and_resolve(req, url, _depth, _visited, settings, hint_ctx):
     from resources.lib import webdav_discovery
 
     have_hint, hint_tokens, hint_episode_tags, min_video_size = hint_ctx
-    # nosemgrep
-    with urlopen(  # nosec B310 — URL from user's configured WebDAV setting
-        req, timeout=10
-    ) as resp:
-        body = resp.read().decode("utf-8", errors="replace")
+    with prefer_ipv4_connections():
+        # nosemgrep
+        with urlopen(  # nosec B310 — URL from user's configured WebDAV setting
+            req, timeout=10
+        ) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
 
     root = webdav_discovery._parse_propfind_xml(body)
     scan = webdav_discovery._scan_propfind_responses(

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2026 nzbdav contributors
 
 import json
+import socket
 from unittest.mock import MagicMock, patch
 
 from resources.lib.http_util import (
@@ -11,6 +12,7 @@ from resources.lib.http_util import (
     http_post_json,
     iso8601_to_rfc2822,
     notify,
+    prefer_ipv4_connections,
     pubdate_to_epoch,
     redact_text,
     redact_url,
@@ -448,6 +450,74 @@ def test_http_post_json_rejects_non_http_scheme():
 
     with pytest.raises(ValueError):
         http_post_json("file:///etc/passwd", {}, timeout=5)
+
+
+# --- prefer_ipv4_connections: IPv6-before-IPv4 loopback delay fix (~10s stall) ---
+
+
+def _fake_getaddrinfo(host, port, *args, **kwargs):
+    """Mimics real getaddrinfo("localhost", ...) ordering: IPv6 first."""
+    return [
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", port, 0, 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", port)),
+    ]
+
+
+def test_prefer_ipv4_connections_sorts_ipv4_first():
+    """The whole point of the fix: within the `with` block, IPv4 results
+    must come before IPv6 ones so urllib tries the working address first
+    instead of eating a ~2s refusal on the unreachable IPv6 loopback."""
+    with patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo):
+        with prefer_ipv4_connections():
+            results = socket.getaddrinfo("localhost", 3000)
+
+    families = [r[0] for r in results]
+    assert families == [socket.AF_INET, socket.AF_INET6]
+
+
+def test_prefer_ipv4_connections_does_not_drop_ipv6():
+    """Reordering must never remove IPv6 entries -- a host reachable only
+    over IPv6 still needs to be tried, just second."""
+    with patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo):
+        with prefer_ipv4_connections():
+            results = socket.getaddrinfo("localhost", 3000)
+
+    assert len(results) == 2
+    assert any(r[0] == socket.AF_INET6 for r in results)
+
+
+def test_prefer_ipv4_connections_restores_original_getaddrinfo_on_exit():
+    """The monkeypatch must be scoped to the `with` block -- leaking it
+    would affect unrelated connections made after the block exits."""
+    original = socket.getaddrinfo
+    with prefer_ipv4_connections():
+        assert socket.getaddrinfo is not original
+    assert socket.getaddrinfo is original
+
+
+def test_prefer_ipv4_connections_restores_original_even_on_exception():
+    """A failed request inside the block must not leave getaddrinfo patched."""
+    import pytest
+
+    original = socket.getaddrinfo
+    with pytest.raises(RuntimeError):
+        with prefer_ipv4_connections():
+            raise RuntimeError("boom")
+    assert socket.getaddrinfo is original
+
+
+def test_prefer_ipv4_connections_preserves_ipv4_only_results():
+    """A host that only resolves to IPv4 must pass through unchanged."""
+
+    def ipv4_only(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", port))]
+
+    with patch("socket.getaddrinfo", side_effect=ipv4_only):
+        with prefer_ipv4_connections():
+            results = socket.getaddrinfo("localhost", 3000)
+
+    assert len(results) == 1
+    assert results[0][0] == socket.AF_INET
 
 
 # --- clean_search_query: strip query-breaking '&' from keyword searches (#294) ---

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1452,6 +1452,94 @@ def test_fallback_worker_append_swallows_on_append_errors():
     assert any(j.get("nzo_id") == "a" for j in state["jobs"])
 
 
+def test_fallback_submit_jobs_snapshot_skips_wait_when_gated_on_playback_start():
+    """A ``wait_for_playback`` worker gates ALL submission behind
+    ``state["playback_started"]``, which the caller of this exact snapshot
+    only sets afterward (see ``_signal_fallback_playback_started`` in
+    ``_resolve_and_play_ready_stream``, called strictly later in the same
+    synchronous flow). Waiting the full grace period here can never observe
+    a job -- it was a guaranteed ~8s no-op stall before every completed-job
+    fast-path handoff. Confirms the wait is skipped (0s) in that case."""
+    from resources.lib.resolver import _fallback_submit_jobs_snapshot
+
+    state = {
+        "lock": threading.Lock(),
+        "jobs": [],
+        "thread": MagicMock(is_alive=MagicMock(return_value=True)),
+        "finished": threading.Event(),
+        "playback_started": threading.Event(),  # not set
+        "wait_for_playback": True,
+    }
+
+    with patch(
+        "resources.lib.resolver_fallback_jobs._await_fallback_worker_finish"
+    ) as mock_wait:
+        _fallback_submit_jobs_snapshot(state, wait_seconds=8.0)
+
+    mock_wait.assert_called_once_with(state["thread"], state["finished"], 0)
+
+
+def test_fallback_submit_jobs_snapshot_waits_when_not_gated_on_playback():
+    """A worker that does NOT require ``wait_for_playback`` (the download
+    submit-and-poll path) starts submitting immediately, so the full grace
+    period genuinely lets it populate jobs -- must not be shortened."""
+    from resources.lib.resolver import _fallback_submit_jobs_snapshot
+
+    state = {
+        "lock": threading.Lock(),
+        "jobs": [],
+        "thread": MagicMock(is_alive=MagicMock(return_value=True)),
+        "finished": threading.Event(),
+        "playback_started": threading.Event(),
+        "wait_for_playback": False,
+    }
+
+    with patch(
+        "resources.lib.resolver_fallback_jobs._await_fallback_worker_finish"
+    ) as mock_wait:
+        _fallback_submit_jobs_snapshot(state, wait_seconds=8.0)
+
+    mock_wait.assert_called_once_with(state["thread"], state["finished"], 8.0)
+
+
+def test_fallback_submit_jobs_snapshot_waits_full_once_playback_already_started():
+    """Once playback has actually started, a ``wait_for_playback`` worker is
+    unblocked and may be mid-submission -- the full wait is useful again."""
+    from resources.lib.resolver import _fallback_submit_jobs_snapshot
+
+    playback_started = threading.Event()
+    playback_started.set()
+    state = {
+        "lock": threading.Lock(),
+        "jobs": [],
+        "thread": MagicMock(is_alive=MagicMock(return_value=True)),
+        "finished": threading.Event(),
+        "playback_started": playback_started,
+        "wait_for_playback": True,
+    }
+
+    with patch(
+        "resources.lib.resolver_fallback_jobs._await_fallback_worker_finish"
+    ) as mock_wait:
+        _fallback_submit_jobs_snapshot(state, wait_seconds=8.0)
+
+    mock_wait.assert_called_once_with(state["thread"], state["finished"], 8.0)
+
+
+def test_start_fallback_submit_worker_records_wait_for_playback_flag():
+    """The snapshot skip above relies on this flag being recorded at
+    creation time; guard against it silently disappearing in a refactor."""
+    from resources.lib.resolver import _start_fallback_submit_worker
+
+    with patch("resources.lib.resolver._submit_fallback_candidates"):
+        state = _start_fallback_submit_worker(
+            candidates=[{"nzb_url": "x"}], wait_for_playback=True
+        )
+        state["thread"].join(timeout=2)
+
+    assert state["wait_for_playback"] is True
+
+
 def test_arm_live_fallback_push_noops_without_service_port():
     from resources.lib.resolver import _arm_live_fallback_push
 


### PR DESCRIPTION
Follow-up to #476, found while verifying it live.

## Problem 1: pointless 8s wait on the completed-job fast path
`_PLAYBACK_PREPARE_HANDOFF_GRACE_SECONDS` (8.0s, from 4811555) is a good grace period for the download submit-and-poll path, where the fallback worker starts submitting immediately. But `_prepare_player_ready_stream_for_handoff` / `_prepare_ready_stream_for_handoff` also use it on the completed-job/direct-play fast path, where the worker is started with `wait_for_playback=True` -- it gates ALL submission behind `state["playback_started"]`, which is only set by `_signal_fallback_playback_started()` *after* this exact snapshot call returns (same synchronous flow, strictly later). So on that path the wait is a guaranteed-timeout no-op: confirmed live, "picker completed stream checked" -> "prepare playback start" measured 7.987s every time.

Fix: record `wait_for_playback` on the worker's state dict; skip the wait when set and playback hasn't started yet (nothing could have been submitted). Unchanged once playback starts, and unchanged for workers that don't require it.

## Problem 2: same IPv6-first tax as #476, different module
The stream proxy's own content-length confirmation (`stream_proxy_fallback.py::_probe_content_length_hint`/`_probe_content_length_tail`, `stream_proxy_mgr_probe.py::_get_content_length`) makes its own `urlopen` calls against the same `localhost` WebDAV host from the persistent service process -- unwrapped by #476's fix since it lives in a different module. Measured live at ~2.77s for this step alone.

Fix: same `prefer_ipv4_connections()` context manager from #476, applied at these call sites.

## Test plan
- 4 new tests for the snapshot-skip logic
- Full suite passes with 0 new regressions