### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix authorization bypass in proxy loopback service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,9 @@
 **Vulnerability:** Inconsistent, incomplete, and fragile XXE (XML External Entity) and Billion Laughs DoS protection across various files (`webdav.py`, `webdav_discovery.py`, `kodi_advancedsettings.py`, `nzb_manifest.py`). The standard library fallback in Python >= 3.3 does not have `.parser` attribute for `ET.XMLParser()`, resulting in `AttributeError` that was caught but silently allowed the parser to continue with entities enabled (failing open).
 **Learning:** Python's C-implementation of ElementTree doesn't expose external entity resolution handlers. You cannot disable entities via `parser.parser.ExternalEntityRefHandler = lambda *_: False` because `parser` lacks a `.parser` attribute. `xml_safety.py` provides a centralized, robust text-scanning fallback for when `defusedxml` is not available.
 **Prevention:** Always use `safe_fromstring` from `xml_safety.py` for parsing XML instead of ad-hoc parser customizations.
+
+## 2025-05-24 - Fix Fail-Open Authentication in Proxy Loopback
+
+**Vulnerability:** Authorization bypass (fail-open) in loopback proxy authentication. The truthiness check `if expected_token and not compare(...)` bypassed the digest comparison and returned True when the expected token was unexpectedly empty/falsy.
+**Learning:** Combining a truthy check and a negative condition directly can result in a fail-open authorization model when the primary required constraint (the secret) is missing.
+**Prevention:** Fail-closed explicitly. Verify the presence of required secrets via a separate `if not expected_token: return False` condition before checking the provided credentials against the expected ones.

--- a/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_dispatch.py
+++ b/repo/plugin.video.nzbdav/resources/lib/stream_proxy_handler_dispatch.py
@@ -26,10 +26,11 @@ class _DispatchMixin:  # pylint: disable=too-few-public-methods
         both sides to str("") if None.
         """
         expected_token = getattr(self.server, "prepare_token", "")
+        if not expected_token:
+            return False
+
         supplied_token = self.headers.get(_sp._PREPARE_TOKEN_HEADER)
-        if expected_token and not _sp.hmac.compare_digest(
-            supplied_token or "", expected_token or ""
-        ):
+        if not _sp.hmac.compare_digest(supplied_token or "", expected_token):
             return False
         return True
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The loopback proxy authentication check `_prepare_token_ok` failed open if the expected token was empty or falsy.
🎯 Impact: A missing expected token would allow unauthorized requests to bypass the authorization check.
🔧 Fix: Explicitly check for the presence of the expected token and fail-closed by returning `False` if it's missing, before performing the HMAC comparison.
✅ Verification: Run the test suite using `PYTHONPATH=.:repo/plugin.video.nzbdav uv run --with-requirements requirements-dev.txt --with pytest --with pytest-cov --with pytest-mock --with defusedxml --with httpretty --with mock --no-project --python 3.14 pytest tests/ -v --tb=short -m "not integration and not functional and not extreme"

---
*PR created automatically by Jules for task [15808533395041786243](https://jules.google.com/task/15808533395041786243) started by @xbmc4lyfe*