### PR TITLE
🎨 Palette: [UX improvement] Add empty state message to custom Kodi list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <align>center</align>
+      <aligny>center</aligny>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
💡 What: Added an empty state label ("No results found") to the results list in `results-dialog.xml` using a visibility condition tied to the list's item count.
🎯 Why: To handle empty states in custom Kodi lists which otherwise result in a confusing blank screen.
📸 Before/After: Before, a blank screen; After, a "No results found" message centered on screen.
♿ Accessibility: Improves user understanding by providing clear visual feedback when no items are present.

---
*PR created automatically by Jules for task [15729391071377223608](https://jules.google.com/task/15729391071377223608) started by @xbmc4lyfe*