### PR TITLE
🎨 Palette: Add empty state feedback to results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state indicator -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1910</width><height>975</height>
+      <align>center</align>
+      <aligny>center</aligny>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <label>No results found</label>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
**What:**
Added an explicit "No results found" label that appears centered over the main results list area when the list container is empty.

**Why:**
Kodi's custom list controls do not inherently provide an empty state fallback. Previously, when a search yielded zero results, the UI would simply show a blank screen with no indication if it was still loading or if the query had failed, which creates confusion.

**Before/After:**
*Before:* Empty list just shows background texture.
*After:* A centered, dim text label reads "No results found" when `Container(50).NumItems` is exactly `0`.

**Accessibility:**
This provides necessary, immediate feedback to the user regarding system state, satisfying basic usability heuristic criteria for state visibility without relying on side-channel notifications.

---
*PR created automatically by Jules for task [860346523930574305](https://jules.google.com/task/860346523930574305) started by @xbmc4lyfe*