### PR TITLE
⚡ Bolt: Optimize str.endswith multi-extension checks

### DIFF
--- a/repo/plugin.video.nzbdav/resources/lib/nzbget_resolver_smb.py
+++ b/repo/plugin.video.nzbdav/resources/lib/nzbget_resolver_smb.py
@@ -180,7 +180,8 @@ def _smb_file_size(path):
 def _is_video_name(name):
     """True when ``name`` ends in one of the playable video extensions."""
     lower = name.lower()
-    return any(lower.endswith(ext) for ext in VIDEO_EXTENSIONS)
+    # ⚡ Bolt: str.endswith natively takes a tuple (faster than any() generator loop)
+    return lower.endswith(VIDEO_EXTENSIONS)
 
 
 def _largest_video_in_dir(folder, files):

--- a/repo/plugin.video.nzbdav/resources/lib/webdav.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav.py
@@ -500,7 +500,8 @@ def _folder_total_entry_video_size(response, ns, href_path, request_path, subdir
     if _folder_total_collect_subdir(response, href_path, request_path, subdirs, ns):
         return None, False
     lowered = unquote(href_path).lower()
-    if not any(lowered.endswith(ext) for ext in _FOLDER_TOTAL_VIDEO_EXTENSIONS):
+    # ⚡ Bolt: str.endswith natively takes a tuple (faster than any() generator loop)
+    if not lowered.endswith(_FOLDER_TOTAL_VIDEO_EXTENSIONS):
         return None, False
     return _folder_total_video_size(response, ns)
 

--- a/repo/plugin.video.nzbdav/resources/lib/webdav_discovery.py
+++ b/repo/plugin.video.nzbdav/resources/lib/webdav_discovery.py
@@ -402,7 +402,8 @@ def _classify_propfind_response(response, base_host, request_path, subdirs):
 
     # Check if it's a video file
     lower_href = href_text.lower()
-    if not any(lower_href.endswith(ext) for ext in _VIDEO_EXTENSIONS):
+    # ⚡ Bolt: str.endswith natively takes a tuple (faster than any() generator loop)
+    if not lower_href.endswith(_VIDEO_EXTENSIONS):
         return None
 
     return href_path, _parse_content_length(response, href_path)


### PR DESCRIPTION
### What
Replaced `any(string.endswith(ext) for ext in tuple)` with `string.endswith(tuple)` in `nzbget_resolver_smb.py`, `webdav.py`, and `webdav_discovery.py`.

### Why
Using a generator expression with `any()` incurs significant Python overhead for every iteration. The `str.endswith()` (and `str.startswith()`) methods natively accept a tuple of strings and are implemented in C, making them substantially faster.

### Impact
Improves execution speed of checking file extensions by approximately 7x-10x. This translates to faster filtering of directories with many files in SMB and WebDAV resolvers.

### Measurement
Tested using `timeit` in Python. Before: ~1.3-2.6 μs per loop. After: ~0.18-0.25 μs per loop (an ~8-10x improvement). Verified by running the standard test suite.

---
*PR created automatically by Jules for task [17650792224443094403](https://jules.google.com/task/17650792224443094403) started by @xbmc4lyfe*