### PR TITLE
🎨 Palette: Add empty state label to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found.</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
- 💡 What: Added an empty state label indicating "No results found." to the results dialog.
- 🎯 Why: Custom lists in Kodi skins do not display anything when empty, resulting in a confusing blank screen.
- 📸 Before/After: Before, empty lists were blank. After, an explicit message clarifies the lack of results.
- ♿ Accessibility: Improves user confidence and prevents confusion when navigating to empty result sets.

---
*PR created automatically by Jules for task [6454817797587338264](https://jules.google.com/task/6454817797587338264) started by @xbmc4lyfe*