### PR TITLE
🎨 Palette: Add empty state handler to results dialog list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state for no results -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found.</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
💡 What: Added a clear "No results found." empty state label to the Results dialog.
🎯 Why: In Kodi, custom UI lists don't natively handle empty states, which leaves users staring at a completely blank screen, confused if it's still loading or if they just got zero results.
📸 Before/After: Before: Blank screen. After: A centered "No results found." message.
♿ Accessibility: The empty state label makes the interface significantly more clear and eliminates cognitive load and uncertainty.

---
*PR created automatically by Jules for task [1266913365990646976](https://jules.google.com/task/1266913365990646976) started by @xbmc4lyfe*