### PR TITLE
🎨 Palette: Add empty state message for results dialog

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -263,6 +263,15 @@
       </focusedlayout>
     </control>
 
+    <!-- Empty state message when there are no results -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1910</width><height>975</height>
+      <align>center</align><aligny>center</aligny>
+      <font>font13</font><textcolor>FF9CA3AF</textcolor>
+      <label>No results found</label>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Scrollbar for the results list -->
     <control type="scrollbar" id="60">
       <left>1910</left><top>60</top><width>10</width><height>975</height>


### PR DESCRIPTION
**What:** Added an empty state message label ("No results found") to `results-dialog.xml`.
**Why:** Custom Kodi lists do not natively handle empty states, which results in a confusing blank screen for users when a search yields zero items. This change provides clear, helpful visual feedback.
**Before/After:** Before, empty lists resulted in a blank dark screen. After, a centralized gray "No results found" message is displayed.
**Accessibility:** Provides explicit status feedback without requiring the user to guess if the app is still loading or broken, enhancing usability for cognitive accessibility and reducing cognitive load.

---
*PR created automatically by Jules for task [16242576043205922954](https://jules.google.com/task/16242576043205922954) started by @xbmc4lyfe*