### PR TITLE
🎨 Palette: Add empty state to results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,17 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state message when there are no results -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <align>center</align>
+      <aligny>center</aligny>
+      <font>font12</font>
+      <textcolor>FFFFFFFF</textcolor>
+      <label>No results found.</label>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
### What
Added a "No results found." empty state label to the results dialog XML when there are no items to display.

### Why
In Kodi XML skins, custom lists do not automatically handle empty states. If a search yields no results, the dialog would present a confusing blank screen. This empty state gives clear feedback to the user.

### Accessibility
Provides immediate, readable text feedback instead of requiring users to infer that a completely blank screen means "no results". Uses high contrast text (`FFFFFFFF` on dark background).

### Before/After
* **Before:** Blank list area when no results found.
* **After:** Centered "No results found." text when list is empty.

---
*PR created automatically by Jules for task [3043452866571368483](https://jules.google.com/task/3043452866571368483) started by @xbmc4lyfe*