### PR TITLE
🎨 Palette: Add empty state message to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -310,5 +310,16 @@
       <aligny>center</aligny>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1910</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
   </controls>
 </window>


### PR DESCRIPTION
### 💡 What
Added a "No results found" label to the `results-dialog.xml` skin file that only displays when the list container (ID `50`) has zero items.

### 🎯 Why
In Kodi XML skins, custom lists do not automatically handle empty states. If a search returns no results, the user previously saw a confusing blank dark screen with just the header and footer, with no confirmation that the search actually completed but found nothing. This empty state explicitly communicates the result to the user.

### 📸 Before/After
**Before:** Blank screen between the header and footer.
**After:** A centered gray text reading "No results found".

### ♿ Accessibility
Reduces cognitive load by explicitly confirming the system state, helping users understand that a lack of results is not a loading error or broken UI.

---
*PR created automatically by Jules for task [2551422589044269587](https://jules.google.com/task/2551422589044269587) started by @xbmc4lyfe*