### PR TITLE
🎨 Palette: Add empty state message to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state indicator -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
## 💡 What
Added an explicit "No results found" message to `results-dialog.xml`.

## 🎯 Why
In Kodi XML skins, lists do not natively handle empty states. When a search returned zero results, the user was presented with an entirely blank, dark screen. This provides immediate, clear feedback that the query completed but found nothing, rather than leaving the user wondering if the add-on crashed or is still loading.

## 📸 Before/After
**Before:** A completely blank screen (just the dark background).
**After:** A centered message reading "No results found" in a subdued gray color (`FF9CA3AF`).

## ♿ Accessibility
Improves cognitive accessibility by providing explicit text feedback for an empty list state, removing ambiguity.

---
*PR created automatically by Jules for task [8974934371020478185](https://jules.google.com/task/8974934371020478185) started by @xbmc4lyfe*