### PR TITLE
🎨 Palette: Add helpful empty state to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/results_dialog.py
+++ b/repo/plugin.video.nzbdav/resources/lib/results_dialog.py
@@ -179,8 +179,10 @@ class ResultsDialog(xbmcgui.WindowXMLDialog):
         self.setProperty("sort_info", _string(30111))
         if self.show_all:
             self.setProperty("filter_info", _fmt(30367, len(active)))
+            self.setProperty("empty_message", _fmt(30087, title_display))
         else:
             self.setProperty("filter_info", _fmt(30112, len(active), self.total_count))
+            self.setProperty("empty_message", _fmt(30089, title_display))
         self.setProperty("footer_hints", self._footer_hints())
 
         list_control = self.getControl(LIST_ID)

--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state label -->
+    <control type="label">
+      <left>0</left><top>400</top><width>1920</width><height>100</height>
+      <label>$INFO[Window.Property(empty_message)]</label>
+      <font>font14</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
💡 What: Added an empty state `<label>` inside `results-dialog.xml` that appears when no results are found, displaying a message dynamically set via the `empty_message` window property. Updated `_populate` in `results_dialog.py` to set the correct message using localized strings.

🎯 Why: Previously, filtering out all results left the user with a confusing blank screen. This makes it clear that there are no results found.

📸 Before/After: Before, it was a blank screen if there were 0 results. After, it shows a centered "No results found for {title}" or "No results after filtering for {title}" message.

♿ Accessibility: Adds explicit messaging for an empty state rather than relying on visual absence of list items.

---
*PR created automatically by Jules for task [5595023871351808517](https://jules.google.com/task/5595023871351808517) started by @xbmc4lyfe*