### PR TITLE
🎨 Palette: Add empty state for results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state indicator when no results are found -->
+    <control type="label">
+      <left>0</left><top>400</top><width>1920</width><height>100</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
💡 What: Added an explicit empty state indicator (a centralized `No results found` label) to the `results-dialog.xml` in the Kodi skin. This label only becomes visible when the results list (control `id="50"`) is empty.

🎯 Why: Custom lists in Kodi XML skins do not automatically handle empty states. When no results were found, the screen was completely blank except for the headers, leading to confusion about whether the add-on was still loading or if a search actually returned zero items.

📸 Before/After: Visual change in the 10-foot UI. A gray "No results found" label is now centered in the results area when the list is empty.

♿ Accessibility: Prevents cognitive friction and provides immediate, unmistakable visual feedback to users when a search yields no results.

---
*PR created automatically by Jules for task [10482924215666183921](https://jules.google.com/task/10482924215666183921) started by @xbmc4lyfe*