### PR TITLE
fix: target next episode instead of season premiere on blank Next-Up plays

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/router.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router.py
@@ -749,6 +749,13 @@ def _handle_script_play(params):
     title, season, episode = _script_play_resolve_episode_args(
         params, search_type, title, season, episode, imdb
     )
+    # Threaded onto params (not just _episode_context) so the picker/
+    # auto-select resolve step can remember these numbers as "last picked"
+    # for this show regardless of which path resolved them.
+    if season:
+        params["season"] = season
+    if episode:
+        params["episode"] = episode
     _attach_episode_context(params, params, title=title, season=season, episode=episode)
     pack_result = _season_pack_result(
         params.get("_episode_context"), settings_getter=_get_script_setting

--- a/repo/plugin.video.nzbdav/resources/lib/router_lastepisode.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_lastepisode.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Session-scoped "last picked episode" memory for the RunScript player.
+
+TMDBHelper's Next-Up/widget re-invocation of the addon often arrives with
+blank season/episode (only the series ids). The existing fallback recovers
+those numbers from whatever Kodi ListItem currently has UI focus, which can
+be stale (e.g. focus resets to the top of the season folder after an episode
+finishes, reading back episode 1 instead of the next one). This module lets
+that fallback prefer "the episode after whatever was last picked for this
+show" instead, using the same ``xbmcgui.Window(10000)`` IPC pattern already
+used by ``resolver_resume.py`` / ``stream_proxy_serviceprops.py`` for
+cross-invocation state within a single Kodi session.
+"""
+
+import xbmcgui
+
+_HOME_WINDOW_ID = 10000
+_PROP_SHOW_ID = "nzbdav.last_ep_show_id"
+_PROP_SEASON = "nzbdav.last_ep_season"
+_PROP_EPISODE = "nzbdav.last_ep_episode"
+
+# Preference order for building a per-show identity key. Season/episode are
+# deliberately excluded -- this identifies the *show*, not the episode.
+_ID_FIELDS = ("tmdb_id", "tvdb", "imdb")
+
+
+def _show_identity_key(params):
+    """Stable per-show key from ``params``, or "" if the show is unknown."""
+    params = params if isinstance(params, dict) else {}
+    for field in _ID_FIELDS:
+        value = str(params.get(field) or "").strip()
+        if value:
+            return "{}:{}".format(field, value)
+    title = str(params.get("title") or "").strip().casefold()
+    return "title:{}".format(title) if title else ""
+
+
+def remember_last_episode(params, season, episode):
+    """Record ``season``/``episode`` as the last pick for this show.
+
+    No-op when the show identity or season/episode can't be determined
+    (harmless for movies, which never carry a numeric season/episode).
+    """
+    show_id = _show_identity_key(params)
+    season = str(season or "")
+    episode = str(episode or "")
+    if not (show_id and season.isdigit() and episode.isdigit()):
+        return
+    home = xbmcgui.Window(_HOME_WINDOW_ID)
+    home.setProperty(_PROP_SHOW_ID, show_id)
+    home.setProperty(_PROP_SEASON, season)
+    home.setProperty(_PROP_EPISODE, episode)
+
+
+def recall_next_episode(params):
+    """Return ``(season, episode)`` one past the last pick for this show.
+
+    Returns ``("", "")`` when nothing is remembered, the remembered show
+    doesn't match ``params``, or the stored numbers aren't usable.
+    """
+    show_id = _show_identity_key(params)
+    if not show_id:
+        return "", ""
+    home = xbmcgui.Window(_HOME_WINDOW_ID)
+    if home.getProperty(_PROP_SHOW_ID) != show_id:
+        return "", ""
+    season = home.getProperty(_PROP_SEASON)
+    episode = home.getProperty(_PROP_EPISODE)
+    if not (season.isdigit() and episode.isdigit()):
+        return "", ""
+    return season, str(int(episode) + 1)

--- a/repo/plugin.video.nzbdav/resources/lib/router_scriptplay.py
+++ b/repo/plugin.video.nzbdav/resources/lib/router_scriptplay.py
@@ -51,6 +51,19 @@ def _script_play_recover_episode_info(params, title, season, episode):
     return title, season, episode
 
 
+def _remember_last_episode_pick(params):
+    """Record the season/episode about to be resolved as "last picked".
+
+    Feeds ``router_lastepisode.recall_next_episode``'s next-episode guess for
+    a future blank-season/episode RunScript play of the same show. No-op for
+    movies or when season/episode weren't resolved (nothing numeric to
+    remember).
+    """
+    from resources.lib.router_lastepisode import remember_last_episode
+
+    remember_last_episode(params, params.get("season"), params.get("episode"))
+
+
 def _write_back_episode_params(params, season, episode):
     """Thread recovered season/episode back into ``params`` (skip blanks)."""
     if season:
@@ -77,9 +90,23 @@ def _script_play_resolve_episode_args(
 
     # TMDBHelper Next-Up / widget / home-screen plays often invoke the player
     # with only the series ids and empty season/episode, so an episode search
-    # broadens to the whole show. Recover the numbers from the focused
-    # ListItem, but trust them only when that item is the same show we're
-    # about to search (the focus may have moved by the time the player fires).
+    # broadens to the whole show. When both are blank -- the actual Next-Up
+    # signature -- prefer "one past whatever was last picked for this show"
+    # over the focused-ListItem guess below: after an episode ends, Kodi's UI
+    # focus can reset to the top of the season folder, which the ListItem
+    # probe would misread as "episode 1" instead of "the next episode".
+    if search_type == "episode" and not season and not episode:
+        from resources.lib.router_lastepisode import recall_next_episode
+
+        recalled_season, recalled_episode = recall_next_episode(params)
+        if recalled_season and recalled_episode:
+            season, episode = recalled_season, recalled_episode
+            _write_back_episode_params(params, season, episode)
+            return title, season, episode
+
+    # Recover the numbers from the focused ListItem, but trust them only when
+    # that item is the same show we're about to search (the focus may have
+    # moved by the time the player fires).
     if search_type == "episode" and not (season and episode):
         title, season, episode = _script_play_recover_episode_info(
             params, title, season, episode
@@ -332,6 +359,7 @@ def _script_play_auto_select(params, best, filtered):
     _router._attach_selected_result_metadata(resolver_params, target)
     if best.get("_season_pack"):
         resolver_params["_season_pack"] = best["_season_pack"]
+    _remember_last_episode_pick(params)
     _router._script_play_stage("resolve start '{}'".format(target.get("title", "")))
     resolve_and_play(target["link"], target["title"], params=resolver_params)
     _router._script_play_stage("resolve returned")
@@ -369,6 +397,7 @@ def _script_play_resolve_selected(params, selected, filtered, completed_jobs):
     _router._attach_selected_result_metadata(resolver_params, target)
     if selected.get("_season_pack"):
         resolver_params["_season_pack"] = selected["_season_pack"]
+    _remember_last_episode_pick(params)
     _router._script_play_stage("resolve start '{}'".format(target.get("title", "")))
     resolve_and_play(target["link"], target["title"], params=resolver_params)
     _router._script_play_stage("resolve returned")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3065,6 +3065,160 @@ def test_handle_script_play_ignores_listitem_episode_for_different_show(
     assert query.episode == ""
 
 
+@patch("xbmcaddon.Addon")
+@patch("xbmc.getInfoLabel")
+@patch(
+    "resources.lib.router_lastepisode.recall_next_episode",
+    return_value=("3", "6"),
+)
+@patch("resources.lib.router._lookup_episode_info", return_value={"title": "From"})
+@patch("resources.lib.results_dialog.show_results_dialog", return_value=None)
+@patch("resources.lib.filter.filter_results", return_value=([], []))
+@patch("resources.lib.router._search_all_providers", return_value=([], None))
+@patch("resources.lib.router._tag_available")
+def test_handle_script_play_prefers_last_played_next_episode_over_listitem(
+    mock_tag,
+    mock_search,
+    mock_filter,
+    mock_show,
+    mock_lookup,
+    mock_recall,
+    mock_infolabel,
+    mock_addon,
+):
+    """A blank-season/episode Next-Up play should trust "last picked + 1" for
+    this show over the focused-ListItem guess, which can be stale (e.g. Kodi
+    UI focus resetting to the top of the season folder after an episode
+    ends, which would otherwise misread as episode 1)."""
+    from resources.lib.router import _handle_script_play
+
+    # A conflicting/stale focused item (season 1 episode 1) that must be
+    # ignored in favor of the last-played+1 recall (season 3 episode 6).
+    info = {
+        "ListItem.TVShowTitle": "From",
+        "ListItem.Season": "1",
+        "ListItem.Episode": "1",
+    }
+    mock_infolabel.side_effect = lambda label: info.get(label, "")
+
+    _handle_script_play({"type": "episode", "imdb": "tt9813792", "tmdb_id": "124364"})
+
+    mock_search.assert_called_once()
+    query = mock_search.call_args.args[0]
+    assert query.season == "3"
+    assert query.episode == "6"
+
+
+@patch("xbmcaddon.Addon")
+@patch("xbmc.getInfoLabel")
+@patch(
+    "resources.lib.router_lastepisode.recall_next_episode",
+    return_value=("", ""),
+)
+@patch("resources.lib.router._lookup_episode_info", return_value={"title": "From"})
+@patch("resources.lib.results_dialog.show_results_dialog", return_value=None)
+@patch("resources.lib.filter.filter_results", return_value=([], []))
+@patch("resources.lib.router._search_all_providers", return_value=([], None))
+@patch("resources.lib.router._tag_available")
+def test_handle_script_play_falls_back_to_listitem_with_no_last_played_memory(
+    mock_tag,
+    mock_search,
+    mock_filter,
+    mock_show,
+    mock_lookup,
+    mock_recall,
+    mock_infolabel,
+    mock_addon,
+):
+    """With no last-played memory yet for this show, the existing
+    focused-ListItem recovery still applies unchanged."""
+    from resources.lib.router import _handle_script_play
+
+    info = {
+        "ListItem.TVShowTitle": "From",
+        "ListItem.Season": "3",
+        "ListItem.Episode": "5",
+    }
+    mock_infolabel.side_effect = lambda label: info.get(label, "")
+
+    _handle_script_play({"type": "episode", "imdb": "tt9813792", "tmdb_id": "124364"})
+
+    mock_search.assert_called_once()
+    query = mock_search.call_args.args[0]
+    assert query.season == "3"
+    assert query.episode == "5"
+
+
+class _ScriptPlayFakeWindow:
+    """Shared dict-backed ``xbmcgui.Window(10000)`` stand-in for this test."""
+
+    _store = {}
+
+    def getProperty(self, key):
+        return self._store.get(key, "")
+
+    def setProperty(self, key, value):
+        self._store[key] = value
+
+
+@patch("resources.lib.resolver.resolve_and_play")
+@patch("xbmcaddon.Addon")
+@patch("xbmc.getInfoLabel")
+@patch("resources.lib.router._lookup_episode_info", return_value={"title": "From"})
+@patch("resources.lib.results_dialog.show_results_dialog", return_value=None)
+@patch("resources.lib.filter.filter_results", return_value=([], []))
+@patch("resources.lib.router._search_all_providers", return_value=([], None))
+@patch("resources.lib.router._tag_available")
+def test_handle_script_play_remembers_pick_and_targets_next_episode_later(
+    mock_tag,
+    mock_search,
+    mock_filter,
+    mock_show,
+    mock_lookup,
+    mock_infolabel,
+    mock_addon,
+    mock_resolve_and_play,
+):
+    """End-to-end: picking S1E8 for a show, then a later blank-season/episode
+    Next-Up play for the same show, should target S1E9 -- reproduces the
+    reported "picker reopens targeting the season premiere" bug and confirms
+    the fix. No focused ListItem is available (all InfoLabels blank), so the
+    old fallback alone would have broadened the search to the whole show."""
+    from resources.lib.router import _handle_script_play
+    from resources.lib.router_scriptplay import _script_play_resolve_selected
+
+    mock_infolabel.return_value = ""
+    _ScriptPlayFakeWindow._store = {}
+
+    with patch(
+        "resources.lib.router_lastepisode.xbmcgui.Window",
+        return_value=_ScriptPlayFakeWindow(),
+    ):
+        # Simulate the user picking a S1E8 release from the picker.
+        picked_params = {
+            "type": "episode",
+            "imdb": "tt9813792",
+            "tmdb_id": "124364",
+            "title": "From",
+            "season": "1",
+            "episode": "8",
+        }
+        selection = {"title": "From.S01E08.1080p", "link": "http://indexer/ep8.nzb"}
+        _script_play_resolve_selected(picked_params, selection, [selection], None)
+        mock_resolve_and_play.assert_called_once()
+
+        # A later Next-Up play for the same show arrives with blank
+        # season/episode -- this used to fall through to the stale focused
+        # ListItem (blank here) and broaden the search to the whole show.
+        _handle_script_play(
+            {"type": "episode", "imdb": "tt9813792", "tmdb_id": "124364"}
+        )
+
+    mock_search.assert_called_once()
+    query = mock_search.call_args.args[0]
+    assert (query.season, query.episode) == ("1", "9")
+
+
 @patch(
     "resources.lib.router.fallback_candidate_prefetch_settings", return_value=(True, 2)
 )

--- a/tests/test_router_lastepisode.py
+++ b/tests/test_router_lastepisode.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 nzbdav contributors
+
+"""Session-scoped last-picked-episode memory (router_lastepisode.py)."""
+
+from unittest.mock import patch
+
+from resources.lib.router_lastepisode import (
+    _show_identity_key,
+    recall_next_episode,
+    remember_last_episode,
+)
+
+
+class _FakeWindow:
+    """Dict-backed stand-in for ``xbmcgui.Window(10000)`` property storage."""
+
+    _store = {}
+
+    def getProperty(self, key):
+        return self._store.get(key, "")
+
+    def setProperty(self, key, value):
+        self._store[key] = value
+
+
+def _patched_window():
+    _FakeWindow._store = {}
+    return patch(
+        "resources.lib.router_lastepisode.xbmcgui.Window",
+        return_value=_FakeWindow(),
+    )
+
+
+def test_show_identity_key_prefers_tmdb_id_then_tvdb_then_imdb():
+    params = {"tmdb_id": "1", "tvdb": "2", "imdb": "tt3"}
+    assert _show_identity_key(params) == "tmdb_id:1"
+    assert _show_identity_key({"tvdb": "2", "imdb": "tt3"}) == "tvdb:2"
+    assert _show_identity_key({"imdb": "tt3"}) == "imdb:tt3"
+
+
+def test_show_identity_key_falls_back_to_casefolded_title():
+    assert _show_identity_key({"title": "From"}) == "title:from"
+    assert _show_identity_key({}) == ""
+
+
+def test_remember_then_recall_returns_next_episode():
+    with _patched_window():
+        params = {"tmdb_id": "124364", "title": "From"}
+        remember_last_episode(params, "3", "5")
+        assert recall_next_episode(params) == ("3", "6")
+
+
+def test_recall_returns_blank_for_a_different_show():
+    with _patched_window():
+        remember_last_episode({"tmdb_id": "124364"}, "3", "5")
+        assert recall_next_episode({"tmdb_id": "999"}) == ("", "")
+
+
+def test_recall_returns_blank_when_nothing_remembered():
+    with _patched_window():
+        assert recall_next_episode({"tmdb_id": "124364"}) == ("", "")
+
+
+def test_remember_is_a_noop_for_non_numeric_season_or_episode():
+    with _patched_window():
+        remember_last_episode({"tmdb_id": "124364"}, "", "")
+        assert recall_next_episode({"tmdb_id": "124364"}) == ("", "")
+
+
+def test_remember_is_a_noop_without_a_show_identity():
+    with _patched_window():
+        remember_last_episode({}, "3", "5")
+        assert recall_next_episode({"title": ""}) == ("", "")


### PR DESCRIPTION
## Summary
- TMDBHelper's Next-Up/widget re-invocation of the RunScript player often arrives with blank `season`/`episode`. The existing fallback recovered those numbers from Kodi's currently-focused ListItem, which can be stale — e.g. UI focus resets to the top of the season folder after an episode finishes, so the picker reopened targeting the season premiere instead of the next episode.
- Add `router_lastepisode.py`: a session-scoped, per-show memory (window-property IPC, same pattern already used by `resolver_resume.py` / `stream_proxy_serviceprops.py`) of the last season/episode picked. When a blank-season/episode play arrives, prefer "last picked + 1" for that show over the focused-ListItem guess; fall back to the ListItem probe unchanged when there's no memory yet or it's a different show.
- No season-boundary detection: always `episode + 1` within the same season. If that overshoots a season finale, the search returns nothing, which already degrades to the existing "no results" picker path.

## Test plan
- [x] `just lint` — clean
- [x] `just test` — 2630 passed, 2 skipped
- [x] New unit tests for `router_lastepisode.py` (roundtrip, show-mismatch, non-numeric/empty no-ops)
- [x] New end-to-end `router.py`/`router_scriptplay.py` tests: last-played+1 takes priority over a conflicting focused ListItem; falls back to ListItem probing with no memory yet; full remember→recall regression reproducing the reported bug
- [x] Deployed to a CoreELEC test box and restarted Kodi for manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)