### PR TITLE
🎨 Palette: Add empty state message to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -62,6 +62,17 @@
       <texture>white.png</texture>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Results list — 2 lines per item, 66px each -->
     <control type="list" id="50">
       <left>0</left><top>60</top><width>1910</width><height>975</height>


### PR DESCRIPTION
### 💡 What
Added an empty state message label ("No results found") to the results dialog skin XML that only appears when the items list is empty.

### 🎯 Why
Previously, if a search returned zero results, the dialog would present an entirely blank list area without explanation. Adding an explicit empty state gives immediate, clear feedback to the user that the query completed but yielded no matches.

### 📸 Before/After
*Before:* Dialog opened with a completely empty black background beneath the header.
*After:* A centered "No results found" text in gray `FF9CA3AF` appears exactly where the list would normally display. 

### ♿ Accessibility
The empty state reduces cognitive load by eliminating ambiguity about whether the add-on is still loading, broken, or intentionally returning zero items.

---
*PR created automatically by Jules for task [15837674836334350037](https://jules.google.com/task/15837674836334350037) started by @xbmc4lyfe*