### PR TITLE
🎨 Palette: [UX improvement] Add empty state for results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -279,6 +279,17 @@
       <textureslidernibfocus></textureslidernibfocus>
     </control>
 
+    <!-- Empty state indicator for when the list has no items -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1910</width><height>975</height>
+      <align>center</align>
+      <aligny>center</aligny>
+      <label>No results found</label>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Footer background -->
     <control type="image">
       <left>0</left><top>1035</top><width>1920</width><height>45</height>


### PR DESCRIPTION
### 💡 What
Added a centered "No results found" empty state label to the results list in `results-dialog.xml`.

### 🎯 Why
Kodi custom lists (`<control type="list">`) do not automatically handle empty states. If a search or filter returned zero results, the dialog would previously display a confusing blank screen without any feedback, leaving the user to wonder if it was still loading or broken.

### 📸 Before/After
**Before:** Blank screen when `Container(50).NumItems` is 0.
**After:** A centered, muted "No results found" message is displayed clearly.

### ♿ Accessibility
Provides clear textual feedback to all users when no items are available, significantly improving usability and reducing cognitive load.

---
*PR created automatically by Jules for task [18249113213817315233](https://jules.google.com/task/18249113213817315233) started by @xbmc4lyfe*