### PR TITLE
🎨 Palette: Add empty state for results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -268,6 +268,17 @@
       <textureslidernibfocus></textureslidernibfocus>
     </control>
 
+    <!-- Empty state for the list -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found.</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Footer background -->
     <control type="image">
       <left>0</left><top>1035</top><width>1920</width><height>45</height>


### PR DESCRIPTION
### 💡 What
Added an empty state label to the results dialog that displays "No results found." when there are no items in the list.

### 🎯 Why
In Kodi XML skins, custom lists do not automatically handle empty states, resulting in a confusing blank screen when no items are present. This provides clear feedback to the user.

### 📸 Before/After
Before: Blank dark screen when no results.
After: Centered "No results found." text.

### ♿ Accessibility
Improves clarity and feedback for users when a search yields no results.

---
*PR created automatically by Jules for task [8633601385416335638](https://jules.google.com/task/8633601385416335638) started by @xbmc4lyfe*