### PR TITLE
🎨 Palette: [UX improvement] Add empty state message to results list

### DIFF
--- a/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
+++ b/repo/plugin.video.nzbdav/resources/skins/Default/1080i/results-dialog.xml
@@ -62,6 +62,17 @@
       <texture>white.png</texture>
     </control>
 
+    <!-- Empty state message -->
+    <control type="label">
+      <left>0</left><top>60</top><width>1920</width><height>975</height>
+      <align>center</align>
+      <aligny>center</aligny>
+      <font>font13</font>
+      <textcolor>FF9CA3AF</textcolor>
+      <label>No results found</label>
+      <visible>Integer.IsEqual(Container(50).NumItems,0)</visible>
+    </control>
+
     <!-- Results list — 2 lines per item, 66px each -->
     <control type="list" id="50">
       <left>0</left><top>60</top><width>1910</width><height>975</height>


### PR DESCRIPTION
* **What:** Added an empty state label indicating "No results found" to the results list.
* **Why:** In Kodi XML skins, custom lists do not automatically handle empty states. Adding an empty state prevents confusing blank screens.
* **Before/After:** Before, empty lists showed nothing. After, they display a centered text.
* **Accessibility:** Reduces cognitive load by explicitly informing users when a list is empty instead of relying on context.

---
*PR created automatically by Jules for task [4959137055829694077](https://jules.google.com/task/4959137055829694077) started by @xbmc4lyfe*