### PR TITLE
🎨 Palette: Add empty state handling to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
💡 What: Added an empty state label ("No results found") to the results dialog.
🎯 Why: To prevent users from seeing a confusing blank screen when a search yields no results.
📸 Before/After: Before, a blank list was shown. After, a centered "No results found" message appears.
♿ Accessibility: Provides clear, immediate feedback on system status (no results) instead of relying on the absence of items.

---
*PR created automatically by Jules for task [3932150954186994229](https://jules.google.com/task/3932150954186994229) started by @xbmc4lyfe*