### PR TITLE
🎨 Palette: Add empty state handling to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -279,6 +279,17 @@
       <textureslidernibfocus></textureslidernibfocus>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>400</top><width>1920</width><height>200</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Footer background -->
     <control type="image">
       <left>0</left><top>1035</top><width>1920</width><height>45</height>


### PR DESCRIPTION
💡 What: Added an empty state message label ("No results found") to the results dialog that displays when the list has zero items.
🎯 Why: Custom lists in Kodi do not automatically handle empty states, leading to a confusing blank screen for the user when there are no results.
📸 Before/After: Before, a blank screen would display with no results. After, a clear "No results found" message is displayed in the center.
♿ Accessibility: Improved cognitive accessibility by explicitly confirming to users that their action resulted in an empty state, rather than leaving them guessing if the app is broken or still loading.

---
*PR created automatically by Jules for task [14150960555307337505](https://jules.google.com/task/14150960555307337505) started by @xbmc4lyfe*